### PR TITLE
Make install-results cope with old build-directories.

### DIFF
--- a/build-scripts/install-results
+++ b/build-scripts/install-results
@@ -3,9 +3,14 @@
 . `dirname "$0"`/functions
 . version
 
-mkdir -p $BASEDIR/../../output/${SCHEDULER}
-mkdir -p $BASEDIR/../../output/${SCHEDULER}/${BRANCH}
-mv $BASEDIR/../../output/.tmp/${SCHEDULER}/${BRANCH}/* $BASEDIR/../../output/${SCHEDULER}/${BRANCH}
-rmdir --ignore-fail-on-non-empty $BASEDIR/../../output/.tmp/${SCHEDULER}/${BRANCH}
-rm -f $BASEDIR/../../output/${SCHEDULER}/current
-ln -fs ${BRANCH} $BASEDIR/../../output/${SCHEDULER}/current
+LNK="$BASEDIR/../../output/$SCHEDULER/current"
+TGT="$BASEDIR/../../output/$SCHEDULER/$BRANCH"
+SRC="$BASEDIR/../../output/.tmp/$SCHEDULER/$BRANCH"
+mkdir -p "$TGT"
+ls -1 "$SRC" | while read name
+do rm -fr "$TGT/$name"
+done # to make way for what we're about to move there:
+mv "$SRC"/* "$TGT"
+rmdir --ignore-fail-on-non-empty "$SRC"
+rm -f "$LNK"
+ln -fs "$BRANCH" "$LNK"


### PR DESCRIPTION
When install-results moves the final output directories from
.../.tmp/X to .../X, it fails if there's already a directory with the
given name in its target directory; this arises when repeating a
build.  So remove any such conflicting directories from the
destination, before trying to move their replacements in.

At the same time, avoid repetition of long and tedious paths by using
variables (which makes it easier to see which ones are the same and
makes the differences easier to see) and skip spurious braces.  Put
all variable expansion inside quotes and ensure that names with odd
things (like spaces) in them won't cause problems.

Given that mkdir -p creates parents, one of the invocations of it
could be skipped, as it made the parent of the next.
