### PR TITLE
Update source for libvirt dependency

### DIFF
--- a/deps-packaging/libvirt/source
+++ b/deps-packaging/libvirt/source
@@ -1,1 +1,1 @@
-http://libvirt.org/sources/
+http://libvirt.org/sources/old/


### PR DESCRIPTION
Version 0.8.4 of libvirt that you use is now in the `/old/` directory of their downloads. This fixes the build for now, but you may want to use a more recent version too :)
