### PR TITLE
Helper packages for Debian-based development.

### DIFF
--- a/contrib/cf-deb-dep/.gitignore
+++ b/contrib/cf-deb-dep/.gitignore
@@ -1,0 +1,2 @@
+/*.deb
+/ChangeLog*.txt

--- a/contrib/cf-deb-dep/Makefile
+++ b/contrib/cf-deb-dep/Makefile
@@ -1,0 +1,37 @@
+# See README.md for details; or just run make
+DEBCTL := $(wildcard cfbuild*.ctl)
+PUBCTL := cfbuild-native.ctl cfbuild-dev.ctl
+
+VERSION := 0.0
+RELEASE := testing
+URGENT  := low
+
+# SINCE: previous release tag
+SINCE  :=
+
+# LOGCHANGES: command to generate Debian-style changelog (of this
+# directory only):
+AUTHOR := $(shell git config --get user.name)
+EMAIL  := $(shell git config --get user.email)
+LOGCHANGES := git log --pretty='  * %s' $(SINCE:%=%..) -- . ; \
+	date +' -- $(AUTHOR) <$(EMAIL)>  %a, %d %b %Y %T %z'
+# TODO: The git-buildpackage package provides git-dch; work out how
+# (if installed) to exploit it (or perhaps its internals) to do a
+# better job.
+
+DEBS := $(DEBCTL:%.ctl=%_$(VERSION)_all.deb)
+pub: $(PUBCTL:%.ctl=%_$(VERSION)_all.deb)
+all: $(DEBS)
+$(DEBS): cfbuild%_$(VERSION)_all.deb: cfbuild%.ctl ChangeLog%.txt
+	@ equivs-build $(@:%_$(VERSION)_all.deb=%.ctl) && lintian $@
+
+Details := ($(VERSION)) $(RELEASE); urgency=$(URGENT)
+$(DEBCTL:cfbuild%.ctl=ChangeLog%.txt): FORCE
+	@(echo '$(@:ChangeLog%.txt=cfbuild%) $(Details)'; \
+	$(LOGCHANGES)) >$@
+
+clean:
+	@$(RM) -f ChangeLog*.txt cfbuild*.deb
+
+FORCE: # no command - depending on this forces creation of files.
+.PHONY: FORCE clean

--- a/contrib/cf-deb-dep/README.md
+++ b/contrib/cf-deb-dep/README.md
@@ -1,0 +1,42 @@
+# Debian Dependencies for CFEngine
+
+The files in this directory provide the means to build Debian packages
+which depend on what you need in order to build and develop the
+CFEngine code-base.  The details of how you do your development affect
+which of these packages you'll find useful; see the description at the
+end of each .ctl file for details.
+
+For typical development, as a contributor, it should suffice to
+install the two packages that a simple run of make -k shall produce.
+If you install these via an apt repository, your apt tools should
+automatically pull in all the packages on which they depend.  The main
+advantages to having these dependency packages installed are
+ * to simplify installing all needed dependencies and
+ * to help you keep track of why you have those packages installed.
+
+If you install using the apt tools, they'll mark the prerequisites as
+installed to satisfy a dependency.  If you later install an update of
+these dependency packages, any obsolete prerequisites shall be marked
+for deletion automatically.
+
+You can also install the packages using dpkg -i; it'll report conflict
+due to any needed packages that are missing, but a run of aptitude
+shall offer you installation of those missing packages as a way to
+resolve those conflicts.  Accept this resolution and it'll all work.
+You may need to repeat your original dpkg -i to clear the packages'
+"broken" flag.
+
+## Implementation
+
+These dependency packages are generated using the Debian equivs
+package: you'll need to install it (and its dependencies) before you
+run make.  The Makefile included here knows how to drive generation of
+packages using the equivs tools.
+
+If you don't have lintian installed, you'll get an error about its
+absence, but your packages have been built all the same (they just
+haven't been sanity-checked), albeit you need to make -k in order to
+get all packages, rather than stopping on the first error.
+
+For details related to contents of the *.ctl files,
+see [Debian Control](http://www.debian.org/doc/debian-policy/ch-controlfields.html)

--- a/contrib/cf-deb-dep/cfbuild-dev.ctl
+++ b/contrib/cf-deb-dep/cfbuild-dev.ctl
@@ -1,0 +1,10 @@
+Section: contrib/devel
+Maintainer: Edward Welbourne <edward.welbourne@cfengine.com>
+Build-Depends: equivs
+Package: cfbuild-dev
+Changelog: ChangeLog-dev.txt
+Depends: autoconf, automake, libtool, flex, bison, cfbuild-native | cfbuild-repack
+Recommends: git, gdb
+Description: CFEngine development essentials
+ This package pulls in the ones you need in order to develop CFEngine
+ from a raw git checkout.

--- a/contrib/cf-deb-dep/cfbuild-native.ctl
+++ b/contrib/cf-deb-dep/cfbuild-native.ctl
@@ -1,0 +1,10 @@
+Section: contrib/devel
+Maintainer: Edward Welbourne <edward.welbourne@cfengine.com>
+Build-Depends: equivs
+Package: cfbuild-native
+Changelog: ChangeLog-native.txt
+Depends: gcc | clang, make, libpam-dev, libssl-dev, libpcre3-dev, liblmdb-dev | libtokyocabinet-dev | libqdbm-dev
+Suggests: libmysqlclient-dev, libpq-dev, libacl1-dev, lcov
+Description: CFEngine native prerequisites
+ This package pulls in the ones you need in order to build shipped
+ versions of CFEngine from source.

--- a/contrib/cf-deb-dep/cfbuild-repack.ctl
+++ b/contrib/cf-deb-dep/cfbuild-repack.ctl
@@ -1,0 +1,10 @@
+Section: contrib/devel
+Maintainer: Edward Welbourne <edward.welbourne@cfengine.com>
+Build-Depends: equivs
+Package: cfbuild-repack
+Changelog: ChangeLog-repack.txt
+Depends: build-essential, debhelper, fakeroot
+Conflicts: fakeroot-ng
+Description: CFEngine build essentials
+ This package pulls in the ones you need in order to build CFEngine
+ complete with custom versions of its dependencies.

--- a/contrib/cf-deb-dep/cfbuilddoc.ctl
+++ b/contrib/cf-deb-dep/cfbuilddoc.ctl
@@ -1,0 +1,9 @@
+Section: contrib/devel
+Maintainer: Edward Welbourne <edward.welbourne@cfengine.com>
+Build-Depends: equivs
+Package: cfbuilddoc
+Changelog: ChangeLogdoc.txt
+Depends: texi2html, texinfo, texlive, cm-super, texlive-fonts-extra
+Description: CFEngine documentation-build essentials
+ This package pulls in the ones you need in order to
+ build CFEngine's documentation from source.

--- a/contrib/cf-deb-dep/cfbuildslave.ctl
+++ b/contrib/cf-deb-dep/cfbuildslave.ctl
@@ -1,0 +1,12 @@
+Section: contrib/devel
+Maintainer: Edward Welbourne <edward.welbourne@cfengine.com>
+Build-Depends: equivs
+Package: cfbuildslave
+Changelog: ChangeLogslave.txt
+Depends: gcc, make, libc-dev, bison, flex, fakeroot | fakeroot-ng, g++, libncurses5-dev, pkg-config, dpkg-dev, rsync, openssh-server
+Suggests: lcov, cfbuilddoc
+Conflicts: cfengine, automake, autoconf, libtool, libssl-dev, libpcre3-dev, libqdbm-dev, libtokyocabinet-dev, libmysqlclient-dev, libpq-dev, libacl1-dev
+Description: CFEngine build-slave essentials
+ This package pulls in the ones a build slave needs in order to build
+ CFEngine.  It also conflicts with things it's a bad idea to have
+ installed on a build slave.


### PR DESCRIPTION
Add contrib/cf-deb-dep/ to automate pulling in needed Debian packages
and help with keeping up to date on what's needed.
