### PR TITLE
Fix ordering of starting Apache and PostgreSQL.

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -515,8 +515,6 @@ fi
 sed -i -e s:INSERT_CERT_HERE:$CFENGINE_MP_CERT:g $PREFIX/httpd/conf/extra/httpd-ssl.conf
 sed -i -e s:INSERT_CERT_KEY_HERE:$CFENGINE_MP_KEY:g $PREFIX/httpd/conf/extra/httpd-ssl.conf
 
-mkdir -p $PREFIX/config
-$PREFIX/httpd/bin/apachectl start
 
 #
 #POSTGRES RELATED
@@ -642,6 +640,11 @@ EOF
 
 fi
 
+#
+# Start Apache server
+#
+mkdir -p $PREFIX/config
+$PREFIX/httpd/bin/apachectl start
 
 #
 #REDIS RELATED


### PR DESCRIPTION
If Apache is started before PostgreSQL it complains about problems
with connecting to database.
(cherry picked from commit 34a962c715452996775cabf63cf27bc823b7f5a2)
