### PR TITLE
Redmine #6818: Detect and clean up lingering processes in chroot.

### DIFF
--- a/build-scripts/prepare-testmachine-chroot
+++ b/build-scripts/prepare-testmachine-chroot
@@ -8,6 +8,9 @@ TRANSFER_SCRIPT=$BASEDIR/prepare-testmachine-chroot-transfer-script.rsync
 # Don't lose the trailing slash!
 CHROOT_ROOT=$HOME/testmachine-chroot/
 
+sudo mkdir -p $CHROOT_ROOT
+
+sudo fuser -k $CHROOT_ROOT || true
 sudo umount ${CHROOT_ROOT}proc || true
 
 echo "P $BASEDIR" > $TRANSFER_SCRIPT

--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -33,9 +33,19 @@ else
     return_code=$?
 fi
 
-# Unmount proc.
 case "$TEST_MACHINE" in
     chroot)
+        # Fuser has special output. The PIDs arrive on stdout, and all the ornaments
+        # arrive on stderr, so all we have to do is to grep for PID numbers.
+        if sudo fuser $CHROOT_ROOT | grep '[0-9]'; then
+            # Leaving processes behind is an error. It should never happen.
+            return_code=1
+            echo "Error: Found processes left behind in the chroot. I'm killing them, but clean up your mess!"
+            # Nevertheless kill them.
+            sudo fuser -k $CHROOT_ROOT || true
+        fi
+
+        # Unmount proc.
         sudo umount ${CHROOT_ROOT}proc || true
         ;;
 esac


### PR DESCRIPTION
Note that we consider failure to clean up after yourself an error.
The chroot survives it just fine, but we still want the tests to
behave nicely so that it doesn't happen when you run them locally
either.