### PR TITLE
[3.6.x] Solaris build fixes

### DIFF
--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -294,6 +294,13 @@ detect_tools()
         FUSER=/sbin/fuser
     fi
     export FUSER
+
+    if which gpatch 2>&1 | grep '^/' >/dev/null; then
+        PATCH=gpatch
+    else
+        PATCH=patch
+    fi
+    export PATCH
 }
 
 detect_cores()

--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -287,6 +287,13 @@ detect_tools()
         RPMBUILD_CMD=rpmbuild
     fi
     export RPMBUILD_CMD
+
+    if [ -x /usr/sbin/fuser ]; then
+        FUSER=/usr/sbin/fuser
+    else
+        FUSER=/sbin/fuser
+    fi
+    export FUSER
 }
 
 detect_cores()

--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -312,6 +312,7 @@ EOF
 + /system/volatile
 - /system/*
 + /system
+- /var/run/*
 EOF
       ;;
     linux)

--- a/build-scripts/prepare-testmachine-chroot
+++ b/build-scripts/prepare-testmachine-chroot
@@ -10,7 +10,7 @@ CHROOT_ROOT=$HOME/testmachine-chroot/
 
 sudo mkdir -p $CHROOT_ROOT
 
-sudo fuser -k $CHROOT_ROOT || true
+sudo $FUSER -k $CHROOT_ROOT || true
 sudo umount ${CHROOT_ROOT}proc || true
 
 echo "P $BASEDIR" > $TRANSFER_SCRIPT

--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -37,15 +37,17 @@ case "$TEST_MACHINE" in
     chroot)
         # Fuser has special output. The PIDs arrive on stdout, and all the ornaments
         # arrive on stderr, so all we have to do is to grep for PID numbers.
-        if sudo fuser $CHROOT_ROOT | grep '[0-9]'; then
+        for pid in `sudo $FUSER $CHROOT_ROOT 2>/dev/null`; do
             # Leaving processes behind is an error. It should never happen.
             return_code=1
-            echo "Error: Found processes left behind in the chroot. I'm killing them, but clean up your mess!"
-            # Nevertheless kill them.
-            sudo fuser -k $CHROOT_ROOT || true
-        fi
+            echo "Error: Found processes left behind in the chroot. I'm killing them, but the build will fail, so clean up your mess!"
+            echo "Found PID $pid. Info from 'ps -ef'"
+            echo "--------------"
+            ps -ef | grep $pid
+            echo "--------------"
+        done
 
-        # Unmount proc.
+        sudo $FUSER -k $CHROOT_ROOT || true
         sudo umount ${CHROOT_ROOT}proc || true
         ;;
 esac

--- a/deps-packaging/libacl/cfbuild-libacl.spec
+++ b/deps-packaging/libacl/cfbuild-libacl.spec
@@ -16,7 +16,7 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n acl-2.2.52
 
-zcat ../../SOURCES/acl.destdir.diff.gz | patch -p1 || true
+zcat ../../SOURCES/acl.destdir.diff.gz | $PATCH -p1 || true
 
 ./configure --prefix=%{prefix} --enable-gettext=no LDFLAGS="-L${BUILDPREFIX}/lib"
 

--- a/deps-packaging/libacl/debian/rules
+++ b/deps-packaging/libacl/debian/rules
@@ -12,7 +12,7 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
-	zcat acl.destdir.diff.gz | $PATCH -p1 || true
+	zcat acl.destdir.diff.gz | $(PATCH) -p1 || true
 
 	./configure --prefix=$(PREFIX) --enable-gettext=no LDFLAGS=$(LDFLAGS)
 

--- a/deps-packaging/libacl/debian/rules
+++ b/deps-packaging/libacl/debian/rules
@@ -12,7 +12,7 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
-	zcat acl.destdir.diff.gz | patch -p1 || true
+	zcat acl.destdir.diff.gz | $PATCH -p1 || true
 
 	./configure --prefix=$(PREFIX) --enable-gettext=no LDFLAGS=$(LDFLAGS)
 

--- a/deps-packaging/libattr/cfbuild-libattr.spec
+++ b/deps-packaging/libattr/cfbuild-libattr.spec
@@ -17,7 +17,7 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n attr-2.4.47
 
-zcat ../../SOURCES/attr.destdir.diff.gz | patch -p1 || true
+zcat ../../SOURCES/attr.destdir.diff.gz | $PATCH -p1 || true
 
 ./configure --prefix=%{prefix} --includedir=%{incldir} --enable-gettext=no
 

--- a/deps-packaging/libattr/debian/rules
+++ b/deps-packaging/libattr/debian/rules
@@ -15,7 +15,7 @@ build-stamp:
 
 # we need to patch attr sources cause by default they don't support DESTDIR
 
-	zcat attr.destdir.diff.gz | patch -p1 --verbose || true
+	zcat attr.destdir.diff.gz | $PATCH -p1 --verbose || true
 
 # installing header files in usr/include is a hack required to compile libacl
 # configure of acl is not able to find headers in any other location than usr/include

--- a/deps-packaging/libattr/debian/rules
+++ b/deps-packaging/libattr/debian/rules
@@ -15,7 +15,7 @@ build-stamp:
 
 # we need to patch attr sources cause by default they don't support DESTDIR
 
-	zcat attr.destdir.diff.gz | $PATCH -p1 --verbose || true
+	zcat attr.destdir.diff.gz | $(PATCH) -p1 --verbose || true
 
 # installing header files in usr/include is a hack required to compile libacl
 # configure of acl is not able to find headers in any other location than usr/include

--- a/deps-packaging/libgcc/solaris/build
+++ b/deps-packaging/libgcc/solaris/build
@@ -11,12 +11,6 @@ PREFIX=/var/cfengine
 #
 # Gross hack, but what we could do?
 #
-LIBGCC_LOC=""
-
-if [ $OS="solaris" ] && [ $OS_VERSION -eq "11" ]; then
 LIBGCC_LOC="/opt/csw/lib/"
-else
-LIBGCC_LOC="/usr/local/lib/"
-fi
 mkdir -p ${BUILD_ROOT}/cfbuild-libgcc/${PREFIX}/lib
 cp "$LIBGCC_LOC"libgcc_s.so.1 ${BUILD_ROOT}/cfbuild-libgcc/${PREFIX}/lib

--- a/deps-packaging/libiconv/solaris/build
+++ b/deps-packaging/libiconv/solaris/build
@@ -16,7 +16,7 @@ export LDFLAGS="-Wl,-R/var/cfengine/lib -L/var/cfengine/lib"
 
 #Build
 
-make 
+$MAKE 
 
 #Test
 
@@ -25,7 +25,7 @@ make
 sed -e"s/ \/usr\/local\/lib / /" libtool > libtool2
 rm -f libtool
 mv libtool2 libtool
-make install DESTDIR=${BUILD_ROOT}/cfbuild-libiconv-devel
+$MAKE install DESTDIR=${BUILD_ROOT}/cfbuild-libiconv-devel
 
 #Package
 

--- a/deps-packaging/libxml2/hpux/build
+++ b/deps-packaging/libxml2/hpux/build
@@ -13,7 +13,7 @@ LDFLAGS="-L${PREFIX}/lib -R${PREFIX}/lib"
 
 # Configure
 
-./configure CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" --prefix=${PREFIX} --without-python --without-iconv --without-lzma --with-iso8859x
+./configure CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" --prefix=${PREFIX} --without-python --without-iconv --without-lzma --without-zlib --with-iso8859x
 
 # Build
 

--- a/deps-packaging/libxml2/solaris/build
+++ b/deps-packaging/libxml2/solaris/build
@@ -18,13 +18,13 @@ patch -p0 < solaris-8-inttypes.patch
 
 # Build
 
-make
+$MAKE
 
 # Test
 
 # Install
 
-make install DESTDIR=${BUILD_ROOT}/cfbuild-libxml2-devel
+$MAKE install DESTDIR=${BUILD_ROOT}/cfbuild-libxml2-devel
 
 # Package
 

--- a/deps-packaging/libxml2/solaris/build
+++ b/deps-packaging/libxml2/solaris/build
@@ -10,7 +10,7 @@ export LDFLAGS="-Wl,-R/var/cfengine/lib -L/var/cfengine/lib"
 
 # Patch
 
-patch -p0 < solaris-8-inttypes.patch
+$PATCH -p0 < solaris-8-inttypes.patch
 
 # Configure
 

--- a/deps-packaging/libxml2/solaris/build
+++ b/deps-packaging/libxml2/solaris/build
@@ -14,7 +14,7 @@ patch -p0 < solaris-8-inttypes.patch
 
 # Configure
 
-./configure --prefix=${PREFIX} --without-python
+./configure --prefix=${PREFIX} --without-python --without-lzma --without-zlib
 
 # Build
 

--- a/deps-packaging/lmdb/cfbuild-lmdb.spec
+++ b/deps-packaging/lmdb/cfbuild-lmdb.spec
@@ -25,10 +25,10 @@ Patch0: mdb.patch
 SYS=`uname -s`
 mkdir -p %{_builddir}
 %setup -q -n %{srcdir}
-patch -s -p3 < %{_topdir}/SOURCES/mdb.patch
-patch -s -p3 < %{_topdir}/SOURCES/mdb-robust.patch
-patch -s -p3 < %{_topdir}/SOURCES/mdb-autoconf.patch
-patch -s -p3 < %{_topdir}/SOURCES/mdb-autoconf-generated.patch
+$PATCH -s -p3 < %{_topdir}/SOURCES/mdb.patch
+$PATCH -s -p3 < %{_topdir}/SOURCES/mdb-robust.patch
+$PATCH -s -p3 < %{_topdir}/SOURCES/mdb-autoconf.patch
+$PATCH -s -p3 < %{_topdir}/SOURCES/mdb-autoconf-generated.patch
 # Executable files taken from mdb-autoconf-generated.patch, which is generated
 # from Git, and contains permission info, but patch -p1 cannot apply it.
 # Use the following command to list the files.

--- a/deps-packaging/lmdb/hpux/build
+++ b/deps-packaging/lmdb/hpux/build
@@ -8,10 +8,10 @@ TT=${BUILD_ROOT}/cfbuild-lmdb${PREFIX}
 TTD=${BUILD_ROOT}/cfbuild-lmdb-devel${PREFIX}
 
 cd libraries/liblmdb
-gpatch -p3 < ../../mdb.patch
-gpatch -p3 < ../../mdb-robust.patch
-gpatch -p3 < ../../mdb-autoconf.patch
-gpatch -p3 < ../../mdb-autoconf-generated.patch
+$PATCH -p3 < ../../mdb.patch
+$PATCH -p3 < ../../mdb-robust.patch
+$PATCH -p3 < ../../mdb-autoconf.patch
+$PATCH -p3 < ../../mdb-autoconf-generated.patch
 # Executable files taken from mdb-autoconf-generated.patch, which is generated
 # from Git, and contains permission info, but patch -p1 cannot apply it.
 # Use the following command to list the files.

--- a/deps-packaging/lmdb/solaris/build
+++ b/deps-packaging/lmdb/solaris/build
@@ -19,7 +19,7 @@ cd libraries/liblmdb && gpatch -p3 < ../../mdb.patch.sun && cd -
 
 # Build
 
-cd libraries/liblmdb && make && cd -
+cd libraries/liblmdb && $MAKE && cd -
 
 # Test
 
@@ -29,7 +29,7 @@ mkdir -p $TTD/bin
 mkdir -p $TTD/lib
 mkdir -p $TTD/include
 mkdir -p $TTD/man/man1
-cd libraries/liblmdb && make install prefix=${TTD} && cd -
+cd libraries/liblmdb && $MAKE install prefix=${TTD} && cd -
 
 # Package
 

--- a/deps-packaging/lmdb/solaris/build
+++ b/deps-packaging/lmdb/solaris/build
@@ -11,9 +11,9 @@ export LDFLAGS="-Wl,-R/var/cfengine/lib -L/var/cfengine/lib"
 # Patch
 # Solaris 8
 
-cd libraries/liblmdb && gpatch -p3 < ../../mdb.patch && cd -
-cd libraries/liblmdb && gpatch -p3 < ../../mdb-robust.patch && cd -
-cd libraries/liblmdb && gpatch -p3 < ../../mdb.patch.sun && cd -
+cd libraries/liblmdb && $PATCH -p3 < ../../mdb.patch && cd -
+cd libraries/liblmdb && $PATCH -p3 < ../../mdb-robust.patch && cd -
+cd libraries/liblmdb && $PATCH -p3 < ../../mdb.patch.sun && cd -
 
 # Configure
 

--- a/deps-packaging/openldap/solaris/build
+++ b/deps-packaging/openldap/solaris/build
@@ -20,15 +20,15 @@ export LDFLAGS="-Wl,-R/var/cfengine/lib -L/var/cfengine/lib"
 
 # Build
 
-make -C include
-make -C libraries
+$MAKE -C include
+$MAKE -C libraries
 
 # Test
 
 # Install
 
-make -C include install DESTDIR=${BUILD_ROOT}/cfbuild-openldap-devel
-make -C libraries install DESTDIR=${BUILD_ROOT}/cfbuild-openldap-devel
+$MAKE -C include install DESTDIR=${BUILD_ROOT}/cfbuild-openldap-devel
+$MAKE -C libraries install DESTDIR=${BUILD_ROOT}/cfbuild-openldap-devel
 
 # Package
 

--- a/deps-packaging/openssl/solaris/build
+++ b/deps-packaging/openssl/solaris/build
@@ -19,7 +19,7 @@ export PATH=`pwd`/solaris:$PATH
 
 cd openssl-fips-1.2.4
 ./config fipscanisterbuild
-make
+$MAKE
 cd ..
 
 ./config fips no-ec shared  no-dtls no-psk no-srp \
@@ -27,19 +27,19 @@ cd ..
 
 # Build
 
-make
+$MAKE
 
 # Test
 
 # ECDSA/ECDH tests are broken, so we explicitly omit them
 
 if [ "$TESTS" != no ]; then
-  make test TESTS="test_des test_idea test_sha test_md4 test_md5 test_hmac test_md2 test_mdc2 test_rmd test_rc2 test_rc4 test_rc5 test_bf test_cast test_aes test_rand test_bn test_ec test_enc test_x509 test_rsa test_crl test_sid test_gen test_req test_pkcs7 test_verify test_dh test_dsa test_ss test_ca test_engine test_evp test_ssl test_ige test_jpake"
+  $MAKE test TESTS="test_des test_idea test_sha test_md4 test_md5 test_hmac test_md2 test_mdc2 test_rmd test_rc2 test_rc4 test_rc5 test_bf test_cast test_aes test_rand test_bn test_ec test_enc test_x509 test_rsa test_crl test_sid test_gen test_req test_pkcs7 test_verify test_dh test_dsa test_ss test_ca test_engine test_evp test_ssl test_ige test_jpake"
 fi
 
 # Install
 
-make INSTALL_PREFIX=${BUILD_ROOT}/cfbuild-openssl-devel install_sw
+$MAKE INSTALL_PREFIX=${BUILD_ROOT}/cfbuild-openssl-devel install_sw
 
 # Package
 

--- a/deps-packaging/pcre/solaris/build
+++ b/deps-packaging/pcre/solaris/build
@@ -18,17 +18,17 @@ patch -p0 < solaris-8-inttypes.patch
 
 # Build
 
-make
+$MAKE
 
 # Test
 
 if [ "$TESTS" = all ]; then
-  make check
+  $MAKE check
 fi
 
 # Install
 
-make install DESTDIR=${BUILD_ROOT}/cfbuild-pcre-devel
+$MAKE install DESTDIR=${BUILD_ROOT}/cfbuild-pcre-devel
 
 # Package
 

--- a/deps-packaging/pcre/solaris/build
+++ b/deps-packaging/pcre/solaris/build
@@ -10,7 +10,7 @@ export LDFLAGS="-Wl,-R/var/cfengine/lib -L/var/cfengine/lib"
 
 # Patch
 
-patch -p0 < solaris-8-inttypes.patch
+$PATCH -p0 < solaris-8-inttypes.patch
 
 # Configure
 

--- a/deps-packaging/pkg-build-solaris
+++ b/deps-packaging/pkg-build-solaris
@@ -60,6 +60,12 @@ PKGDIR=$BASEDIR/$PKGNAME/pkg
 rm -rf $PKGDIR
 mkdir -p $PKGDIR
 
+if which gtar 2>&1 | grep '^/' >/dev/null; then
+  TAR=gtar
+else
+  TAR=tar
+fi
+
 pkg-get-buildscripts-src "$P" | while read srcfile opts; do
   case "$srcfile" in
     *.gz|*.tgz)
@@ -72,19 +78,11 @@ pkg-get-buildscripts-src "$P" | while read srcfile opts; do
   esac
 
   if [ x$opts = xsubdir ]; then
-   if [ "$OS_VERSION" = "8" ]; then
-    $UNCOMPRESS $srcfile | (cd $PKGDIR; LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" gtar xf -) || false
-   else
-    $UNCOMPRESS $srcfile | (cd $PKGDIR; gtar xf -) || false
-   fi
+    $UNCOMPRESS $srcfile | (cd $PKGDIR; $TAR xf -) || false
   else
     TD=/tmp/`basename $srcfile`.$$
     mkdir -p "$TD"
-    if [ "$OS_VERSION" = "8" ]; then
-     $UNCOMPRESS $srcfile | (cd "$TD" && gtar xf -) || false
-    else
-     $UNCOMPRESS $srcfile | (cd "$TD" && LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" gtar xf -) || false
-    fi
+    $UNCOMPRESS $srcfile | (cd "$TD" && $TAR xf -) || false
     mv $TD/*/* $PKGDIR
     rm -r "$TD"
   fi

--- a/deps-packaging/pkg-build-solaris
+++ b/deps-packaging/pkg-build-solaris
@@ -78,11 +78,11 @@ pkg-get-buildscripts-src "$P" | while read srcfile opts; do
   esac
 
   if [ x$opts = xsubdir ]; then
-    $UNCOMPRESS $srcfile | (cd $PKGDIR; $TAR xf -) || false
+    $UNCOMPRESS $srcfile | (cd $PKGDIR; $TAR xf -) || true
   else
     TD=/tmp/`basename $srcfile`.$$
     mkdir -p "$TD"
-    $UNCOMPRESS $srcfile | (cd "$TD" && $TAR xf -) || false
+    $UNCOMPRESS $srcfile | (cd "$TD" && $TAR xf -) || true
     mv $TD/*/* $PKGDIR
     rm -r "$TD"
   fi

--- a/deps-packaging/pkg-get-src
+++ b/deps-packaging/pkg-get-src
@@ -122,6 +122,8 @@ fetch_file()
     else
       # wget(1) tends to create empty files even if download did not finish
       rm -f "$CACHEDIR/$FILENAME"
+      echo 'If you get a message about "Unsupported scheme", simply upload the' 1>&2
+      echo "given file to $CACHEDIR yourself." 1>&2
     fi
   done
 

--- a/deps-packaging/pkg-get-src
+++ b/deps-packaging/pkg-get-src
@@ -57,7 +57,7 @@ checksum()
           if which gzcat 2>&1 | grep '^/' >/dev/null; then
             UNCOMPRESS=gzcat
           else
-            UNCOMPRESS=zcat
+            UNCOMPRESS="gunzip -c"
           fi
           ;;
         *.bz2)

--- a/deps-packaging/postgresql-hub/source
+++ b/deps-packaging/postgresql-hub/source
@@ -1,1 +1,1 @@
-http://ftp.se.postgresql.org/pub/databases/relational/postgresql/source/v9.3.2/
+https://ftp.postgresql.org/pub/source/v9.3.2/

--- a/deps-packaging/postgresql/cfbuild-postgresql.spec
+++ b/deps-packaging/postgresql/cfbuild-postgresql.spec
@@ -25,7 +25,7 @@ mkdir -p %{_builddir}
 SYS=`uname -s`
 
 if [ $SYS = "AIX" ]; then
-  patch -p1 < ../../SOURCES/makefile.aix.patch
+  $PATCH -p1 < ../../SOURCES/makefile.aix.patch
 fi
 
 ./configure --prefix=%{prefix} --without-zlib --without-readline --enable-shared

--- a/deps-packaging/postgresql/solaris/build
+++ b/deps-packaging/postgresql/solaris/build
@@ -17,17 +17,17 @@ export LIBS="-lrt"
 
 # Build
 
-make -C src/bin/pg_config
-make -C src/backend ../../src/include/utils/fmgroids.h
-make -C src/interfaces/libpq
+$MAKE -C src/bin/pg_config
+$MAKE -C src/backend ../../src/include/utils/fmgroids.h
+$MAKE -C src/interfaces/libpq
 
 # Test
 
 # Install
 
-make install -C src/bin/pg_config DESTDIR=${BUILD_ROOT}/cfbuild-postgresql-devel
-make install -C src/include DESTDIR=${BUILD_ROOT}/cfbuild-postgresql-devel
-make install -C src/interfaces/libpq DESTDIR=${BUILD_ROOT}/cfbuild-postgresql-devel
+$MAKE install -C src/bin/pg_config DESTDIR=${BUILD_ROOT}/cfbuild-postgresql-devel
+$MAKE install -C src/include DESTDIR=${BUILD_ROOT}/cfbuild-postgresql-devel
+$MAKE install -C src/interfaces/libpq DESTDIR=${BUILD_ROOT}/cfbuild-postgresql-devel
 
 # Package
 

--- a/deps-packaging/postgresql/solaris/build
+++ b/deps-packaging/postgresql/solaris/build
@@ -7,6 +7,7 @@ PREFIX=/var/cfengine
 PG=${BUILD_ROOT}/cfbuild-postgresql${PREFIX}
 PGD=${BUILD_ROOT}/cfbuild-postgresql-devel${PREFIX}
 export LDFLAGS="-Wl,-R/var/cfengine/lib -L/var/cfengine/lib"
+export LIBS="-lrt"
 
 # Patch
 

--- a/deps-packaging/postgresql/source
+++ b/deps-packaging/postgresql/source
@@ -1,1 +1,1 @@
-http://ftp.se.postgresql.org/pub/databases/relational/postgresql/source/v9.0.4/
+https://ftp.postgresql.org/pub/source/v9.0.4/

--- a/deps-packaging/redis/cfbuild-redis.spec
+++ b/deps-packaging/redis/cfbuild-redis.spec
@@ -22,7 +22,7 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 
 %setup -q -n redis-2.8.2
-patch -s -p1 < %{_topdir}/SOURCES/redis.patch
+$PATCH -s -p1 < %{_topdir}/SOURCES/redis.patch
 
 %build
 

--- a/deps-packaging/sasl2/solaris/build
+++ b/deps-packaging/sasl2/solaris/build
@@ -16,15 +16,15 @@ gpatch -p1 < solaris-unistd.patch
 
 #Build
 
-make -C include
-make -C lib
+$MAKE -C include
+$MAKE -C lib
 
 #Test
 
 #Install
 
-make -C include install DESTDIR=${BUILD_ROOT}/cfbuild-sasl2-devel
-make -C lib install DESTDIR=${BUILD_ROOT}/cfbuild-sasl2-devel
+$MAKE -C include install DESTDIR=${BUILD_ROOT}/cfbuild-sasl2-devel
+$MAKE -C lib install DESTDIR=${BUILD_ROOT}/cfbuild-sasl2-devel
 
 #Package
 

--- a/deps-packaging/sasl2/solaris/build
+++ b/deps-packaging/sasl2/solaris/build
@@ -9,7 +9,7 @@ LSD=${BUILD_ROOT}/cfbuild-sasl2-devel${PREFIX}
 export LDFLAGS="-Wl,-R/var/cfengine/lib -L/var/cfengine/lib"
 
 #Patch
-gpatch -p1 < solaris-unistd.patch
+$PATCH -p1 < solaris-unistd.patch
 #Configure
 
 ./configure --prefix=$PREFIX CPPFLAGS=-I/var/cfengine/include

--- a/deps-packaging/zlib/solaris/build
+++ b/deps-packaging/zlib/solaris/build
@@ -16,17 +16,17 @@ mv Makefile.new Makefile
 
 # Build
 
-make
+$MAKE
 
 # Test
 
 if [ "$TESTS" = all ]; then
-  make check
+  $MAKE check
 fi
 
 # Install
 
-make install prefix=${TZD}
+$MAKE install prefix=${TZD}
 
 # Package
 


### PR DESCRIPTION
Various fixes for Solaris. This was used to build the 3.6.4 package so the commit IDs should not be altered. If fixes are needed they should be put on top.