### PR TITLE
Fix Solaris binaries not finding the libnet library.

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -283,3 +283,8 @@ case "$BUILD_TYPE" in
 esac
 
 export OPTIMIZE
+
+# Don't let existing LD_LIBRARY_PATH variables disturb the build.
+# Java sets this when Jenkins launches it.
+# PS! Solaris shell returns false if the var is already unset.
+unset LD_LIBRARY_PATH || true


### PR DESCRIPTION
The LD_LIBRARY_PATH points to Java libraries, and for some reason the
OpenLDAP build thinks it needs the libnet library from there, which is
of course completely wrong, since it is a Java library. Nevertheless
it tries to depend on it, which then causes problems when trying to
run the binary.