### PR TITLE
Fix quoting of rpmbuild command line.

### DIFF
--- a/build-scripts/package
+++ b/build-scripts/package
@@ -28,8 +28,8 @@ esac
 case "$BUILD_TYPE" in
   DEBUG)
     DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS noopt nostrip"
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS "--define="with_optimize 0"
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS "--define="with_debugsym 1";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_optimize 0'"
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_debugsym 1'";;
   RELEASE|CODE_COVERAGE)
      DEB_BUILD_OPTIONS="nostrip"
     ;;

--- a/build-scripts/package
+++ b/build-scripts/package
@@ -146,7 +146,11 @@ case "$PACKAGING" in
       (cd $BASEDIR/$PKG/SOURCES; ln -sf $i) || false
     done
 
-    $RPMBUILD_CMD -bb --define="_topdir $BASEDIR/$PKG" --define="buildprefix $BUILDPREFIX" --define="_basedir $BASEDIR" ${RPMBUILD_OPTIONS:+"${RPMBUILD_OPTIONS}"} $SPEC
+    $RPMBUILD_CMD -bb \
+      --define="_topdir $BASEDIR/$PKG" \
+      --define="buildprefix $BUILDPREFIX" \
+      --define="_basedir $BASEDIR" \
+      $RPMBUILD_OPTIONS $SPEC
     ;;
   deb)
     if [ "$BUILDPREFIX" = "/opt/cfengine" ]
@@ -342,8 +346,12 @@ case "$PACKAGING" in
       (cd $BASEDIR/$PKG/SOURCES; ln -sf $i) || false
     done
 
-    $RPMBUILD_CMD -bb --define="_topdir $BASEDIR/$PKG" --define="buildprefix $BUILDPREFIX" --define="_basedir $BASEDIR" ${RPMBUILD_OPTIONS:+"${RPMBUILD_OPTIONS}"} $SPEC
-    
+    $RPMBUILD_CMD -bb \
+      --define="_topdir $BASEDIR/$PKG" \
+      --define="buildprefix $BUILDPREFIX" \
+      --define="_basedir $BASEDIR" \
+      $RPMBUILD_OPTIONS $SPEC
+
     #create bff packages
     chmod +x $P/$PKG.bff.sh
     $P/$PKG.bff.sh $RPM_VERSION $BASEDIR

--- a/build-scripts/package
+++ b/build-scripts/package
@@ -15,7 +15,8 @@ case "$PROJECT-$ROLE" in
   nova-hub)
     PKG=cfengine-nova-hub
     DEB_BUILD_OPTIONS=
-    RPMBUILD_OPTIONS="--define='with_expansion 1'";;
+    RPMBUILD_OPTIONS="--define 'with_expansion 1'"
+    ;;
   nova-agent)
     PKG=cfengine-nova
     DEB_BUILD_OPTIONS=
@@ -28,8 +29,9 @@ esac
 case "$BUILD_TYPE" in
   DEBUG)
     DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS noopt nostrip"
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_optimize 0'"
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_debugsym 1'";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define 'with_optimize 0'"
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define 'with_debugsym 1'"
+    ;;
   RELEASE|CODE_COVERAGE)
      DEB_BUILD_OPTIONS="nostrip"
     ;;
@@ -147,13 +149,13 @@ case "$PACKAGING" in
     done
 
     # eval and double quoting is needed to separate args,
-    # example cmd --define='a b':
+    # example cmd --define 'a b':
     #     - argv[1] = --define
     #     - argv[2] = a b
     eval $RPMBUILD_CMD -bb \
-      --define="'_topdir $BASEDIR/$PKG'" \
-      --define="'buildprefix $BUILDPREFIX'" \
-      --define="'_basedir $BASEDIR'" \
+      --define "'_topdir $BASEDIR/$PKG'" \
+      --define "'buildprefix $BUILDPREFIX'" \
+      --define "'_basedir $BASEDIR'" \
       $RPMBUILD_OPTIONS $SPEC
     ;;
   deb)
@@ -351,13 +353,13 @@ case "$PACKAGING" in
     done
 
     # eval and double quoting is needed to separate args,
-    # example cmd --define='a b':
+    # example cmd --define 'a b':
     #     - argv[1] = --define
     #     - argv[2] = a b
     eval $RPMBUILD_CMD -bb \
-      --define="'_topdir $BASEDIR/$PKG'" \
-      --define="'buildprefix $BUILDPREFIX'" \
-      --define="'_basedir $BASEDIR'" \
+      --define "'_topdir $BASEDIR/$PKG'" \
+      --define "'buildprefix $BUILDPREFIX'" \
+      --define "'_basedir $BASEDIR'" \
       $RPMBUILD_OPTIONS $SPEC
 
     #create bff packages

--- a/build-scripts/package
+++ b/build-scripts/package
@@ -15,7 +15,7 @@ case "$PROJECT-$ROLE" in
   nova-hub)
     PKG=cfengine-nova-hub
     DEB_BUILD_OPTIONS=
-    RPMBUILD_OPTIONS=--define="with_expansion 1";;
+    RPMBUILD_OPTIONS="--define='with_expansion 1'";;
   nova-agent)
     PKG=cfengine-nova
     DEB_BUILD_OPTIONS=
@@ -146,10 +146,14 @@ case "$PACKAGING" in
       (cd $BASEDIR/$PKG/SOURCES; ln -sf $i) || false
     done
 
-    $RPMBUILD_CMD -bb \
-      --define="_topdir $BASEDIR/$PKG" \
-      --define="buildprefix $BUILDPREFIX" \
-      --define="_basedir $BASEDIR" \
+    # eval and double quoting is needed to separate args,
+    # example cmd --define='a b':
+    #     - argv[1] = --define
+    #     - argv[2] = a b
+    eval $RPMBUILD_CMD -bb \
+      --define="'_topdir $BASEDIR/$PKG'" \
+      --define="'buildprefix $BUILDPREFIX'" \
+      --define="'_basedir $BASEDIR'" \
       $RPMBUILD_OPTIONS $SPEC
     ;;
   deb)
@@ -346,10 +350,14 @@ case "$PACKAGING" in
       (cd $BASEDIR/$PKG/SOURCES; ln -sf $i) || false
     done
 
-    $RPMBUILD_CMD -bb \
-      --define="_topdir $BASEDIR/$PKG" \
-      --define="buildprefix $BUILDPREFIX" \
-      --define="_basedir $BASEDIR" \
+    # eval and double quoting is needed to separate args,
+    # example cmd --define='a b':
+    #     - argv[1] = --define
+    #     - argv[2] = a b
+    eval $RPMBUILD_CMD -bb \
+      --define="'_topdir $BASEDIR/$PKG'" \
+      --define="'buildprefix $BUILDPREFIX'" \
+      --define="'_basedir $BASEDIR'" \
       $RPMBUILD_OPTIONS $SPEC
 
     #create bff packages

--- a/deps-packaging/pkg-build-rpm
+++ b/deps-packaging/pkg-build-rpm
@@ -78,9 +78,9 @@ fi
 
 case "$TESTS" in
   no)
-    RPMBUILD_OPTIONS=--define="with_testsuite 0";;
+    RPMBUILD_OPTIONS="--define='with_testsuite 0'";;
   yes)
-    RPMBUILD_OPTIONS=--define="with_testsuite 1";;
+    RPMBUILD_OPTIONS="--define='with_testsuite 1'";;
   *)
     fatal "Unknown tests option: $TESTS";;
 esac
@@ -103,10 +103,13 @@ case "$DEBUGSYM" in
     fatal "Unknown debugsym option: $DEBUGSYM";;
 esac
 
-$RPMBUILD_CMD -bb \
-  --define="_topdir $BASEDIR/$PKGNAME" \
-  --define="version $VERSION" \
-  --define="buildprefix $BUILDPREFIX" \
-  --define="make $MAKE" \
-  "$RPMBUILD_OPTIONS" \
-  $SPEC
+# eval and double quoting is needed to separate args,
+# example cmd --define='a b':
+#     - argv[1] = --define
+#     - argv[2] = a b
+eval $RPMBUILD_CMD -bb \
+  --define="'_topdir $BASEDIR/$PKGNAME'" \
+  --define="'version $VERSION'" \
+  --define="'buildprefix $BUILDPREFIX'" \
+  --define="'make $MAKE'" \
+  $RPMBUILD_OPTIONS $SPEC

--- a/deps-packaging/pkg-build-rpm
+++ b/deps-packaging/pkg-build-rpm
@@ -87,18 +87,18 @@ esac
 
 case "$OPTIMIZE" in
   no)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS "--define="with_optimize 0";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_optimize 0'";;
   yes)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS "--define="with_optimize 1";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_optimize 1'";;
   *)
     fatal "Unknown optimize option: $OPTIMIZE";;
 esac
 
 case "$DEBUGSYM" in
   yes)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS "--define="with_debugsym 1";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_debugsym 1'";;
   no)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS "--define="with_debugsym 0";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_debugsym 0'";;
   *)
     fatal "Unknown debugsym option: $DEBUGSYM";;
 esac

--- a/deps-packaging/pkg-build-rpm
+++ b/deps-packaging/pkg-build-rpm
@@ -78,38 +78,38 @@ fi
 
 case "$TESTS" in
   no)
-    RPMBUILD_OPTIONS="--define='with_testsuite 0'";;
+    RPMBUILD_OPTIONS="--define 'with_testsuite 0'";;
   yes)
-    RPMBUILD_OPTIONS="--define='with_testsuite 1'";;
+    RPMBUILD_OPTIONS="--define 'with_testsuite 1'";;
   *)
     fatal "Unknown tests option: $TESTS";;
 esac
 
 case "$OPTIMIZE" in
   no)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_optimize 0'";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define 'with_optimize 0'";;
   yes)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_optimize 1'";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define 'with_optimize 1'";;
   *)
     fatal "Unknown optimize option: $OPTIMIZE";;
 esac
 
 case "$DEBUGSYM" in
   yes)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_debugsym 1'";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define 'with_debugsym 1'";;
   no)
-    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define='with_debugsym 0'";;
+    RPMBUILD_OPTIONS="$RPMBUILD_OPTIONS --define 'with_debugsym 0'";;
   *)
     fatal "Unknown debugsym option: $DEBUGSYM";;
 esac
 
 # eval and double quoting is needed to separate args,
-# example cmd --define='a b':
+# example cmd --define 'a b':
 #     - argv[1] = --define
 #     - argv[2] = a b
 eval $RPMBUILD_CMD -bb \
-  --define="'_topdir $BASEDIR/$PKGNAME'" \
-  --define="'version $VERSION'" \
-  --define="'buildprefix $BUILDPREFIX'" \
-  --define="'make $MAKE'" \
+  --define "'_topdir $BASEDIR/$PKGNAME'" \
+  --define "'version $VERSION'" \
+  --define "'buildprefix $BUILDPREFIX'" \
+  --define "'make $MAKE'" \
   $RPMBUILD_OPTIONS $SPEC


### PR DESCRIPTION
It seems this never worked right for more than one "--define" arguments
in `$RPMBUILD_OPTIONS`. However it only got exposed after the
"debug_and_release kill" commit, that cause more complex rpmbuild
commands to be needed.
