### PR TITLE
Make sure well known hub platforms default to hub in the test builds.

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -120,14 +120,15 @@ case "$EXPLICIT_ROLE" in
 # We do not support 32 bits hubs anymore
 	nova-i386-*-*) ROLE=agent;;
     nova-s390*-*-*) ROLE=agent;;
-    nova-*-centos-[56].*) ROLE=hub;;
+    nova-*-centos-[56789].*) ROLE=hub;;
     nova-*-debian-6.*) ROLE=hub;;
     nova-*-opensuse-11.*) ROLE=hub;;
-    nova-*-rhel-[56].*) ROLE=hub;;
+    nova-*-rhel-[56789].*) ROLE=hub;;
     nova-*-sles-11.*) ROLE=hub;;
     nova-*-ubuntu-8.04) ROLE=hub;;
     nova-*-ubuntu-10.04) ROLE=hub;;
     nova-*-ubuntu-12.04) ROLE=hub;;
+    nova-*-ubuntu-14.04) ROLE=hub;;
     nova-*-mingw-*) ROLE=agent;;
     nova-*) ROLE=agent;;
     *)


### PR DESCRIPTION
Not urgent, since the package builds specify hub/agent specifically, but good to have in the testing pipeline so it tests the right type of agent.