### PR TITLE
Check PATH and MANPATH content before expanding them.

### DIFF
--- a/packaging/cfengine-community/profile.sh
+++ b/packaging/cfengine-community/profile.sh
@@ -1,2 +1,7 @@
-export PATH=$PATH:/var/cfengine/bin
-export MANPATH=$MANPATH:/var/cfengine/share/man
+if ! echo ${PATH} | /bin/grep -q /var/cfengine/bin ; then
+    export PATH=$PATH:/var/cfengine/bin
+fi
+
+if ! echo ${MANPATH} | /bin/grep -q /var/cfengine/share/man ; then
+    export MANPATH=$MANPATH:/var/cfengine/share/man
+fi


### PR DESCRIPTION
Check for existence of /var/cfengine/bin in $PATH and /var/cfengine/share/man in $MANPATH before expanding them.

My current $MANPATH, running inside tmux inside X terminal:
```bash
$ echo $MANPATH
:/var/cfengine/share/man:/var/cfengine/share/man:/var/cfengine/share/man
```