### PR TITLE
Moved libpam-dev from native to dev.

### DIFF
--- a/contrib/cf-deb-dep/cfbuild-dev.ctl
+++ b/contrib/cf-deb-dep/cfbuild-dev.ctl
@@ -3,7 +3,7 @@ Maintainer: Edward Welbourne <edward.welbourne@cfengine.com>
 Build-Depends: equivs
 Package: cfbuild-dev
 Changelog: ChangeLog-dev.txt
-Depends: autoconf, automake, libtool, flex, bison, cfbuild-native | cfbuild-repack
+Depends: autoconf, automake, libtool, flex, bison, libpam-dev, cfbuild-native | cfbuild-repack
 Recommends: git, gdb
 Description: CFEngine development essentials
  This package pulls in the ones you need in order to develop CFEngine

--- a/contrib/cf-deb-dep/cfbuild-native.ctl
+++ b/contrib/cf-deb-dep/cfbuild-native.ctl
@@ -3,7 +3,7 @@ Maintainer: Edward Welbourne <edward.welbourne@cfengine.com>
 Build-Depends: equivs
 Package: cfbuild-native
 Changelog: ChangeLog-native.txt
-Depends: gcc | clang, make, libpam-dev, libssl-dev, libpcre3-dev, liblmdb-dev | libtokyocabinet-dev | libqdbm-dev
+Depends: gcc | clang, make, libssl-dev, libpcre3-dev, liblmdb-dev | libtokyocabinet-dev | libqdbm-dev
 Suggests: libmysqlclient-dev, libpq-dev, libacl1-dev, lcov
 Description: CFEngine native prerequisites
  This package pulls in the ones you need in order to build shipped


### PR DESCRIPTION
We do use the system library for this (it's too tied to login
infrastructure), so we don't repack it; thus a repacking developer
does need it, as much as the native developer does.