### PR TITLE
Fix fuser output being misinterpreted on RHEL4.

### DIFF
--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -37,7 +37,7 @@ case "$TEST_MACHINE" in
     chroot)
         # Fuser has special output. The PIDs arrive on stdout, and all the ornaments
         # arrive on stderr, so all we have to do is to grep for PID numbers.
-        for pid in `sudo $FUSER $CHROOT_ROOT 2>/dev/null`; do
+        for pid in `sudo $FUSER $CHROOT_ROOT 2>/dev/null | sed -e 's/[^ 0-9]//g'`; do
             # Leaving processes behind is an error. It should never happen.
             return_code=1
             (


### PR DESCRIPTION
Most platforms print the PIDs on stdout, and decorative characters on
stderr. Together they look like nicely formatted output when printed
on the console, but it also allows you to pipe only the PIDs somewhere
else. However, RHEL4 prints everything on stdout, so we need to filter
out the superflous characters there. All we need are numbers and the
spaces between them, so reject everything else.