### PR TITLE
Fix .gitignore for cf_promises_* in OOTB git repo for enterprise hubs

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -142,7 +142,7 @@ EOHIPPUS
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT init")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT config user.email admin@cfengine.com")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT config user.name admin")
-  (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "echo -e '/cf_promise_*\n.*.sw[po]\n*~\n\\#*#' >.gitignore")
+  (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "echo -e '/cf_promises_*\n.*.sw[po]\n*~\n\\#*#' >.gitignore")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT add .gitignore")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT commit -m 'Ignore cf_promise_*'")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT add *")


### PR DESCRIPTION
This is for the /opt/cfengine/masterfiles.git repo that is created when a hub is first installed.