### PR TITLE
Teach detect-environment about Debian stretch (new testing, shall be 9.0)

### DIFF
--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -135,6 +135,9 @@ detect_distribution()
       jessie*)
         REL=8.0
         ;;
+      stretch*)
+        REL=9.0
+        ;;
       *)
         echo "Unable to detect version of Debian: $REL"
         exit 42;;


### PR DESCRIPTION
Now that Jessie has been released (as 8.0), we need to be able to recognise the new testing version.