### PR TITLE
Change the command to create Design Centre's .gitignore

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -158,7 +158,7 @@ EOHIPPUS
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT init")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT config user.email admin@cfengine.com")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT config user.name admin")
-  (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "echo -e '/cf_promises_*\n.*.sw[po]\n*~\n\\#*#' >.gitignore")
+  (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "(echo '/cf_promises_*'; echo '.*.sw[po]'; echo '*~'; echo '\\#*#') >.gitignore")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT add .gitignore")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT commit -m 'Ignore cf_promise_*'")
   (cd $DCWORKDIR/masterfiles_staging && su $MP_APACHE_USER -c "$GIT add *")


### PR DESCRIPTION
On looking at the installed file on my Debian test machine, I found it
started with the -e we'd passed to echo to get it to honour the '\n'
that appear in what we're echoing.  It turns out bash's echo outputs a
'\n' as such unless given -e; while dash's echo interprets \n as a
newline without a -e and includes any -e passed to it as part of its
output.  So no single echo invocation works for both.  Break up the
lines into separate invocations of echo, bung them in a sub-shell and
drop the sub-shell's accumulated output into .gitignore

I still need to test this works as expected.