### PR TITLE
Redmine#7270: iconv is needed to be built into PHP

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -207,6 +207,9 @@ case "$ROLE" in
     LIBCURL=yes
     GIT=yes
     RSYNC=yes
+    # Needed by PHP, see redmine#7270
+    LIBICONV=yes
+
     case "$OS-${OS_VERSION}" in
       rhel-[5].*) PHP_JSON=yes;;
       centos-[5].*) PHP_JSON=yes;;

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -54,6 +54,8 @@ Hub specific dependencies:
   * Needed for php module
 * libmcrypt 2.5.8
   * Needed for php module
+* [libiconv](http://ftp.gnu.org/gnu/libiconv/) 1.14
+  * Needed to be built into PHP, it's used by `cf_util_helper.php`
 
 Other dependencies (**find out why they are needed!**)
 

--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -70,7 +70,7 @@ mkdir -p %{_builddir}
 --without-gettext \
 --without-gmp \
 --without-mhash \
---without-iconv \
+--with-iconv-dir=%{prefix} \
 --without-imap \
 --without-imap-ssl \
 --without-interbase \

--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -61,7 +61,7 @@ build-stamp:
 --without-gettext \
 --without-gmp \
 --without-mhash \
---without-iconv \
+--with-iconv-dir=%{prefix} \
 --without-imap \
 --without-imap-ssl \
 --without-interbase \


### PR DESCRIPTION
It's used (but probably shouldn't be) in a couple of places in
cf_util_helper.php.