### PR TITLE
Redmine #7289: Add libltdl7 as a dependency to the hub package.

### DIFF
--- a/packaging/cfengine-nova-hub/debian/control
+++ b/packaging/cfengine-nova-hub/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.8.4
 
 Package: cfengine-nova-hub
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, libltdl7
 Provides: cfengine-nova-hub
 Replaces: cfengine3, cfengine-community, cfengine-nova-hub
 Description: CFEngine Nova : The next generation tool for data centre.


### PR DESCRIPTION
All Debian platforms which support the hub package (Debian 6 and
higher, as well as Ubuntu 10 and higher) need this library in order
to work. Debian 4 doesn't have the library, but we also don't build a
hub package for that platform.