### PR TITLE
Fix SSIZE_MAX not being defined in certain MinGW versions.

### DIFF
--- a/deps-packaging/lmdb/debian/rules
+++ b/deps-packaging/lmdb/debian/rules
@@ -4,9 +4,13 @@ PREFIX=$(BUILDPREFIX)
 
 ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
   PTHREAD=
+  CPPFLAGS=
 else
   PTHREAD=--with-pthread=/var/cfengine
+  CPPFLAGS=-D_POSIX_
 endif
+
+export CPPFLAGS
 
 clean:
 	dh_testdir


### PR DESCRIPTION
The build slaves don't seem to need it, but I do on my machine.