### PR TITLE
Redmine #7335: Debian: Make sure systemd is used when it's supported.

### DIFF
--- a/packaging/common/script-templates/deb-script-common.sh
+++ b/packaging/common/script-templates/deb-script-common.sh
@@ -19,7 +19,11 @@ rc_d_path()
 
 platform_service()
 {
-  /etc/init.d/"$1" "$2"
+  if [ -x /bin/systemctl ]; then
+    /bin/systemctl "$2" "$1"
+  else
+    /etc/init.d/"$1" "$2"
+  fi
 }
 
 IS_UPGRADE=0


### PR DESCRIPTION
Fixes CFEngine web service being launched in the wrong process group.