### PR TITLE
Redmine #6954: Prevent accumulation of unrelated AIX packages.

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.bff.sh
+++ b/packaging/cfengine-nova/cfengine-nova.bff.sh
@@ -15,8 +15,14 @@ BASEDIR=$2
 LPPBASE=$2/..
 P="$BASEDIR/buildscripts/packaging/cfengine-nova"
 
-#create necessary directory skeleton
-sudo rm -rf $LPPBASE/lppdir/lpp/cfengine-nova-$VERSION
+# Clean up old build artifacts.
+for i in bff lpp out
+do
+    sudo rm -rf $LPPBASE/lppdir/$i/*
+    sudo rm -rf $HOME/lppdir/$i/*
+done
+
+# Create necessary directory skeleton.
 mkdir -p $LPPBASE/lppdir/lpp/cfengine-nova-$VERSION
 cd $LPPBASE/lppdir/lpp/cfengine-nova-$VERSION
 


### PR DESCRIPTION
The directory is not cleaned, so each time we build a different
version we get a new package. This propogates all the way to the final
package directory, which is both confusing and potentially dangerous,
since someone may be tempted to download a package for a given version
that looks legitimate, but is in fact, an old/broken build.