### PR TITLE
Add build-scripts/bootstrap-tarballs and build-scripts/unpack-tarballs

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -1,0 +1,30 @@
+#!/bin/sh -x
+
+. `dirname "$0"`/functions
+. detect-environment
+. compile-options
+
+
+mkdir -p $BASEDIR/output/tarballs
+
+cd $BASEDIR/core
+rm cfengine-3.*.tar.gz || true
+git rev-parse HEAD > $BASEDIR/output/core-commitID
+
+make dist
+mv cfengine-3.*.tar.gz $BASEDIR/output/tarballs/
+
+cd $BASEDIR/masterfiles
+rm cfengine-masterfiles*.tar.gz || true
+git rev-parse HEAD > $BASEDIR/output/masterfiles-commitID
+
+make dist
+mv cfengine-masterfiles*.tar.gz $BASEDIR/output/tarballs/
+
+# We remove the git-checked-out directories so that we use the tarballs,
+# in order to ensure they are good. The tarballs are unpacked and
+# symlinked into place, during the next building stage in each of the
+# various buildslaves.
+
+cd "$BASEDIR"
+rm -rf "$BASEDIR/core/" "$BASEDIR/masterfiles/"

--- a/build-scripts/generate-source-tarballs
+++ b/build-scripts/generate-source-tarballs
@@ -20,3 +20,14 @@ cd ..
 mkdir -p "$OUTDIR"
 cp core/*.tar.gz masterfiles/*.tar.gz "$OUTDIR"
 rm core/*.tar.gz masterfiles/*.tar.gz
+
+
+echo '
+The source tarballs here are generated in each and every
+buildslave. THIS IS NOT THE TARBALL TO BE RELEASED! This is only to make
+sure that "make dist" works everywhere.
+
+The release tarball is generated from the "bootstrap-*-community"
+jenkins jobs, running only on one buildslave. It should be located under
+the "output/tarballs" directory of that job.
+'    > "$OUTDIR"/TARBALLS.txt

--- a/build-scripts/unpack-tarballs
+++ b/build-scripts/unpack-tarballs
@@ -1,0 +1,23 @@
+#!/bin/sh -x
+
+. `dirname "$0"`/functions
+. detect-environment
+. compile-options
+
+
+SOURCE_TARBALL="$BASEDIR/output/tarballs/cfengine-3.*.tar.gz"
+MASTERFILES_TARBALL="$BASEDIR/output/tarballs/cfengine-masterfiles*.tar.gz"
+cd $BASEDIR
+
+echo "Ensuring that the git-checked-out directories core/ and masterfiles/ are not here"
+[ -e core -o -e masterfiles ] && exit 1 || true
+
+# NATIVE TAR is being used on purpose, and *not* GNU TAR.
+
+echo "UNPACKING SOURCE TARBALL AND SYMLINKING core/"
+gzip -dc "$SOURCE_TARBALL"  | tar -xf -
+ln -s cfengine-3* core
+
+echo "UNPACKING MASTERFILES TARBALL AND SYMLINKING masterfiles/"
+gzip -dc "$MASTERFILES_TARBALL" | tar -xf -
+ln -s cfengine-masterfiles-* masterfiles


### PR DESCRIPTION
The first is supposed to run from the "bootstrap" jenkins job and create
the core and masterfiles tarballs, and delete the git-checked-out
directories.

The second is supposed to run in the next stage in each of the
buildslaves, and unpack the tarballs and symlink into the core/ and
masterfiles/ directories.

This way we have a separate tarball from the "bootstrap" slave suitable
for releasing, and we test in all platforms that the tarball is valid.