### PR TITLE
Redmine #7591: Fix Solaris pkgs contain dupl. files instead of links.

### DIFF
--- a/build-scripts/package
+++ b/build-scripts/package
@@ -172,21 +172,27 @@ case "$PACKAGING" in
     sudo rm -rf $BASEDIR/$PKG/pkg
     mkdir -p $BASEDIR/$PKG/pkg
 
-    cp -pr $BASEDIR/cfengine/dist/* $BASEDIR/$PKG/pkg
-    cp -pr $P/solaris/* $BASEDIR/$PKG/pkg
-    cp -pr /var/cfengine/bin/* $BASEDIR/$PKG/pkg/var/cfengine/bin
-    cp -pr /var/cfengine/lib/* $BASEDIR/$PKG/pkg/var/cfengine/lib
-
-    ARCH=`uname -p`
-    sed -e "s/@@PKG@@/$PKG/g;s/@@ARCH@@/$ARCH/g;s/@@VERSION@@/$VERSION/g" $BASEDIR/$PKG/pkg/pkginfo.in > $BASEDIR/$PKG/pkg/pkginfo
+    rsync -lpr $BASEDIR/cfengine/dist/* $BASEDIR/$PKG/pkg/
+    rsync -lpr /var/cfengine/bin/* $BASEDIR/$PKG/pkg/var/cfengine/bin/
+    rsync -lpr /var/cfengine/lib/* $BASEDIR/$PKG/pkg/var/cfengine/lib/
 
     cd $BASEDIR/$PKG/pkg
-    cat prototype.head > prototype.tmp
-    find . -type f | egrep -v "$PREFIX|(pre|post)(install|remove)|pkginfo|prototype|prototype.head|pkginfo.in" | pkgproto >> prototype.tmp
-    find var/cfengine | pkgproto >> prototype.tmp
+    # IMPORTANT: Before this step, do not copy any files into the current
+    # directory that shouldn't be in the package, otherwise they will be
+    # included as package files.
+    pkgproto .=/ > ../prototype.tmp
+    mv ../prototype.tmp .
 
-    # Replace last two words with "root root".
-    sed -e 's/^\([fd].* \)[^ ][^ ]*  *[^ ][^ ]*$/\1root root/' prototype.tmp > prototype
+    # Paste several things together in the prototype.
+    (
+      cat $P/solaris/prototype.head
+      # Replace last two words with "root root" and filter out directories that
+      # aren't ours.
+      sed -e 's/^\([fd].* \)[^ ][^ ]*  *[^ ][^ ]*$/\1root root/' prototype.tmp | egrep '^([^d]|d none /var/cfengine)'
+    ) > prototype
+
+    ARCH=`uname -p`
+    sed -e "s/@@PKG@@/$PKG/g;s/@@ARCH@@/$ARCH/g;s/@@VERSION@@/$VERSION/g" $P/solaris/pkginfo.in > $BASEDIR/$PKG/pkg/pkginfo
 
     $P/../common/produce-script $PKG preinstall pkg > preinstall
     $P/../common/produce-script $PKG postinstall pkg > postinstall

--- a/deps-packaging/pkg-build-solaris
+++ b/deps-packaging/pkg-build-solaris
@@ -10,15 +10,15 @@ gen_prototype() {
       continue
     elif [ "$destf" = "/var" ]; then
       continue
+    elif [ -h $f ]; then
+      dest=`LANG= file -h $f | sed -e 's/.*symbolic link to //'`
+      echo "s none /$destf=$dest root root"
     elif [ -f $f ] && [ -x $f ]; then
       echo "f none /$destf=$f 0755 root root"
     elif [ -f $f ]; then
       echo "f none /$destf=$f 0644 root root"
     elif [ -d $f ]; then
       echo "d none /$destf=$f 0755 root root"
-    elif [ -h $f ]; then
-      dest=`LANG= file -h $f | sed -e 's/.*symbolic link to //'`
-      echo "s none /$destf=$dest root root"
     else
       echo "Unknown file type: $f" >&2
       exit 42


### PR DESCRIPTION
There were in fact three separate issues at work to prevent symlinks
from reaching the package:

The first is the fact that Solaris' shell appears to return true for
the -f test, even if the file is actually a link. So we need to test
for a link first. This is the fix in pkg-build-solaris.

Secondly, cp does not preserve links unless -P is given, but -P is not
supported on Solaris 9, so instead we use rsync with the -l option.

And third, we were using `find -type f` to iterate through the package
candidate files, but this would not return links at all. We switch to
using the pkgproto tool directly instead, but this required some
restructuring because the directory cannot have any non-package files
when that command is invoked, or they will be included in the package
verbatim. Changed the logic to copy these into the directory later
instead.

Changelog: Fix: Solaris packages no longer contain duplicate library
files, but instead symlinks to them.