### PR TITLE
Remove sneaky build-time dependency of apr-util to apr

### DIFF
--- a/deps-packaging/apr-util/debian/rules
+++ b/deps-packaging/apr-util/debian/rules
@@ -21,10 +21,10 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
-	./configure --prefix=$(PREFIX)  --with-apr=$(PREFIX) --with-ldap-lib=$(PREFIX)/lib --with-ldap\
+	./configure --prefix=$(PREFIX)  --with-apr=$(PREFIX) --with-ldap-lib=$(PREFIX)/lib --with-ldap \
 	    CPPFLAGS="$(CPPFLAGS)"
-	cp ../../apr/pkg/build/apr_rules.mk build/rules.mk
-	make 
+
+	make
 
 	touch build-stamp
 


### PR DESCRIPTION
RPM spec file has the same hack removed some time now, and it's not obvious what purpose it serves.