### PR TITLE
Fix certain Linux build targets bleeding over into other build slaves.

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -14,6 +14,7 @@ git rev-parse HEAD > $BASEDIR/output/core-commitID
 ./configure --with-tokyocabinet=/usr
 make dist
 mv cfengine-3.*.tar.gz $BASEDIR/output/tarballs/
+make distclean
 
 cd $BASEDIR/masterfiles
 rm cfengine-masterfiles*.tar.gz || true
@@ -22,6 +23,7 @@ git rev-parse HEAD > $BASEDIR/output/masterfiles-commitID
 ./configure
 make dist
 mv cfengine-masterfiles*.tar.gz $BASEDIR/output/tarballs/
+make distclean
 
 cd $BASEDIR/output/tarballs
 sha256sum *.tar.gz > sha256sums.txt


### PR DESCRIPTION
The problem is that a few select build targets are built even when
doing just "make dist". One example is the
tests/unit/init_script_test_helper, which is built because the test
shell script depends on it. This is no problem for the tarball,
because it won't be included, however when we afterwards copy the
workspace to the other build slaves, they will think that this target
was already built, and therefore it won't be rebuilt in the native
binary format.  Obviously a Solaris host won't be able to run a Linux
binary.