### PR TITLE
Redmine #7267: Allow exporting CSV files over HTTPS.

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -233,15 +233,25 @@ done
 # The certificate will be named $(hostname -f).cert and the corresponding key should be named $(hostname -f).key.
 #
 CFENGINE_MP_DEFAULT_CERT_LOCATION="$PREFIX/httpd/ssl/certs"
+CFENGINE_MP_DEFAULT_CERT_LINK_LOCATION="$PREFIX/httpd/ssl"
 CFENGINE_MP_DEFAULT_KEY_LOCATION="$PREFIX/httpd/ssl/private"
 CFENGINE_OPENSSL="$PREFIX/bin/openssl"
 mkdir -p $CFENGINE_MP_DEFAULT_CERT_LOCATION
 mkdir -p $CFENGINE_MP_DEFAULT_KEY_LOCATION
 CFENGINE_LOCALHOST=$(hostname -f)
 CFENGINE_MP_CERT=$CFENGINE_MP_DEFAULT_CERT_LOCATION/$CFENGINE_LOCALHOST.cert
+CFENGINE_MP_CERT_LINK=$CFENGINE_MP_DEFAULT_CERT_LINK_LOCATION/cert.pem
 CFENGINE_MP_KEY=$CFENGINE_MP_DEFAULT_KEY_LOCATION/$CFENGINE_LOCALHOST.key
 if [ ! -f $CFENGINE_MP_CERT ]; then
   $CFENGINE_OPENSSL req -new -newkey rsa:2048 -days 3650 -nodes -x509 -utf8 -sha256 -subj "/CN=$CFENGINE_LOCALHOST" -keyout $CFENGINE_MP_KEY  -out $CFENGINE_MP_CERT -config $PREFIX/ssl/openssl.cnf
+  ln -sf $CFENGINE_MP_CERT $CFENGINE_MP_CERT_LINK
+fi
+
+#
+# If we are upgrading and the link is not there make sure to create it
+#
+if [ ! -h $CFENGINE_MP_CERT_LINK ]; then
+  ln -sf $CFENGINE_MP_CERT $CFENGINE_MP_CERT_LINK
 fi
 #
 # Modify the Apache configuration with the corresponding key and certificate


### PR DESCRIPTION
In order to support CSV reports being send over HTTPS connection
we need to have cert.pem certificate in /var/cfengine/httpd/ssl.

This one is making a symbolic link in mentioned location to the
certificate file placed in /var/cfengine/httpd/ssl/.

Changelog: Fix exporting CSV reports through HTTPS. (Redmine #7267)