### PR TITLE
ENT-2724: Fix crash in PHP cleanup function.

### DIFF
--- a/deps-packaging/php/0001-Revert-Fix-memory-leak-with-not-freeing-OpenSSL-erro.patch
+++ b/deps-packaging/php/0001-Revert-Fix-memory-leak-with-not-freeing-OpenSSL-erro.patch
@@ -1,0 +1,33 @@
+From 82ceb3f9a089104f353b9532bd6b28c82c3b65ca Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@mender.io>
+Date: Tue, 3 May 2016 10:23:30 +0200
+Subject: [PATCH] Revert "Fix memory leak with not freeing OpenSSL errors"
+
+This reverts commit a63d0f55da87fc620c66f1b909d752d7c8b1159c.
+
+Both Curl and OpenSSL want to call this function, but it's only
+allowed to call it once. This is a bug in PHP itself, so remove for
+now. A memory leak in the cleanup is insignificant compared to a
+crash.
+---
+ ext/openssl/openssl.c |    4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/ext/openssl/openssl.c b/ext/openssl/openssl.c
+index 88e396c..27d9c6c 100644
+--- a/ext/openssl/openssl.c
++++ b/ext/openssl/openssl.c
+@@ -1277,10 +1277,6 @@ PHP_MSHUTDOWN_FUNCTION(openssl)
+ {
+ 	EVP_cleanup();
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00090805f
+-	ERR_free_strings();
+-#endif
+-
+ 	php_unregister_url_stream_wrapper("https" TSRMLS_CC);
+ 	php_unregister_url_stream_wrapper("ftps" TSRMLS_CC);
+ 
+-- 
+1.7.9.5
+

--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -11,6 +11,8 @@ Group: Other
 Url: http://example.com/
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
+Patch0: 0001-Revert-Fix-memory-leak-with-not-freeing-OpenSSL-erro.patch
+
 AutoReqProv: no
 
 %define prefix %{buildprefix}
@@ -18,6 +20,8 @@ AutoReqProv: no
 %prep
 mkdir -p %{_builddir}
 %setup -q -n php-%{php_version}
+
+%patch0 -p1
 
 ./configure --prefix=%{prefix}/httpd/php \
 --with-apxs2=%{prefix}/httpd/bin/apxs \

--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -12,6 +12,8 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
+	patch -p1 < 0001-Revert-Fix-memory-leak-with-not-freeing-OpenSSL-erro.patch
+
 	./configure --prefix=$(PREFIX)/httpd/php \
 --with-apxs2=$(PREFIX)/httpd/bin/apxs \
 --with-config-file=$(PREFIX)/httpd/php \


### PR DESCRIPTION
Both Curl and OpenSSL want to call this function, but it's only
allowed to call it once. This is a bug in PHP itself, so remove for
now. A memory leak in the cleanup is insignificant compared to a
crash.