### PR TITLE
ENT-2714: Add libtool-ltdl as RedHat package dependency.

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -12,7 +12,7 @@ Group: Applications/System
 URL: http://cfengine.com/
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3, cfengine-community
-Requires: coreutils gzip
+Requires: coreutils gzip libtool-ltdl
 Requires(pre): /usr/sbin/useradd, /usr/sbin/userdel, /usr/bin/getent
 Requires(post): /usr/sbin/usermod, /bin/sed
 AutoReqProv: no


### PR DESCRIPTION
Otherwise login to Mission Portal fails for platforms that don't have
it.