### PR TITLE
Fix error in package scripts when trying to redirect output on HP-UX.

### DIFF
--- a/packaging/common/script-templates/script-common-header-last.sh
+++ b/packaging/common/script-templates/script-common-header-last.sh
@@ -22,6 +22,7 @@ is_nova()
 }
 
 INSTLOG=/var/log/CFEngineHub-Install.log
+mkdir -p "$(dirname "$INSTLOG")"
 CONSOLE=7
 # Redirect most output to log file, but keep console around for custom output.
 case "$SCRIPT_TYPE" in


### PR DESCRIPTION
/var/log doesn't always exist on HP-UX.