### PR TITLE
ENT-2714 fix libltdl dependency

### DIFF
--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -1,36 +1,74 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . `dirname "$0"`/functions
 . detect-environment
 . compile-options
 
+
 case "$OS" in
     rhel|centos)
         # Fakeroot is here: http://dl.atrpms.net/el5-$1/atrpms/stable/fakeroot-1.6.4-15.1.el5.$1.rpm
-        DEP_LIST="ntp rsync gcc make bison flex fakeroot gcc-c++ ncurses ncurses-devel pkgconfig rpm-build autoconf pam-devel"
-        CHECK_CMD="rpm -q"
+        DEP_LIST="ntp rsync gcc make fakeroot gcc-c++ ncurses ncurses-devel pkgconfig rpm-build pam-devel"
+        # Libtool is unwanted because "libltdl" polutes our package dependencies.
+        # The rest are wanted only on the machine doing "autogen.sh", which is *different* from the buildslaves
+        ### TODO add to the unwanted list:    bison byacc flex autoconf automake
+        UNWANTED_DEPS="libtool libtool-ltdl libtool-ltdl-devel"
+        CHECK_CMD="rpm -q --quiet"
+        REMOVE_CMD="rpm -e"
         ;;
     debian|ubuntu)
-        DEP_LIST="ntp rsync gcc make bison flex fakeroot dpkg-dev debhelper g++ libncurses5 pkg-config build-essential autoconf libpam0g-dev"
+        DEP_LIST="ntp rsync gcc make fakeroot dpkg-dev debhelper g++ libncurses5 pkg-config build-essential autoconf libpam0g-dev"
+        UNWANTED_DEPS="libtool libltdl7 libltdl-dev"
         CHECK_CMD="dpkg -l | grep -q -w"
+        REMOVE_CMD="dpkg --purge"
         ;;
     *)
         exit 0
         ;;
 esac
 
-RET=0
+RET1=0
 MISSING_DEPS=
 COMMA=
-for dep in $DEP_LIST; do
-    if ! eval $CHECK_CMD $dep; then
+for dep in $DEP_LIST
+do
+    if ! $CHECK_CMD $dep
+    then
         MISSING_DEPS="$MISSING_DEPS$COMMA$dep"
-        COMMA=", "
-        RET=1
+        COMMA=","
+        RET1=1
     fi
 done
-
-if test $RET -gt 0; then
-    echo "Dependencies $MISSING_DEPS not found. Make sure they are installed on the build machine." 1>&2
+if [ $RET1 -gt 0 ]
+then
+    echo "Need packages INSTALLED to proceed:" $MISSING_DEPS    1>&2
 fi
-exit $RET
+
+RET2=0
+COMMA=
+TOREMOVE_DEPS=
+for unwanted in $UNWANTED_DEPS
+do
+    if $CHECK_CMD $unwanted
+    then
+        TOREMOVE_DEPS="$TOREMOVE_DEPS$COMMA$unwanted"
+        COMMA=","
+        RET2=1
+    fi
+done
+if [ $RET2 -gt 0 ]
+then
+    echo "Need packages REMOVED to proceed:" $TOREMOVE_DEPS    1>&2
+fi
+
+
+
+# Exit with the right exit code
+if [  $RET1 = 0  -a  $RET2 = 0  ]
+then
+    echo "$0: SUCCESS buildslave is correctly setup"
+    exit 0
+else
+    echo "$0: FAILURE buildslave is NOT correctly setup"
+    exit 1
+fi

--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -5,6 +5,9 @@
 . compile-options
 
 
+# WARNING we alter the buildslave: we remove UNWANTED_DEPS
+
+
 case "$OS" in
     rhel|centos)
         # Fakeroot is here: http://dl.atrpms.net/el5-$1/atrpms/stable/fakeroot-1.6.4-15.1.el5.$1.rpm
@@ -12,6 +15,7 @@ case "$OS" in
         # Libtool is unwanted because "libltdl" polutes our package dependencies.
         # The rest are wanted only on the machine doing "autogen.sh", which is *different* from the buildslaves
         ### TODO add to the unwanted list:    bison byacc flex autoconf automake
+        ###      unfortunately they are automatically installed at some later stage...
         UNWANTED_DEPS="libtool libtool-ltdl libtool-ltdl-devel"
         CHECK_CMD="rpm -q --quiet"
         REMOVE_CMD="rpm -e"
@@ -22,12 +26,23 @@ case "$OS" in
         CHECK_CMD="dpkg -l | grep -q -w"
         REMOVE_CMD="dpkg --purge"
         ;;
+
+    # QUIT IN UNKNOWN OS
     *)
         exit 0
         ;;
 esac
 
-RET1=0
+RET=0
+for unwanted in $UNWANTED_DEPS
+do
+    if $CHECK_CMD $unwanted
+    then
+        echo "Removing unwanted package:" $unwanted
+        $REMOVE_CMD $unwanted    ||     echo FAILURE && RET=1
+    fi
+done
+
 MISSING_DEPS=
 COMMA=
 for dep in $DEP_LIST
@@ -36,35 +51,17 @@ do
     then
         MISSING_DEPS="$MISSING_DEPS$COMMA$dep"
         COMMA=","
-        RET1=1
+        RET=1
     fi
 done
-if [ $RET1 -gt 0 ]
+if [ $RET != 0 ]
 then
     echo "Need packages INSTALLED to proceed:" $MISSING_DEPS    1>&2
 fi
 
-RET2=0
-COMMA=
-TOREMOVE_DEPS=
-for unwanted in $UNWANTED_DEPS
-do
-    if $CHECK_CMD $unwanted
-    then
-        TOREMOVE_DEPS="$TOREMOVE_DEPS$COMMA$unwanted"
-        COMMA=","
-        RET2=1
-    fi
-done
-if [ $RET2 -gt 0 ]
-then
-    echo "Need packages REMOVED to proceed:" $TOREMOVE_DEPS    1>&2
-fi
-
-
 
 # Exit with the right exit code
-if [  $RET1 = 0  -a  $RET2 = 0  ]
+if [  $RET = 0  ]
 then
     echo "$0: SUCCESS buildslave is correctly setup"
     exit 0

--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -339,8 +339,9 @@ detect_environment
 
 # Print the environment variables so that the log can be used to debug problems
 # stemming from wrong environment.
-echo "Current environment:"
+echo -e "\n\n==================== Current environment ========================"
 env
+echo -e "=================================================================\n\n"
 
 #
 # We need to detect the following pieces of data:

--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -220,7 +220,7 @@ remote_script_general() {
   ENVVARS="$ENVVARS TEST_MACHINE=$TEST_MACHINE"
   ENVVARS="$ENVVARS TEST_SHELL=$TEST_SHELL"
 
-  ( set -x; eval $LOGIN_COMMAND env $ENVVARS "$SCRIPT_BASEDIR"/buildscripts/build-scripts/"$SCRIPT" )
+  ( eval $LOGIN_COMMAND env $ENVVARS "$SCRIPT_BASEDIR"/buildscripts/build-scripts/"$SCRIPT" )
 }
 
 remote_script() {

--- a/build-scripts/install-dependencies
+++ b/build-scripts/install-dependencies
@@ -60,9 +60,9 @@ esac
 
 case "$OS-$OS_VERSION" in
   rhel-4.*)
-    AUTOCONF=$(rpm -qa autoconf)
-    AUTOMAKE=$(rpm -qa automake)
-    LIBTOOL=$(rpm -qa libtool)
+    AUTOCONF=$(rpm -q autoconf)
+    AUTOMAKE=$(rpm -q automake)
+    LIBTOOL=$(rpm -q libtool)
     ACVER=cfbuild-autoconf-2.60-1
     AMVER=cfbuild-automake-1.10.1-1
     LTVER=cfbuild-libtool-1.5.24-1

--- a/build-scripts/install-dependencies
+++ b/build-scripts/install-dependencies
@@ -60,73 +60,33 @@ esac
 
 case "$OS-$OS_VERSION" in
   rhel-4.*)
-    AUTOCONF=$(rpm -q autoconf)
-    AUTOMAKE=$(rpm -q automake)
-    LIBTOOL=$(rpm -q libtool)
     ACVER=cfbuild-autoconf-2.60-1
     AMVER=cfbuild-automake-1.10.1-1
     LTVER=cfbuild-libtool-1.5.24-1
-    if ! [ -z "$AUTOCONF" ]; then
-      if [ "$AUTOCONF" != "$ACVER" ]; then
-        sudo /bin/rpm -ev --nodeps autoconf
-        DEPS="$DEPS autoconf"
-      fi
-    else
-      DEPS="$DEPS autoconf"
-    fi
 
-    if ! [ -z "$AUTOMAKE" ]; then
-      if [ "$AUTOMAKE" != "$AMVER" ]; then
-        sudo /bin/rpm -ev --nodeps automake
-        DEPS="$DEPS automake"
-      fi
-    else
-      DEPS="$DEPS automake"
-    fi
+    sudo rpm -e autoconf || true
+    DEPS="$DEPS autoconf"
 
-    if ! [ -z "$LIBTOOL" ]; then
-      if [ "$LIBTOOL" != "$LTVER" ]; then
-        sudo /bin/rpm -ev --nodeps libtool
-        DEPS="$DEPS libtool"
-      fi
-    else
-      DEPS="$DEPS libtool"
-    fi
+    sudo rpm -e automake || true
+    DEPS="$DEPS automake"
+
+    sudo rpm -e libtool || true
+    DEPS="$DEPS libtool"
     ;;
+
   debian-4.*)
-    AUTOCONF=$(dpkg -l | grep autoconf | awk '{ print $3 }')
-    AUTOMAKE=$(dpkg -l | grep automake | awk '{ print $3 }')
-    LIBTOOL=$(dpkg -l | grep libtool | awk '{ print $3 }')
     ACVER=cfbuild-autoconf-2.60-1
     AMVER=cfbuild-automake-1.10.1-1
     LTVER=cfbuild-libtool-1.5.24-1
 
-    if ! [ -z "$AUTOCONF" ]; then
-      if [ "$AUTOCONF" != "$ACVER" ]; then
-          sudo /usr/bin/dpkg -r autoconf
-          DEPS="$DEPS autoconf"
-      fi 
-    else
-      DEPS="$DEPS autoconf"
-    fi
+    sudo dpkg -r autoconf || true
+    DEPS="$DEPS autoconf"
 
-    if ! [ -z "$AUTOMAKE" ]; then
-      if [ "$AUTOMAKE" != "$AMVER" ]; then
-          sudo /usr/bin/dpkg -r automake
-          DEPS="$DEPS automake"
-      fi 
-    else
-      DEPS="$DEPS automake"
-    fi
+    sudo dpkg -r automake || true
+    DEPS="$DEPS automake"
 
-    if ! [ -z "$LIBTOOL" ]; then
-      if [ "$LIBTOOL" != "$LTVER" ]; then
-          sudo /usr/bin/dpkg -r libtool
-          DEPS="$DEPS libtool"
-      fi 
-    else
-      DEPS="$DEPS libtool"
-    fi
+    sudo dpkg -r libtool || true
+    DEPS="$DEPS libtool"
     ;;
   *)
     ;;

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -12,7 +12,7 @@ Group: Applications/System
 URL: http://cfengine.com/
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3, cfengine-community
-Requires: coreutils gzip libtool-ltdl
+Requires: coreutils gzip
 Requires(pre): /usr/sbin/useradd, /usr/sbin/userdel, /usr/bin/getent
 Requires(post): /usr/sbin/usermod, /bin/sed
 AutoReqProv: no


### PR DESCRIPTION
Accidental installation of libtool and related packages on our buildslaves led to our hub package gaining one dependency. This is a series of commits that ensures this won't happen in the future.