### PR TITLE
Fix incorrect CentOS version detecton for newer OSes.

### DIFF
--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -54,8 +54,7 @@ detect_distribution()
     REL=$(cat /etc/redhat-release)
     case "$REL" in
       "CentOS "*)
-        VER=${REL#CentOS release }
-        VER=${VER% \(Final\)}
+        VER="$(echo "$REL" | sed -e 's/^CentOS \([^ ]* \)release \([0-9][0-9]*\.[0-9][0-9]*\).*$/\2/')"
         case "$VER" in
           [0-9].[0-9]);;
           *)


### PR DESCRIPTION
It could not handle strings of the type:
'CentOS Linux release 7.2.1511 (Core) '

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>