### PR TITLE
Don't include Linux Container directories in chroot.

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -326,6 +326,7 @@ EOF
     linux|hpux)
       cat <<EOF
 + /dev
+- /var/lib/lxcfs
 EOF
       ;;
   esac


### PR DESCRIPTION
They contain a lot of weird stuff that can't be copied.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>