### PR TITLE
Adapt to newer Linux distros having moved lock files to /run.

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -326,6 +326,9 @@ EOF
     linux|hpux)
       cat <<EOF
 + /dev
++ /run/lock
+- /run/*
++ /run
 - /var/lib/lxcfs
 EOF
       ;;


### PR DESCRIPTION
We need to include them in the test chroot.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>