### PR TITLE
Fix CentOS version detection.

### DIFF
--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -54,7 +54,7 @@ detect_distribution()
     REL=$(cat /etc/redhat-release)
     case "$REL" in
       "CentOS "*)
-        VER="$(echo "$REL" | sed -e 's/^CentOS \([^ ]* \)release \([0-9][0-9]*\.[0-9][0-9]*\).*$/\2/')"
+        VER="$(echo "$REL" | sed -e 's/^CentOS.* release \([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/')"
         case "$VER" in
           [0-9].[0-9]);;
           *)


### PR DESCRIPTION
Specifically for strings like:
'CentOS release 4.5 (Final)'

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>