### PR TITLE
When exporting environment to chroot, treat PATH specially.

### DIFF
--- a/build-scripts/prepare-testmachine-chroot
+++ b/build-scripts/prepare-testmachine-chroot
@@ -50,8 +50,11 @@ fi
 cd $HOME
 EOF
 
-# Include entire environment in chroot, and make sure everything is exported.
-export | sed -e 's/^\([^ ]*\)=/export \1=/' | sudo bash -c "cat >> ${CHROOT_ROOT}run-in-home-dir.sh"
+# Include entire environment in chroot, and make sure everything is exported,
+# and added to the existing environment.
+export | sed -e 's/^\([^ ]*\)=/export \1=/' | grep -v '^[^=]* PATH=' | sudo bash -c "cat >> ${CHROOT_ROOT}run-in-home-dir.sh"
+# Treat PATH specifically, and add to existing path.
+printf 'export PATH="%s:$PATH"\n' "$PATH" | sudo bash -c "cat >> ${CHROOT_ROOT}run-in-home-dir.sh"
 
 # Note different quote style on Here document.
 sudo bash -c "cat >> ${CHROOT_ROOT}run-in-home-dir.sh" <<'EOF'


### PR DESCRIPTION
It needs to add to the existing PATH, not just add it blindly. The
reason is that root has a different path than a user, and we will
need entries from both.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>