### PR TITLE
Index the package cache by Jenkins node label.

### DIFF
--- a/deps-packaging/pkg-cache
+++ b/deps-packaging/pkg-cache
@@ -27,7 +27,16 @@ fi
 #
 set -e
 
-CACHEDIR=$HOME/.cache/cfengine-buildscripts-pkgs
+# Check for Jenkins node label and use that as index.
+if [ -n "$NODE_LABELS" ]
+then
+  # There can be multiple labels, pick the first one.
+  # The last one is usually the node name.
+  label=${NODE_LABELS%% *}
+else
+  label=NO_LABEL
+fi
+CACHEDIR=$HOME/.cache/cfengine-buildscripts-pkgs/$label
 
 usage()
 {


### PR DESCRIPTION
This way multiple build slaves can share the cache without fear of
overwriting each other's packages.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>