### PR TITLE
ENT-2760: Enterprise: Fix Postgres database migration from 3.8- to 3.9+.

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -289,7 +289,7 @@ if [ ! -d $PREFIX/state/pg/data ]; then
   # If total memory is lower than 3GB, we use the default pgsql conf file
   # If total memory is beyond 64GB, we use a shared_buffers of 16G
   # Otherwise, we use a shared_buffers equal to 25% of total memory
-  total=$(awk '/^MemTotal:.*[0-9]+\skB/ {print $2}' /proc/meminfo)
+  total=`cat /proc/meminfo |grep "^MemTotal:.*[0-9]\+ kB"|awk '{print $2}'`
 
   echo "$total" | grep -q '^[0-9]\+$'
   if [ $? -ne 0 ] ;then

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -35,6 +35,8 @@ if is_upgrade && egrep '^3\.[6-8]\.' "$PREFIX/UPGRADED_FROM.txt" >/dev/null && [
     done
     exit 1
   fi
+
+  cf_console echo "Done making backup. They will be in $PREFIX/state/pg/db_dump-*.sql.gz."
 fi
 
 if [ "`package_type`" = "rpm" ]; then


### PR DESCRIPTION
The problem was that the initial population of the new database was
run before re-import of the database that was dumped from the old one.
The import script was not prepared for the database to already have
content. However the population scripts are prepared for this, since
this is what would happen if you upgraded between CFEngine versions
that run the same PostgreSQL version.

So the fix is to swap the order, run the import first. However, we
must take care to create the actual databases as well as the database
users first, since these are not covered by the import script.


Fix a couple of other minor things as well.