### PR TITLE
Fix Solaris choking on environment transfer.

### DIFF
--- a/build-scripts/prepare-testmachine-chroot
+++ b/build-scripts/prepare-testmachine-chroot
@@ -52,7 +52,22 @@ EOF
 
 # Include entire environment in chroot, and make sure everything is exported,
 # and added to the existing environment.
-export | grep -v '^[^=]*\bPATH=' | sed -e 's/^[^=]* //; s/^\([^=]*\)=\(.*\)/\1=\2\nexport \1/' | sudo sh -c "cat >> ${CHROOT_ROOT}run-in-home-dir.sh"
+# Split on newlines, not on spaces.
+IFS='
+'
+for entry in $(export)
+do
+    name=$(echo "$entry" | sed -e 's/^[^=]* //; s/^\([^=]*\)=.*/\1/')
+    if [ "$name" = "PATH" ]
+    then
+        continue
+    fi
+    value="$(echo "$entry" | sed -e 's/^[^=]*=//')"
+    printf "%s=%s\nexport %s\n" "$name" "$value" "$name"
+done | sudo sh -c "cat >> ${CHROOT_ROOT}run-in-home-dir.sh"
+# Restore normal splitting semantics.
+unset IFS
+
 # Treat PATH specifically, and add to existing path.
 printf 'export PATH="%s:$PATH"\n' "$PATH" | sudo sh -c "cat >> ${CHROOT_ROOT}run-in-home-dir.sh"
 


### PR DESCRIPTION
Apparently its sed doesn't handle '\n' characters in the script. Break
up the whole section instead, make it more readable, and use printf
for the final output.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>