### PR TITLE
Fetch correct version from 'configure' even for new style AC_INIT.

### DIFF
--- a/build-scripts/version
+++ b/build-scripts/version
@@ -9,7 +9,11 @@ parse_version_string()
 
   VERSION=$(awk '/^ ?'$VARNAME'=/ {print}' < $BASEDIR/$VERSION_PATH/configure)
 
+  # Remove "VERSION="
   VERSION=${VERSION#*=}
+  # Remove quotes, if any.
+  VERSION=${VERSION%\'}
+  VERSION=${VERSION#\'}
 
   if [ -z "$VERSION" ]; then
     echo "Unable to detect version (variable $VARNAME). Bailing out" >&2


### PR DESCRIPTION
When using AC_INIT to specify the version, the result in 'configure'
is slightly different, now having quotes around it.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>