### PR TITLE
INF-370: fix hub being built on agent nodes

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -131,7 +131,7 @@ case "$EXPLICIT_ROLE" in
   agent) ROLE=agent;;
   hub) ROLE=hub;;
   *)
-    if [ -z "$NODE_LABELS" ]
+    if [ -z "$label" ]
     then
       case "$PROJECT-$ARCH-$OS-${OS_VERSION}" in
         community-*) ROLE=agent;;
@@ -152,8 +152,10 @@ case "$EXPLICIT_ROLE" in
           ;;
       esac
       echo "Autodetected $ROLE role based on missing Jenkins label and OS."
-    else
-      case "$NODE_LABELS" in
+
+    else    # $label is set
+
+      case "$label" in
         *_HUB_*)
           echo "Autodetected hub role based on '_HUB_' in Jenkins label."
           ROLE=hub

--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -2,7 +2,7 @@
 
 detect_labels()
 {
-  case "$NODE_LABELS" in
+  case "$label" in
     *_x86_64_mingw*)
       CROSS_TARGET=${CROSS_TARGET:-x64-mingw}
       export CROSS_TARGET

--- a/deps-packaging/pkg-cache
+++ b/deps-packaging/pkg-cache
@@ -27,16 +27,18 @@ fi
 #
 set -e
 
+
 # Check for Jenkins node label and use that as index.
-if [ -n "$NODE_LABELS" ]
+# There can be multiple labels, pick the first one.
+firstlabel=${NODE_LABELS%% *}
+
+if [ x"$firstlabel" = x ]
 then
-  # There can be multiple labels, pick the first one.
-  # The last one is usually the node name.
-  label=${NODE_LABELS%% *}
-else
-  label=NO_LABEL
+    echo "Jenkins has not assigned a LABEL to this node, you are probably building manually"
+    firstlabel=NO_LABEL
 fi
-CACHEDIR=$HOME/.cache/cfengine-buildscripts-pkgs/$label
+
+CACHEDIR=$HOME/.cache/cfengine-buildscripts-pkgs/$firstlabel
 
 usage()
 {


### PR DESCRIPTION
This was happening because the NODE_LABELS variable contained all labels
that a particular node can get. Fixed by switching to the "label"
environment variable.