### PR TITLE
ENT-2831: Fix bootstrap hanging on non-systemd platforms.

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -426,7 +426,7 @@ mkdir -p $PREFIX/config
 #REDIS RELATED
 #
 cat > $PREFIX/config/redis.conf << EOF
-daemonize no
+daemonize yes
 pidfile $PREFIX/redis-server.pid
 unixsocket /tmp/redis.sock
 unixsocketperm 600


### PR DESCRIPTION
redis-server needs to daemonize, otherwise non-systemd platforms will
hang when trying to launch it.

Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>