### PR TITLE
CFE-2545: Fix services launching under wrong cgroup after upgrade.

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1,3 +1,9 @@
+if [ -x /bin/systemctl ]; then
+  # This is important in case any of the units have been replaced by the package
+  # and we call them in the postinstall script.
+  /bin/systemctl daemon-reload
+fi
+
 #
 # Make sure the cfapache user has a home folder and populate it
 #

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -1,3 +1,9 @@
+if [ -x /bin/systemctl ]; then
+  # This is important in case any of the units have been replaced by the package
+  # and we call them in the postinstall script.
+  /bin/systemctl daemon-reload
+fi
+
 #
 # Generate a host key
 #


### PR DESCRIPTION
What would happen is that after an upgrade, particularly going from
pre-3.10 to 3.10.0+, the systemd files would change significantly, but
systemd would not pick this up. This would cause it to use the old
systemd units, which would launch the services using the init script.
This would place nearly all services under a single cgroup, instead of
in separate cgroups, which is the intention in 3.10. This is bad
enough on its own, but is rendered particularly troublesome because
PostgreSQL uses sudo to launch itself, and it would place itself in a
separate cgroup which is unmanaged by systemd, hence it could never be
killed afterwards, except manually.

We avoid all this by reloading the systemd unit files at the start of
the postinstall script, after the files have been updated, but before
using any of them.

Changelog: Fix inability to correctly manage cf-postgres service after
upgrade.
Signed-off-by: Kristian Amlie <kristian.amlie@cfengine.com>