### PR TITLE
pkg-cache list: do not print literal '*' if the directory is empty.

### DIFF
--- a/deps-packaging/pkg-cache
+++ b/deps-packaging/pkg-cache
@@ -117,14 +117,15 @@ export _POSIX2_VERSION=1
 
 case "$CMD" in
   find)
-    if [ -d "$PKGCACHEDIR" ]; then
-      # Update access time for autoprune.
-      touch "$PKGCACHEDIR"
-      exit 0
-    else
-      exit 1
-    fi
-    ;;
+      if [ `find "$PKGCACHEDIR" -type f  |  wc -l`  !=  0 ]
+      then
+          # Update access time for autoprune.
+          touch "$PKGCACHEDIR"
+          exit 0
+      else
+          exit 1
+      fi
+      ;;
   store)
       mkdir -p "$PKGCACHEDIR"
       for sourcefile in $PKGFILES

--- a/deps-packaging/pkg-cache
+++ b/deps-packaging/pkg-cache
@@ -136,17 +136,15 @@ case "$CMD" in
           then
               # Force-remove cache directory if cp fails, otherwise
               # cache might become inconsistent
-              cp "$sourcefile" "$destfile" || \
-                  (rm -rf "$PKGCACHEDIR"; fatal 'Failed to copy!')
+              cp "$sourcefile" "$destfile"  \
+                  ||  (rm -rf "$PKGCACHEDIR"; fatal "Failed to copy $PKGVR")
           fi
       done
       ;;
   list)
-    if [ -d "$PKGCACHEDIR" ]; then
-      echo "$PKGCACHEDIR"/*
-    else
-      fatal "Package $PKGVR is not in cache."
-    fi;;
+      find "$PKGCACHEDIR" -type f  \
+          ||  fatal "Failed searching $PKGVR in cache"
+      ;;
   prune)
     if [ -d "$PKGCACHEDIR" ]; then
       rm -rf "$PKGCACHEDIR"


### PR DESCRIPTION
Also improved some logging messages.