### PR TITLE
INF-422: Mingw slaves not launching correctly

### DIFF
--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -11,7 +11,7 @@ Build dependencies:
 Agent dependencies:
 
 * [zlib](http://www.zlib.net/) 1.2.11
-* [OpenSSL](http://openssl.org/) 1.0.2j
+* [OpenSSL](http://openssl.org/) 1.0.2k
 * [PCRE](http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/) 8.39
 * [LMDB](https://github.com/LMDB/lmdb/) 0.9.19
 * [libyaml](http://pyyaml.org/wiki/LibYAML) 0.1.7

--- a/deps-packaging/openldap/mingw/debian/rules
+++ b/deps-packaging/openldap/mingw/debian/rules
@@ -14,11 +14,12 @@ build-stamp:
 
 	patch -p1 < 0001-Prefix-windres-with-cross-compiler-name.patch
 	patch -p0 < fix-libtool-magic.patch
+	ln -s /var/cfengine/bin/libgnurx-0.dll .
 
 	# Configure is unable to test memcmp for cross-compilation
 	# getaddrinfo/getnameinfo are broken in MinGW as well as socklen in2.4.36 work around it
 	ac_cv_type_socklen_t=yes \
-	ac_cv_func_memcmp_working=yes  \
+	ac_cv_func_memcmp_working=yes \
             ac_cv_func_getaddrinfo=no \
             ac_cv_func_getnameinfo=no \
 	    ./configure --host=$(DEB_HOST_GNU_TYPE) --prefix=$(PREFIX) \

--- a/deps-packaging/openssl/cfbuild-openssl.spec
+++ b/deps-packaging/openssl/cfbuild-openssl.spec
@@ -1,4 +1,4 @@
-%define openssl_version 1.0.2j
+%define openssl_version 1.0.2k
 
 Summary: CFEngine Build Automation -- openssl
 Name: cfbuild-openssl

--- a/deps-packaging/openssl/distfiles
+++ b/deps-packaging/openssl/distfiles
@@ -1,1 +1,1 @@
-96322138f0b69e61b7212bc53d5e912b  openssl-1.0.2j.tar.gz
+f965fc0bf01bf882b31314b61391ae65  openssl-1.0.2k.tar.gz

--- a/deps-packaging/openssl/solaris/build
+++ b/deps-packaging/openssl/solaris/build
@@ -14,6 +14,12 @@ export LD_LIBRARY_PATH=$PREFIX/lib
 
 $PATCH -p1 < honor-LDFLAGS.patch
 
+# Add dummy header files for features which are not compiled, but required
+mkdir -p ${BUILD_ROOT}/../include/openssl
+for f in idea srp; do
+	touch ${BUILD_ROOT}/../include/openssl/${f}.h
+done
+
 # Configure
 
 # config misdetects architecture when building on a 64-kernel with 32-bit

--- a/deps-packaging/pkg-get-src
+++ b/deps-packaging/pkg-get-src
@@ -105,7 +105,8 @@ fetch_file()
 
         # Some wget (1.9.1 on AIX) return 0 even when they failed! So we
         # must test for file existence for retrying.
-        [ -f "$OUTFILE" ]  ||  $WGET -t5 "$URL$FILENAME" -O "$OUTFILE" 1>&2  ||  true
+        # Also, they need an estra parameter to switch to passive mode FTP.
+        [ -f "$OUTFILE" ]  ||  $WGET -t5 --passive-ftp "$URL$FILENAME" -O "$OUTFILE" 1>&2  ||  true
         rm_if_empty "$OUTFILE"
 
         # Try one last time after converting https to http.


### PR DESCRIPTION
* Update OpenSSL version. Actually not required for mingw compilation, but since build artifacts cache was accidentally [disabled](https://github.com/mendersoftware/jenkins-jobs/commit/b1676ddc23635730bedd25e33ecd3e752d334706) via Jenkins policy, it was breaking the build process.

* symlink a *.dll file to a folder where a test will find it
