### PR TITLE
ENT-3129: Run database migrations during post-install

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -441,6 +441,9 @@ EOF
 
 fi
 
+# Proper Database Migrations
+$PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php migration/tasks/migrate
+
 #
 # Apache related
 #


### PR DESCRIPTION
This runs database migrations during post-install. Note, it always tries
to move forward (even though migrations support going backwards with
the "down" option). If a package is either upgraded or downgraded then
the migration runs. We don't explicitly support downgrading packages
currently so I believe this is OK even if not ideal.