### PR TITLE
Use an HTTP mirror for libcurl-hub.

### DIFF
--- a/deps-packaging/libcurl-hub/source
+++ b/deps-packaging/libcurl-hub/source
@@ -1,1 +1,1 @@
-https://curl.haxx.se/download/
+http://dl.uxnr.de/mirror/curl/


### PR DESCRIPTION
Just like we do for libcurl. RHEL4, RHEL5 are giving TLS errors for the
HTTPS upstream repository.