### PR TITLE
ENT-3205: Purge previous versions htdocs on upgrade

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -197,15 +197,17 @@ if [ -d $PREFIX/httpd/htdocs ]; then
   cf_console echo "A previous version of CFEngine Mission Portal was found,"
   cf_console echo "creating a backup of it at /tmp/cfengine-htdocs.tar.gz"
   tar zcf /tmp/cfengine-htdocs.tar.gz $PREFIX/httpd/htdocs
+fi
 
   cf_console echo "Purging old version from $PREFIX/httpd/htdocs"
   # We preserve the tmp directory as it may contain scheduled or exported
   # reports. We preserve cf_robot.php because it is generated
   find "$PREFIX/httpd/htdocs" -not \( -path "$PREFIX/httpd/htdocs/tmp" -prune \) -not \( -name "cf_robot.php" \) -type f -print0 | xargs -0 rm
+  # Hack around ENT-3205
+  if [ -e "$PREFIX/share/GUI/system/libraries/Session.php" ]; then
+    rm "$PREFIX/share/GUI/system/libraries/Session.php"
+  fi
 
-fi
-
-#
 # Make a backup of the key CFE_CLIENT_SECRET_KEY, if any, and restore the
 # original file content.
 #

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -197,6 +197,12 @@ if [ -d $PREFIX/httpd/htdocs ]; then
   cf_console echo "A previous version of CFEngine Mission Portal was found,"
   cf_console echo "creating a backup of it at /tmp/cfengine-htdocs.tar.gz"
   tar zcf /tmp/cfengine-htdocs.tar.gz $PREFIX/httpd/htdocs
+
+  cf_console echo "Purging old version from $PREFIX/httpd/htdocs"
+  # We preserve the tmp directory as it may contain scheduled or exported
+  # reports. We preserve cf_robot.php because it is generated
+  find "$PREFIX/httpd/htdocs" -not \( -path "$PREFIX/httpd/htdocs/tmp" -prune \) -not \( -name "cf_robot.php" \) -type f -print0 | xargs -0 rm
+
 fi
 
 #


### PR DESCRIPTION
Take care to not purge the generated cf_robot.php and tmp which may
contain reports.