### PR TITLE
ENT-3205: Purge previous versions htdocs on upgrade

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -197,6 +197,12 @@ if [ -d $PREFIX/httpd/htdocs ]; then
   cf_console echo "A previous version of CFEngine Mission Portal was found,"
   cf_console echo "creating a backup of it at /tmp/cfengine-htdocs.tar.gz"
   tar zcf /tmp/cfengine-htdocs.tar.gz $PREFIX/httpd/htdocs
+
+  cf_console echo "Purging old version from $PREFIX/httpd/htdocs"
+  # We preserve the tmp directory as it may contain scheduled or exported
+  # reports. We preserve cf_robot.php because it is generated
+  find "$PREFIX/httpd/htdocs" -not \( -path "$PREFIX/httpd/htdocs/tmp" -prune \) -not \( -name "cf_robot.php" \) -type f -print | xargs rm
+
 fi
 
 #


### PR DESCRIPTION
Take care to not purge the generated cf_robot.php and tmp which may
contain reports.

(cherry picked from commit 7406f93c9987f82df871e04b3c194a5385b55449)