### PR TITLE
ENT-3205, ENT-3218: Warn that RPM hub package upgrade is unsupported

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -4,6 +4,14 @@ if [ -x /bin/systemctl ]; then
   /bin/systemctl daemon-reload
 fi
 
+if is_upgrade
+then
+    cf_console echo  \
+        'WARNING: attempted hub upgrade detected;'                      \
+        'this is UNSUPPORTED and might not work, you are on your own!'  \
+        '(relevant tickets: ENT-3205, ENT-3218)'
+fi
+
 #
 # Make sure the cfapache user has a home folder and populate it
 #


### PR DESCRIPTION
After package upgrade a bunch of old and new files are mixed up in
htdocs directory, for example old and new Code Igniter versions coexist.
Unfortunately it's not trivial to just delete the old files, because
they are manually copied after package installation, and workarounds are
messy because of the mess the hub package currently is (see ENT-3218).