### PR TITLE
unshallow repos

### DIFF
--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -2,7 +2,17 @@
 
 set -ex
 for i in core nova enterprise mission-portal masterfiles design-center; do
-	test -d $i || git clone git@github.com:cfengine/$i.git
+	if [ -d $i ]; then
+		# Repo already checked out. Probably by Travis.
+		# Travis checks out only one branch, what confuses `determine-version.py`.
+		# To fix it, we need to perform "unshallow" operation.
+		# But we do it only for "core" and those repos where
+		# ./3rdparty/core/determine-version.py file exists.
+		# (Other repos are not checked for versions, we assume).
+		[ "$i" = "core" -o -f $i/3rdparty/core/determine-version.py ] && (cd $i && git fetch --unshallow)
+	else
+		git clone git@github.com:cfengine/$i.git
+	fi
 done
 
 # packages needed for autogen


### PR DESCRIPTION
Travis checks out with `--depth` parameter[1], which implies
`--single-branch`[2]. This confuses determine-version.py script, so we
need to convert the repo to normal one.

[1]: https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth

[2]: https://git-scm.com/docs/git-clone#git-clone---depthltdepthgt