### PR TITLE
ENT-3325: Fix split service enablement on older versions of systemd

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -542,16 +542,16 @@ if ! is_upgrade; then
     # Reload systemd config to pick up newly installed units
     /bin/systemctl daemon-reload > /dev/null 2>&1
     # Enable service units
-    /bin/systemctl enable cf-apache > /dev/null 2>&1
-    /bin/systemctl enable cf-execd > /dev/null 2>&1
-    /bin/systemctl enable cf-serverd > /dev/null 2>&1
-    /bin/systemctl enable cf-runalerts > /dev/null 2>&1
-    /bin/systemctl enable cf-consumer > /dev/null 2>&1
-    /bin/systemctl enable cf-monitord > /dev/null 2>&1
-    /bin/systemctl enable cf-postgres > /dev/null 2>&1
-    /bin/systemctl enable cf-redis-server > /dev/null 2>&1
-    /bin/systemctl enable cf-hub > /dev/null 2>&1
-    /bin/systemctl enable cfengine3 > /dev/null 2>&1
+    /bin/systemctl enable cf-apache.service > /dev/null 2>&1
+    /bin/systemctl enable cf-execd.service > /dev/null 2>&1
+    /bin/systemctl enable cf-serverd.service > /dev/null 2>&1
+    /bin/systemctl enable cf-runalerts.service > /dev/null 2>&1
+    /bin/systemctl enable cf-consumer.service > /dev/null 2>&1
+    /bin/systemctl enable cf-monitord.service > /dev/null 2>&1
+    /bin/systemctl enable cf-postgres.service > /dev/null 2>&1
+    /bin/systemctl enable cf-redis-server.service > /dev/null 2>&1
+    /bin/systemctl enable cf-hub.service > /dev/null 2>&1
+    /bin/systemctl enable cfengine3.service > /dev/null 2>&1
   else
     case "`os_type`" in
       redhat)

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -92,7 +92,7 @@ if is_upgrade; then
     # stop due to the command above, the web part may only do so after some
     # delay, which may cause problems in an upgrade situation, since this script
     # will immediately check whether the ports are in use.
-    /bin/systemctl stop cfengine3-web
+    /bin/systemctl stop cfengine3-web.service
   fi
 fi
 
@@ -100,7 +100,7 @@ fi
 if is_upgrade; then
   if [ -e /usr/lib/systemd/system/cfengine3-web.service ]; then
     # It's functionality is replaced with multiple units.
-    /bin/systemctl disable cfengine3-web
+    /bin/systemctl disable cfengine3-web.service
   fi
 fi
 

--- a/packaging/common/cfengine-hub/preremove.sh
+++ b/packaging/common/cfengine-hub/preremove.sh
@@ -4,7 +4,7 @@ if [ -x /bin/systemctl ]; then
   # stop due to the command above, the web part may only do so after some
   # delay, which may cause problems later if the binaries are gone by the time
   # it tries to stop them.
-  /bin/systemctl stop cfengine3-web
+  /bin/systemctl stop cfengine3-web.service
 fi
 
 case "`os_type`" in

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -80,10 +80,10 @@ case `os_type` in
       # Reload systemd config to pick up newly installed units
       /bin/systemctl daemon-reload > /dev/null 2>&1
       # Enable service units
-      /bin/systemctl enable cf-execd > /dev/null 2>&1
-      /bin/systemctl enable cf-serverd > /dev/null 2>&1
-      /bin/systemctl enable cf-monitord > /dev/null 2>&1
-      /bin/systemctl enable cfengine3 > /dev/null 2>&1
+      /bin/systemctl enable cf-execd.service > /dev/null 2>&1
+      /bin/systemctl enable cf-serverd.service > /dev/null 2>&1
+      /bin/systemctl enable cf-monitord.service > /dev/null 2>&1
+      /bin/systemctl enable cfengine3.service > /dev/null 2>&1
     else
       case `os_type` in
         redhat)

--- a/packaging/common/cfengine-non-hub/preremove.sh
+++ b/packaging/common/cfengine-non-hub/preremove.sh
@@ -10,7 +10,7 @@ case `os_type` in
     #
     # systemd support
     #
-    test -x /bin/systemctl && systemctl disable cfengine3 > /dev/null 2>&1
+    test -x /bin/systemctl && systemctl disable cfengine3.service > /dev/null 2>&1
 
     #
     # Clean lock files created by initscript, if any

--- a/packaging/common/script-templates/deb-script-common.sh
+++ b/packaging/common/script-templates/deb-script-common.sh
@@ -20,7 +20,7 @@ rc_d_path()
 platform_service()
 {
   if [ -x /bin/systemctl ]; then
-    /bin/systemctl "$2" "$1"
+    /bin/systemctl "$2" "$1".service
   else
     /etc/init.d/"$1" "$2"
   fi

--- a/packaging/common/script-templates/rpm-script-common.sh
+++ b/packaging/common/script-templates/rpm-script-common.sh
@@ -28,7 +28,7 @@ rc_d_path()
 platform_service()
 {
   if [ -x /bin/systemctl ]; then
-    /bin/systemctl "$2" "$1"
+    /bin/systemctl "$2" "$1".service
   else
     /etc/init.d/"$1" "$2"
   fi


### PR DESCRIPTION
Older versions of systemd require the unit suffix to be provided when enabling
services. This change better supports older versions (like those from wheezy
backports).

Changelog: Title