### PR TITLE
Make travis build script compatible both with Precise and Trusty

### DIFF
--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -39,8 +39,8 @@ NO_CONFIGURE=1 PROJECT=nova ./buildscripts/build-scripts/autogen
 
 # packages needed for building
 sudo apt-get install bison flex binutils build-essential fakeroot ntp dpkg-dev libpam0g-dev python debhelper pkg-config psmisc nfs-common
-# without this line, next one sometimes fails
-sudo apt-get purge emacs emacs24
+# On Ubuntu Trusty, we need to remove these packages - otherwise apt fails miserably on next line
+[ "$(lsb_release --release --short)" == "14.04" ] && sudo apt-get purge emacs emacs24
 # remove unwanted dependencies
 sudo apt-get purge libltdl-dev libltdl7 libtool
 


### PR DESCRIPTION
We need to uninstall emacs* packages on Trusty (otherwise next apt-get command fails), but should not do it on Precise ('cause there is no such package)