### PR TITLE
ENT-3284: Run ldap migration script in postinstall.sh

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -523,6 +523,7 @@ $PREFIX/httpd/bin/apachectl start
 #
 CFE_ROBOT_PWD=$(dd if=/dev/urandom bs=1024 count=1 2>/dev/null | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 $PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php cli_tasks create_cfe_robot_user $CFE_ROBOT_PWD
+$PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php cli_tasks migrate_ldap_settings https://localhost/ldap
 
 # Shut down Apache and Postgres again, because we may need them to start through
 # systemd later.


### PR DESCRIPTION
Signed-off-by: Aleksei Shpakovskii <aleksei.shpakovskii@cfengine.com>