### PR TITLE
ENT-3391: Set default memory_limit for php to 256M

### DIFF
--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -138,6 +138,9 @@ cp %{_builddir}/php-%{php_version}/php.ini-production ${RPM_BUILD_ROOT}%{prefix}
 # Reduce information leakage by default
 sed -ri 's/^\s*expose_php\s*=.*/expose_php = Off/g' ${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/php.ini
 
+# Increase the php memory limit so that Mission Portal works with larger infrastructures without modification
+sed -ri 's/^\s*memory_limit\s*=.*/memory_limit = 256M/g' ${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/php.ini
+
 echo "extension=curl.so" >> ${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/curl.ini
 echo "extension=mcrypt.so" >> ${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/mcrypt.ini
 echo "extension=openssl.so" >>${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/openssl.ini

--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -130,8 +130,11 @@ install: build
 
 	cp $(CURDIR)/php.ini-production $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/php.ini
 
-	# Reduce information leakage by default
+  # Reduce information leakage by default
 	sed -ri 's/^\s*expose_php\s*=.*/expose_php = Off/g' $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/php.ini
+
+  # Increase the php memory limit so that Mission Portal works with larger infrastructures without modification
+  sed -ri 's/^\s*memory_limit\s*=.*/memory_limit = 256M/g' $(CURDIR)debian/tmp$(PREFIX)/httpd/php/lib/php.ini
 
 	echo "extension=curl.so" >> $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/curl.ini
 	echo "extension=mcrypt.so" >> $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/mcrypt.ini


### PR DESCRIPTION
This change increases the default memory_limit for php so that Mission Portal
works better with larger environments without altering default configuration.

Changelog: Title
(cherry picked from commit 7d103c97595a0fb02fb196d5979fe89b59228f2c)