### PR TITLE
Fix errors about undeclared curl_off_t on AIX and HP-UX.

### DIFF
--- a/deps-packaging/libcurl/cfbuild-libcurl.spec
+++ b/deps-packaging/libcurl/cfbuild-libcurl.spec
@@ -16,6 +16,9 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n curl-7.54.1
 
+# AIX is broken without this
+$PATCH   -i $BASEDIR/buildscripts/deps-packaging/libcurl/curl_off_t.diff   include/curl/system.h
+
 ./configure \
     --with-sysroot=%{prefix} \
     --with-ssl=%{prefix} \

--- a/deps-packaging/libcurl/curl_off_t.diff
+++ b/deps-packaging/libcurl/curl_off_t.diff
@@ -1,0 +1,5 @@
+351c351,352
+<    (defined(__SIZEOF_LONG__) && __SIZEOF_LONG__ == 4))
+---
+>    (defined(__SIZEOF_LONG__) && __SIZEOF_LONG__ == 4) ||                \
+>    (defined(SIZEOF_LONG) && SIZEOF_LONG == 4))

--- a/deps-packaging/libcurl/hpux/build
+++ b/deps-packaging/libcurl/hpux/build
@@ -9,6 +9,9 @@ TTD=${BUILD_ROOT}/cfbuild-libcurl-devel${PREFIX}
 
 # Build
 
+# HP-UX is broken without this
+$PATCH   -i $BASEDIR/buildscripts/deps-packaging/libcurl/curl_off_t.diff   include/curl/system.h
+
 ./configure --prefix=$PREFIX \
     --with-sysroot=$PREFIX \
     --with-ssl=$PREFIX \


### PR DESCRIPTION
This patch has been submitted upstream:
https://github.com/curl/curl/pull/2186

The format of the patch file is very basic, because AIX patch(1) does not work
with neither git diffs, context diffs, nor unified diffs.