### PR TITLE
ENT-3531: Set proper permissions for php binary in hub package

### DIFF
--- a/packaging/cfengine-nova-hub/debian/rules
+++ b/packaging/cfengine-nova-hub/debian/rules
@@ -90,7 +90,8 @@ install: build
 	chmod 600 $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/phpcfenginenova/migrations/*.sql
 	chmod 600 $(CURDIR)/debian/tmp$(PREFIX)/share/db/*.sql
 
-
+# ENT-3531
+  chmod 755 $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/bin/php
 
 binary-indep: build install
 


### PR DESCRIPTION
This was world writeable causing security alerts and preventing cf-agent
from executing the command as desired.

   error: SECURITY ALERT: promised executable
'/var/cfengine/httpd/php/bin/php' is world writable!
   error: SECURITY ALERT: CFEngine will not execute this - requires
human inspection