### PR TITLE
ENT-2746: Tighten postgres socket permissions

### DIFF
--- a/deps-packaging/postgresql-hub/postgresql.conf.cfengine
+++ b/deps-packaging/postgresql-hub/postgresql.conf.cfengine
@@ -68,7 +68,7 @@ max_connections = 300			# (change requires restart)
 #unix_socket_directories = '/tmp'	# comma-separated list of directories
 					# (change requires restart)
 #unix_socket_group = ''			# (change requires restart)
-#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+unix_socket_permissions = 0770		# begin with 0 to use octal notation
 					# (change requires restart)
 #bonjour = off				# advertise server via Bonjour
 					# (change requires restart)

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -132,15 +132,22 @@ then
   fi
 fi
 #
-# We need a cfapache user for our web server
+# We need a cfapache user and group for our web server
 #
 /usr/bin/getent passwd cfapache >/dev/null || /usr/sbin/useradd -M -r cfapache
 /usr/bin/getent group cfapache >/dev/null || /usr/sbin/groupadd -r cfapache
 
 #
-# We check if there is a postgres user already, otherwise we create one
+# We make sure there is a cfpostgres user and group
 #
 /usr/bin/getent passwd cfpostgres >/dev/null || /usr/sbin/useradd -M -r cfpostgres
+/usr/bin/getent group cfpostgres >/dev/null || /usr/sbin/groupadd -r cfpostgres
+
+#
+# We make sure that the cfapache user is part of the cfpostgres group so that
+# the webserver can read from the socket ENT-2746
+#
+getent group cfpostgres && /bin/gpasswd --add cfapache cfpostgres
 
 #
 # Backup htdocs

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -147,7 +147,7 @@ fi
 # We make sure that the cfapache user is part of the cfpostgres group so that
 # the webserver can read from the socket ENT-2746
 #
-getent group cfpostgres && /bin/gpasswd --add cfapache cfpostgres
+getent group cfpostgres && gpasswd --add cfapache cfpostgres
 
 #
 # Backup htdocs


### PR DESCRIPTION
Now the postgres socket permissions are only accessible by cfapache, cfpostgres, and root.

Changelog: Title
(cherry picked from commit 06b5a70c214007820b4c3b6821fd628c55b20b2c)