### PR TITLE
Increase the level of parallelism to 2 * NUM_CPUS

### DIFF
--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -328,7 +328,7 @@ detect_cores()
 
   # Make number of jobs one higher than core count, to account for I/O, network, etc.
   echo "Detected amount of CPU cores is $NUM_CORES"
-  MAKEFLAGS="${MAKEFLAGS:--j$(($NUM_CORES + 1))}"
+  MAKEFLAGS="${MAKEFLAGS:--j$((2 * $NUM_CORES + 1))}"
   export MAKEFLAGS
 }
 

--- a/build-scripts/install-dependencies
+++ b/build-scripts/install-dependencies
@@ -163,3 +163,6 @@ do
     # keep 50 most recent packages to preserve disk space
     pkg-cache keep_newest 50
 done
+
+# stop pretending we only have one CPU now that deps are built
+unset MAKEFLAGS


### PR DESCRIPTION
All our operations are IO-bound so having twice the number of
jobs as CPUs is not a problem. The rare cases (if there are even
any) where this makes things slightly slower due to
process/context switching are well worth the extra speed.

Also make sure a temporary value for the MAKEFLAGS variable is
really temporary.