### PR TITLE
ENT-3685: Include libwinpthread-1.dll to windows packages

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.wxs
+++ b/packaging/cfengine-nova/cfengine-nova.wxs
@@ -162,6 +162,7 @@
             <ComponentRef Id='pthreadGC2.dll' />
             <ComponentRef Id='libcrypto_1_1_x64.dll' />
             <ComponentRef Id='libssl_1_1_x64.dll' />
+            <ComponentRef Id='libwinpthread_1.dll' />
             <ComponentRef Id='libgnurx_0.dll' />
             <ComponentRef Id='liblmdb.dll' />
             <ComponentRef Id='libyaml_0_2.dll' />


### PR DESCRIPTION
It is required by our utilities.