### PR TITLE
ENT-3691 fixup apt-get purge to not glob on locally downloaded pgtap …

### DIFF
--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -24,7 +24,7 @@ test -z "$ARTIFACTS_KEY" -o -z "$ARTIFACTS_SECRET" -o -z "$GITHUB_STATUS_TOKEN" 
 set -x
 
 # remove unwanted packages
-sudo apt-get purge apache* postgresql* redis*
+sudo apt-get purge apache* "postgresql*" redis*
 # On Travis, hostname can be ridiculously long - let's truncate it
 sudo hostname localhost
 


### PR DESCRIPTION
…package name causing failure