### PR TITLE
ENT-3726: Remove cf-consumer from packaging/buildscripts

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -108,7 +108,6 @@ rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 %defattr(644,root,root,755)
 /usr/lib/systemd/system/cfengine3.service
 /usr/lib/systemd/system/cf-apache.service
-/usr/lib/systemd/system/cf-consumer.service
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-hub.service
 /usr/lib/systemd/system/cf-monitord.service

--- a/packaging/cfengine-community/debian/cfengine-community.install
+++ b/packaging/cfengine-community/debian/cfengine-community.install
@@ -1,7 +1,6 @@
 /etc/init.d/cfengine3
 /usr/lib/systemd/system/cfengine3.service
 /usr/lib/systemd/system/cf-apache.service
-/usr/lib/systemd/system/cf-consumer.service
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-hub.service
 /usr/lib/systemd/system/cf-monitord.service

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -161,7 +161,6 @@ exit 0
 %prefix/bin/cf-serverd
 # Nova-only binaries
 %prefix/bin/cf-hub
-%prefix/bin/cf-consumer
 %prefix/bin/runalerts.php
 #rsync
 %prefix/bin/rsync
@@ -252,7 +251,6 @@ exit 0
 %defattr(644,root,root,755)
 /usr/lib/systemd/system/cfengine3.service
 /usr/lib/systemd/system/cf-apache.service
-/usr/lib/systemd/system/cf-consumer.service
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-hub.service
 /usr/lib/systemd/system/cf-monitord.service

--- a/packaging/cfengine-nova-hub/debian/cfengine-nova-hub.install
+++ b/packaging/cfengine-nova-hub/debian/cfengine-nova-hub.install
@@ -3,7 +3,6 @@
 /etc/profile.d
 /usr/lib/systemd/system/cfengine3.service
 /usr/lib/systemd/system/cf-apache.service
-/usr/lib/systemd/system/cf-consumer.service
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-hub.service
 /usr/lib/systemd/system/cf-monitord.service
@@ -19,7 +18,6 @@
 /var/cfengine/bin/cf-promises
 /var/cfengine/bin/cf-runagent
 /var/cfengine/bin/cf-serverd
-/var/cfengine/bin/cf-consumer
 /var/cfengine/bin/runalerts.php
 /var/cfengine/bin/rsync
 /var/cfengine/bin/cfengine3-nova-hub-init-d.sh

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -108,7 +108,6 @@ exit 0
 %defattr(644,root,root,755)
 /usr/lib/systemd/system/cfengine3.service
 /usr/lib/systemd/system/cf-apache.service
-/usr/lib/systemd/system/cf-consumer.service
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-hub.service
 /usr/lib/systemd/system/cf-monitord.service

--- a/packaging/cfengine-nova/debian/cfengine-nova.install
+++ b/packaging/cfengine-nova/debian/cfengine-nova.install
@@ -3,7 +3,6 @@
 /etc/profile.d
 /usr/lib/systemd/system/cfengine3.service
 /usr/lib/systemd/system/cf-apache.service
-/usr/lib/systemd/system/cf-consumer.service
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-hub.service
 /usr/lib/systemd/system/cf-monitord.service

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -555,7 +555,6 @@ if ! is_upgrade; then
     /bin/systemctl enable cf-execd.service > /dev/null 2>&1
     /bin/systemctl enable cf-serverd.service > /dev/null 2>&1
     /bin/systemctl enable cf-runalerts.service > /dev/null 2>&1
-    /bin/systemctl enable cf-consumer.service > /dev/null 2>&1
     /bin/systemctl enable cf-monitord.service > /dev/null 2>&1
     /bin/systemctl enable cf-postgres.service > /dev/null 2>&1
     /bin/systemctl enable cf-redis-server.service > /dev/null 2>&1


### PR DESCRIPTION
Merge together:
https://github.com/cfengine/core/pull/3086
https://github.com/cfengine/nova/pull/1152
https://github.com/cfengine/buildscripts/pull/359