### PR TITLE
ENT-3761: update to php 7.2.5 and fix rhel 5 compilation issue

### DIFF
--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -19,6 +19,13 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n php-%{php_version}
 
+# really we should maybe check gcc version and if somewhere around 4.1.2 (or <4.3) use this patch.
+# I just check for redhat 5 since this is a hub-related package only.
+if expr "`cat /etc/redhat-release`" : '.* [5]\.'
+then
+  patch -p0 < old-gcc-isfinite.patch
+fi
+
 ./configure --prefix=%{prefix}/httpd/php \
 --with-apxs2=%{prefix}/httpd/bin/apxs \
 --with-config-file=%{prefix}/httpd/php \

--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -1,4 +1,4 @@
-%define php_version 7.2.0
+%define php_version 7.2.5
 
 Summary: CFEngine Build Automation -- php
 Name: cfbuild-php

--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -23,7 +23,7 @@ mkdir -p %{_builddir}
 # I just check for redhat 5 since this is a hub-related package only.
 if expr "`cat /etc/redhat-release`" : '.* [5]\.'
 then
-  patch -p0 < old-gcc-isfinite.patch
+  patch -p0 < %{_topdir}/SOURCES/old-gcc-isfinite.patch
 fi
 
 ./configure --prefix=%{prefix}/httpd/php \

--- a/deps-packaging/php/distfiles
+++ b/deps-packaging/php/distfiles
@@ -1,1 +1,1 @@
-cd35bdf6364a44e1383e3cad57c4cf54  php-7.2.0.tar.gz
+e9bede5ea2cbb2e3a2581d38316c9356    php-7.2.5.tar.gz

--- a/deps-packaging/php/old-gcc-isfinite.patch
+++ b/deps-packaging/php/old-gcc-isfinite.patch
@@ -1,0 +1,29 @@
+--- configure.old	2018-04-24 10:10:05.000000000 -0500
++++ configure	2018-04-26 15:25:46.615652210 -0500
+@@ -94908,7 +94908,7 @@
+ ac_fn_c_check_decl "$LINENO" "isfinite" "ac_cv_have_decl_isfinite" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isfinite" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+@@ -94919,7 +94919,7 @@
+ ac_fn_c_check_decl "$LINENO" "isnan" "ac_cv_have_decl_isnan" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isnan" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+@@ -94930,7 +94930,7 @@
+ ac_fn_c_check_decl "$LINENO" "isinf" "ac_cv_have_decl_isinf" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isinf" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi


### PR DESCRIPTION
Sorry to include both in one... we can split of course.

Hopefully 7.2.0->7.2.5 doesn't cause any trouble for anything else. :crossed_fingers: Shouldn't be a problem hopefully since we are in the 7.2.x range.

