### PR TITLE
ENT-3761: Upgrade php 7.2.5 and fix rhel5 php problems

### DIFF
--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -1,4 +1,4 @@
-%define php_version 7.2.0
+%define php_version 7.2.5
 
 Summary: CFEngine Build Automation -- php
 Name: cfbuild-php
@@ -18,6 +18,12 @@ AutoReqProv: no
 %prep
 mkdir -p %{_builddir}
 %setup -q -n php-%{php_version}
+
+# this patch should probably be applied to older versions of gcc but for now depend on redhat version. 
+if expr "`cat /etc/redhat-release`" : '.* [5]\.'
+then
+  patch -p0 < %{_topdir}/SOURCES/old-gcc-isfinite.patch
+fi
 
 ./configure --prefix=%{prefix}/httpd/php \
 --with-apxs2=%{prefix}/httpd/bin/apxs \

--- a/deps-packaging/php/distfiles
+++ b/deps-packaging/php/distfiles
@@ -1,1 +1,1 @@
-cd35bdf6364a44e1383e3cad57c4cf54  php-7.2.0.tar.gz
+e9bede5ea2cbb2e3a2581d38316c9356    php-7.2.5.tar.gz

--- a/deps-packaging/php/old-gcc-isfinite.patch
+++ b/deps-packaging/php/old-gcc-isfinite.patch
@@ -1,0 +1,30 @@
+--- configure.old	2018-04-24 10:10:05.000000000 -0500
++++ configure	2018-04-26 15:25:46.615652210 -0500
+@@ -94908,7 +94908,7 @@
+ ac_fn_c_check_decl "$LINENO" "isfinite" "ac_cv_have_decl_isfinite" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isfinite" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+@@ -94919,7 +94919,7 @@
+ ac_fn_c_check_decl "$LINENO" "isnan" "ac_cv_have_decl_isnan" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isnan" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+@@ -94930,7 +94930,7 @@
+ ac_fn_c_check_decl "$LINENO" "isinf" "ac_cv_have_decl_isinf" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isinf" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+


### PR DESCRIPTION
option #2, upgrade php and fix rhel5 build problem for php