### PR TITLE
ENT-3761: Fix php build for rhel5 due to isfinite reference

### DIFF
--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -19,6 +19,11 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n php-%{php_version}
 
+if expr "`cat /etc/redhat-release`" : '.* [5]\.'
+then
+  patch -p0 < %{_topdir}/SOURCES/old-gcc-isfinite.patch
+fi
+
 ./configure --prefix=%{prefix}/httpd/php \
 --with-apxs2=%{prefix}/httpd/bin/apxs \
 --with-config-file=%{prefix}/httpd/php \

--- a/deps-packaging/php/old-gcc-isfinite.patch
+++ b/deps-packaging/php/old-gcc-isfinite.patch
@@ -1,0 +1,30 @@
+--- configure.old	2018-04-24 10:10:05.000000000 -0500
++++ configure	2018-04-26 15:25:46.615652210 -0500
+@@ -94908,7 +94908,7 @@
+ ac_fn_c_check_decl "$LINENO" "isfinite" "ac_cv_have_decl_isfinite" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isfinite" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+@@ -94919,7 +94919,7 @@
+ ac_fn_c_check_decl "$LINENO" "isnan" "ac_cv_have_decl_isnan" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isnan" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+@@ -94930,7 +94930,7 @@
+ ac_fn_c_check_decl "$LINENO" "isinf" "ac_cv_have_decl_isinf" "#include <math.h>
+ "
+ if test "x$ac_cv_have_decl_isinf" = xyes; then :
+-  ac_have_decl=1
++  ac_have_decl=0
+ else
+   ac_have_decl=0
+ fi
+


### PR DESCRIPTION
@vpodzime moved patch to proper location
@Lex-2008 skipped the upgrade to make this commit and our lives a bit more certain
will start a pr-pipeline build on rhel5 for hub now.