### PR TITLE
ENT-3835 Treat php.ini as a config file by pacakge

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -305,6 +305,7 @@ exit 0
 %prefix/httpd/modules
 %prefix/httpd/php/lib
 %prefix/httpd/php/php
+%config(noreplace) %prefix/httpd/php/lib/php.ini
 
 %defattr(755,root,root,755)
 %prefix/httpd/php/bin


### PR DESCRIPTION
This ensures that if a user modifies php.ini locally, their changes will be preserved when they upgrade the package.

Changelog: Title