### PR TITLE
INF-402: exclude from copying file which can't be copied

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -303,6 +303,13 @@ generate_chroot_transfer_script()
 {
   # These rules are processed in a "first that matches" fashion.
 
+  # This should go before 'Cross platform', in order not to be overwritten by
+  # '+ /etc' rule below
+  if [ "$OS_FAMILY" = solaris ]
+  then
+    echo '- /etc/svc/volatile/.inetd.uds'
+  fi
+
   ############# Cross platform #############
   cat <<EOF
 - */proc


### PR DESCRIPTION
failure, for example, in https://ci.cfengine.com/job/testing-enterprise-3.12.x/8/label=PACKAGES_sparc64_solaris_10/console:

```
00:25:19.609 rsync: mknod "/home/jenkins/testmachine-chroot/etc/svc/volatile/.inetd.uds" failed: Not owner (1)
00:25:19.639 skipping non-regular file "etc/svc/volatile/repository_door"
00:25:19.639 skipping non-regular file "etc/svc/volatile/zonestat_door"
00:25:19.639 skipping non-regular file "etc/svc/volatile/netcfg/netcfgd_door"
00:27:17.020 rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1052) [sender=3.0.8]
00:27:17.054 + ret=23
00:27:17.054 + [ -f /home/jenkins/stop_slave ]
00:27:17.054 + exit 23
```