### PR TITLE
Use proper gitconfig and gitattributes file paths when building git

### DIFF
--- a/deps-packaging/git/cfbuild-git.spec
+++ b/deps-packaging/git/cfbuild-git.spec
@@ -18,7 +18,7 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n git-%{git_version}
 
-./configure --prefix=%{prefix} --with-openssl=%{prefix} --without-iconv --with-gitconfig=%{prefix} --with-gitattributes=%{prefix} --with-zlib=%{prefix} --with-curl=%{prefix}  --libexecdir=%{prefix}/lib
+./configure --prefix=%{prefix} --with-openssl=%{prefix} --without-iconv --with-gitconfig=%{prefix}/config/gitconfig --with-gitattributes=%{prefix}/config/gitattributes --with-zlib=%{prefix} --with-curl=%{prefix}  --libexecdir=%{prefix}/lib
 
 %build
 

--- a/deps-packaging/git/debian/rules
+++ b/deps-packaging/git/debian/rules
@@ -12,7 +12,7 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
-	./configure --prefix=$(PREFIX) --with-openssl=$(PREFIX) --without-iconv --with-gitconfig=$(PREFIX) --with-gitattributes=$(PREFIX) --with-zlib=$(PREFIX) --with-curl=$(PREFIX) --libexecdir=$(PREFIX)/lib
+	./configure --prefix=$(PREFIX) --with-openssl=$(PREFIX) --without-iconv --with-gitconfig=$(PREFIX)/config/gitconfig --with-gitattributes=$(PREFIX)/config/gitattributes --with-zlib=$(PREFIX) --with-curl=$(PREFIX) --libexecdir=$(PREFIX)/lib
 	make
 
 	touch build-stamp


### PR DESCRIPTION
These two ./configure options are:

  --with-gitconfig=VALUE  Use VALUE instead of /etc/gitconfig as the global
                          git configuration file. If VALUE is not fully
                          qualified it will be interpreted as a path relative
                          to the computed prefix at runtime.

  --with-gitattributes=VALUE
                          Use VALUE instead of /etc/gitattributes as the
                          global git attributes file. If VALUE is not fully
                          qualified it will be interpreted as a path relative
                          to the computed prefix at runtime.

so they should be file paths, not directories. New versions of
git are sensitive to this difference.

Ticket: ENT-3818
(cherry picked from commit 25113aaffad41253f64fec64a9162f82863cfc1d)