### PR TITLE
ENT-3898: Move old shared/GUI files aside during upgrade

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -83,6 +83,15 @@ sed -i s/LDAP_API_SECRET_KEY/"$UUID"/ $PREFIX/share/GUI/ldap/config/settings.php
 sed -i /LDAP_API_SECRET_KEY/s/\'\'/"'$UUID'"/ $PREFIX/share/GUI/api/config/config.php
 
 cp -r $PREFIX/share/GUI/* $PREFIX/httpd/htdocs
+
+# If old files were moved aside during upgrade, we should move them back so that
+# rpm can do its cleanup procedures. But avoid overwriting new files with the
+# old ones (hence cp -n).
+if [ -d $PREFIX/share/GUI_old ]; then
+    cp -rn $PREFIX/share/GUI_old/* $PREFIX/share/GUI/
+    rm -rf $PREFIX/share/GUI_old/
+fi
+
 mkdir -p $PREFIX/httpd/htdocs/tmp
 mv $PREFIX/httpd/htdocs/Apache-htaccess $PREFIX/httpd/htdocs/.htaccess
 chmod 755 $PREFIX/httpd

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -201,6 +201,11 @@ if [ -d $PREFIX/httpd/htdocs ]; then
       # Make list of files in share/GUI and remove "them" from httpd/htdocs
       find -type f -print0 | ( cd ../../httpd/htdocs/ && xargs -0 rm )
     )
+    # Make sure old files are not copied over together with new files later
+    # (this only happens during upgrade of RPMs)
+    if [ "x${PKG_TYPE}" = "xrpm" ]; then
+        mv $PREFIX/share/GUI $PREFIX/share/GUI_old
+    fi
   else
     # Purge all files in httpd/htdocs with exceptions:
     # Preserve the tmp directory as it may contain scheduled or exported reports.


### PR DESCRIPTION
Otherwise they may end up being copied over to htdocs together
with the new files because the postinstall.sh script is run when
*both* the old package and the new package are installed.

(cherry picked from commit d10682132702d032f4c4d0987234c6732357611a)