### PR TITLE
ENT-3921: Make runalerts.php executable.

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -748,6 +748,11 @@ $PREFIX/httpd/bin/apachectl stop
 #
 rm -f $PREFIX/CF_CLIENT_SECRET_KEY.tmp
 
+##
+# ENT-3921: Make bin/runalerts.php executable
+#
+chmod 755 $PREFIX/bin/runalerts.php
+
 #
 # Register CFEngine initscript, if not yet.
 #


### PR DESCRIPTION
Because cf-runalerts.service executes this script.