### PR TITLE
ENT-3921: Make runalerts.php executable.

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -524,6 +524,11 @@ $PREFIX/httpd/bin/apachectl stop
 #
 rm -f $PREFIX/CF_CLIENT_SECRET_KEY.tmp
 
+##
+# ENT-3921: Make bin/runalerts.php executable
+#
+chmod 755 $PREFIX/bin/runalerts.php
+
 #
 # Register CFEngine initscript, if not yet.
 #


### PR DESCRIPTION
Because cf-runalerts.service executes this script.

(cherry picked from commit f999f8dfab5bd8a0cbb4bd7f870ae56a2e9ab624)