### PR TITLE
Disable Solaris 9 builds on master

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -14,7 +14,6 @@ PACKAGES_ia64_hpux_11.23
 PACKAGES_ppc64_aix_53
 PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
-PACKAGES_sparc64_solaris_9
 PACKAGES_x86_64_linux_debian_4
 PACKAGES_x86_64_linux_debian_7
 PACKAGES_x86_64_linux_redhat_4


### PR DESCRIPTION
Solaris 9 is not a supported system for future releases.