### PR TITLE
lmdb: Do not put functions into a separate text section on PPC64

### DIFF
--- a/deps-packaging/lmdb/0007-Do-not-put-functions-into-a-separate-text-section-on.patch
+++ b/deps-packaging/lmdb/0007-Do-not-put-functions-into-a-separate-text-section-on.patch
@@ -1,0 +1,35 @@
+From 5ba8c511f0e9c0bd636c8af249d3b821c22259e2 Mon Sep 17 00:00:00 2001
+From: Vratislav Podzimek <vratislav.podzimek@northern.tech>
+Date: Wed, 22 Aug 2018 16:47:04 +0200
+Subject: [PATCH] Do not put functions into a separate text section on PPC64
+
+Somehow this breaks things horribly and such functions seem to
+collide in address space with 'glibc' functions. Segfaults then
+happen and backtraces are totally weird.(*)
+
+(*) at least on RHEL 6.9, gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23)
+
+Signed-off-by: Vratislav Podzimek <v.podzimek@mykolab.com>
+---
+ libraries/liblmdb/mdb.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+index d9e7c5e..79133d5 100644
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -197,8 +197,9 @@ typedef SSIZE_T	ssize_t;
+ # error "Two's complement, reasonably sized integer types, please"
+ #endif
+ 
+-#ifdef __GNUC__
+-/** Put infrequently used env functions in separate section */
++#if defined(__GNUC__) && !defined(__PPC64__)
++/** Put infrequently used env functions in separate section
++ *  (break things horribly on PPC64 for unknown reasons) */
+ # ifdef __APPLE__
+ #  define	ESECT	__attribute__ ((section("__TEXT,text_env")))
+ # else
+-- 
+2.17.1
+


### PR DESCRIPTION
Somehow this breaks things horribly and such functions seem to
collide in address space with 'glibc' functions. Segfaults then
happen and backtraces are totally weird.(*)

(*) at least on RHEL 6.9, gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23)