### PR TITLE
ENT-3972: Save and restore state on package upgrade

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -794,7 +794,13 @@ if ! [ -f "$PREFIX/UPGRADED_FROM.txt" ] || egrep '3\.([0-6]|7\.0)' "$PREFIX/UPGR
   # more time now that we have upgraded.
   cf_console platform_service cfengine3 stop
 fi
-cf_console platform_service cfengine3 start
+
+if is_upgrade && [ -f "$PREFIX/UPGRADED_FROM_STATE.txt" ]; then
+    cf_console restore_cfengine_state "$PREFIX/UPGRADED_FROM_STATE.txt"
+    rm -f "$PREFIX/UPGRADED_FROM_STATE.txt"
+else
+    cf_console platform_service cfengine3 start
+fi
 
 rm -f "$PREFIX/UPGRADED_FROM.txt"
 

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -789,7 +789,7 @@ fi
 # Do not test for existence of $PREFIX/policy_server.dat, since we want the
 # web service to start. The script should take care of detecting that we are
 # not bootstrapped.
-if ! [ -f "$PREFIX/UPGRADED_FROM.txt" ] || egrep '3\.([0-6]|7\.0)' "$PREFIX/UPGRADED_FROM.txt" > /dev/null; then
+if ! [ -f "$PREFIX/UPGRADED_FROM.txt" ] || egrep '3\.([0-6]\.|7\.0)' "$PREFIX/UPGRADED_FROM.txt" > /dev/null; then
   # Versions <= 3.7.0 are unreliable in their daemon killing. Kill them one
   # more time now that we have upgraded.
   cf_console platform_service cfengine3 stop

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -36,7 +36,7 @@ if [ "`package_type`" = "rpm" ]; then
   # from the 3.6 series.
   #
   if is_upgrade; then
-    if $PREFIX/bin/cf-agent -V | egrep '^CFEngine Core 3\.([0-5]|6\.[01])' > /dev/null; then
+    if $PREFIX/bin/cf-agent -V | egrep '^CFEngine Core 3\.([0-5]\.|6\.[01])' > /dev/null; then
       ( echo "Upgraded from:"; $PREFIX/bin/cf-agent -V ) > $PREFIX/BROKEN_UPGRADE_NEED_TO_RESTART_DAEMONS.txt
     fi
   fi

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -1,8 +1,11 @@
 
 if is_upgrade; then
-  # This is nice to know to provide fixes for bugs in already released
-  # package scripts.
-  "$PREFIX/bin/cf-agent" -V | grep '^CFEngine Core' | sed -e 's/^CFEngine Core \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/' > "$PREFIX/UPGRADED_FROM.txt"
+    # This is nice to know to provide fixes for bugs in already released
+    # package scripts.
+    "$PREFIX/bin/cf-agent" -V | grep '^CFEngine Core' | sed -e 's/^CFEngine Core \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/' > "$PREFIX/UPGRADED_FROM.txt"
+
+    # Save the pre-upgrade state so that it can be restored
+    get_cfengine_state > "${PREFIX}/UPGRADED_FROM_STATE.txt"
 fi
 
 BACKUP_DIR=$PREFIX/backup-before-postgres10-migration

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -122,7 +122,7 @@ case `os_type` in
 esac
 
 if [ -f $PREFIX/policy_server.dat ]; then
-  if ! [ -f "$PREFIX/UPGRADED_FROM.txt" ] || egrep '3\.([0-6]|7\.0)' "$PREFIX/UPGRADED_FROM.txt" > /dev/null; then
+  if ! [ -f "$PREFIX/UPGRADED_FROM.txt" ] || egrep '3\.([0-6]\.|7\.0)' "$PREFIX/UPGRADED_FROM.txt" > /dev/null; then
     # Versions <= 3.7.0 are unreliable in their daemon killing. Kill them one
     # more time now that we have upgraded.
     cf_console platform_service cfengine3 stop

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -128,7 +128,12 @@ if [ -f $PREFIX/policy_server.dat ]; then
     cf_console platform_service cfengine3 stop
   fi
 
-  cf_console platform_service cfengine3 start
+  if is_upgrade && [ -f "$PREFIX/UPGRADED_FROM_STATE.txt" ]; then
+      cf_console restore_cfengine_state "$PREFIX/UPGRADED_FROM_STATE.txt"
+      rm -f "$PREFIX/UPGRADED_FROM_STATE.txt"
+  else
+      cf_console platform_service cfengine3 start
+  fi
 fi
 
 rm -f "$PREFIX/UPGRADED_FROM.txt"

--- a/packaging/common/cfengine-non-hub/preinstall.sh
+++ b/packaging/common/cfengine-non-hub/preinstall.sh
@@ -3,6 +3,9 @@ if is_upgrade; then
   # package scripts.
   "$PREFIX/bin/cf-agent" -V | grep '^CFEngine Core' | sed -e 's/^CFEngine Core \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/' > "$PREFIX/UPGRADED_FROM.txt"
 
+  # Save the pre-upgrade state so that it can be restored
+  get_cfengine_state > "${PREFIX}/UPGRADED_FROM_STATE.txt"
+
   # Stop the services on upgrade.
   cf_console platform_service cfengine3 stop
 fi

--- a/packaging/common/cfengine-non-hub/preinstall.sh
+++ b/packaging/common/cfengine-non-hub/preinstall.sh
@@ -25,7 +25,7 @@ case `os_type` in
     # from the 3.6 series, as well as the posttrans script.
     #
     if is_upgrade; then
-      if %{prefix}/bin/cf-agent -V | egrep '^CFEngine Core 3\.([0-5]|6\.[01])' > /dev/null; then
+      if %{prefix}/bin/cf-agent -V | egrep '^CFEngine Core 3\.([0-5]\.|6\.[01])' > /dev/null; then
         ( echo "Upgraded from:"; %{prefix}/bin/cf-agent -V ) > %{prefix}/BROKEN_UPGRADE_NEED_TO_RESTART_DAEMONS.txt
       fi
     fi

--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -40,3 +40,33 @@ case "$PKG_TYPE" in
     esac
     ;;
 esac
+
+get_cfengine_state() {
+    if type systemctl >/dev/null 2>&1; then
+        systemctl list-units -l | grep -P '^\s*cf-' | sed -r 's/\s*(cf-[-a-z]+)\.service.*/\1/'
+    else
+        platform_service cfengine3 status | grep 'is running' | sed -r 's/^([-a-z]+).*/\1/'
+    fi
+}
+
+restore_cfengine_state() {
+    # $1 -- file where the state to restore is saved (see get_cfengine_state())
+
+    if type systemctl >/dev/null 2>&1; then
+        xargs -n1 -a "$1" systemctl start
+    else
+        if [ -f ${PREFIX}/bin/cfengine3-nova-hub-init-d.sh ]; then
+            . ${PREFIX}/bin/cfengine3-nova-hub-init-d.sh
+            if grep postgres "$1" >/dev/null; then
+                start_postgres >/dev/null
+            fi
+            if grep httpd "$1" >/dev/null; then
+                start_httpd >/dev/null
+            fi
+        fi
+
+        for d in `grep 'cf-' "$1"`; do
+            ${PREFIX}/bin/${d}
+        done
+    fi
+}


### PR DESCRIPTION
We shouldn't blindly start all our daemons/services after package
upgrade, but rather honor the original/pre-upgrade state.

Changelog: Only start previously running processes on package upgrade