### PR TITLE
Try harder to stop PostgreSQL on upgrades

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -145,10 +145,13 @@ then
       cf_console echo "The PostgreSQL server belongs to a previous CFEngine deployment, shutting it down."
       if [ -x "$PREFIX/bin/pg_ctl" ];
       then
-	(cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart")
+        (cd /tmp &&
+         su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart" ||
+         # '-m fast' quits directly, without proper session shutdown
+         su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m fast")
       else
-	cf_console echo "No pg_ctl found at $PREFIX/bin/pg_ctl, aborting"
-	exit 1
+	    cf_console echo "No pg_ctl found at $PREFIX/bin/pg_ctl, aborting"
+	    exit 1
       fi
     else
       cf_console echo "The PostgreSQL is not from a previous CFEngine deployment"


### PR DESCRIPTION
If 'pg_ctl stop -m smart' fails, it means that there are some
clients that are not properly terminating their sessions. Using
'pg_ctl stop -m fast' shuts down such sessions. That may
potentially be unsafe, but the only clients of our PostgreSQL are
our components -- namely Redis, cf-hub and Mission Portal. All of
these should be dead by the time we stop PostgreSQL so it's safe
to terminate any sessions they may have left open.