### PR TITLE
Set the flag for the enterprise init script in state restore

### DIFF
--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -55,6 +55,7 @@ restore_cfengine_state() {
     if type systemctl >/dev/null 2>&1; then
         xargs -n1 -a "$1" systemctl start
     else
+        CALLED_FROM_STATE_RESTORE=1
         if [ -f ${PREFIX}/bin/cfengine3-nova-hub-init-d.sh ]; then
             . ${PREFIX}/bin/cfengine3-nova-hub-init-d.sh
             if grep postgres "$1" >/dev/null; then


### PR DESCRIPTION
The enterprise init script checks is was called from an expected
place (the core init script or state restore) so we need to tell
it that we are restoring state in scriptlets.