### PR TITLE
ENT-3715 Only attempt to generate key during install if not present on windows

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.wxs
+++ b/packaging/cfengine-nova/cfengine-nova.wxs
@@ -35,7 +35,7 @@
 
 	  <!-- Run cf-key after new installation -->
 	  <Property Id='GenerateKey' Value='empty, for now'  />
-	  <CustomAction Id='GenerateKeyPath' Property='GenerateKey' Value='&quot;[$(var.dirProgFiles)]\Cfengine\bin\cf-key.exe&quot;' Return='check' />
+	  <CustomAction Id='GenerateKeyPath' Property='GenerateKey' Value='&quot;C:\windows\system32\cmd.exe&quot; /c if not exist &quot;[$(var.dirProgFiles)]\Cfengine\ppkeys\localhost.pub&quot; &quot;[$(var.dirProgFiles)]\Cfengine\bin\cf-key.exe&quot;' Return='check' />
 	  <CustomAction Id='GenerateKey' BinaryKey='WixCA' DllEntry='CAQuietExec' Execute='deferred' Impersonate='no' Return='check' />
 
 	  <!-- Start service if the host has already been bootstrapped -->


### PR DESCRIPTION
If an existing key is present during pacakge install we should not try
to re-generate a new one. Trying to generate a new key when one already
exists will fail, and that will cause the package to not finish
installing correctly.

Changelog: Title
(cherry picked from commit b08245956187e8ca2e361839b43156da0e3e7d80)