### PR TITLE
ENT-4063 Keep specified files in htdocs dir during the update - 3.12.x

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -194,26 +194,45 @@ getent group cfpostgres && gpasswd --add cfapache cfpostgres
 #
 # Backup htdocs
 #
+
+generate_preserve_filter() {
+  # generates filter for `find` command to exclude files and dirs listed in
+  # "preserve_during_upgrade.txt" file: for each directory, prints
+  # "-not \( -path "$PREFIX/httpd/htdocs/$NAME" -prune \)";
+  # for each file, prints "-not \( -name "$NAME" \)".
+  sed -e '
+    /^\s*#/d  # skip lines beginning with #
+    /^\s*$/d  # also skip empty lines
+    \_/$_{    # for lines ending with /
+              # treat them as dirnames and exclude all files inside:
+      s_.*_-not \( -path "PREFIX/httpd/htdocs/&" -prune \)_
+    }
+    \_/$_!{   # for lines not ending with /
+              # treat them as filenames to be excluded:
+    s_.*_-not \( -name "&" \)_
+    }' -e "s/PREFIX/$PREFIX/" $PREFIX/httpd/htdocs/preserve_during_upgrade.txt
+}
+
 if [ -d $PREFIX/httpd/htdocs ]; then
   cf_console echo "A previous version of CFEngine Mission Portal was found,"
   cf_console echo "creating a backup of it at /tmp/cfengine-htdocs.tar.gz"
   tar zcf /tmp/cfengine-htdocs.tar.gz $PREFIX/httpd/htdocs
 
   cf_console echo "Purging old version from $PREFIX/httpd/htdocs"
-  if [ -d $PREFIX/share/GUI ]; then
+  if [ -f $PREFIX/httpd/htdocs/preserve_during_upgrade.txt ]; then
+    # Purge all files in httpd/htdocs with exceptions listed in preserve_during_upgrade.txt
+    cf_console echo "Keeping only what's listed in preserve_during_upgrade.txt file"
+    $PRESERVE_FILTER="`generate_preserve_filter`"
+    find "$PREFIX/httpd/htdocs" $PRESERVE_FILTER -type f -print0 | xargs -0 rm
+  elif [ -d $PREFIX/share/GUI ]; then
     # Remove only files copied from share/GUI to httpd/htdocs
     cf_console echo "Using share/GUI as template"
     ( cd $PREFIX/share/GUI
       # Make list of files in share/GUI and remove "them" from httpd/htdocs
       find -type f -print0 | ( cd ../../httpd/htdocs/ && xargs -0 rm )
     )
-    # Make sure old files are not copied over together with new files later
-    # (this only happens during upgrade of RPMs)
-    if [ "x${PKG_TYPE}" = "xrpm" ]; then
-        mv $PREFIX/share/GUI $PREFIX/share/GUI_old
-    fi
   else
-    # Purge all files in httpd/htdocs with exceptions:
+    # Purge all files in httpd/htdocs with hardcoded exceptions:
     # Preserve the tmp directory as it may contain scheduled or exported reports.
     # Preserve cf_robot.php and settings.ldap.php because they are generated.
     cf_console echo "No share/GUI found, purging all files except known exceptions"
@@ -221,6 +240,11 @@ if [ -d $PREFIX/httpd/htdocs ]; then
 	    -not \( -name "cf_robot.php" \) \
 	    -not \( -name "settings.ldap.php" \) \
 	    -type f -print0 | xargs -0 rm
+  fi
+  if [ -d $PREFIX/share/GUI -a "x${PKG_TYPE}" = "xrpm" ]; then
+    # Make sure old files are not copied over together with new files later
+    # (this only happens during upgrade of RPMs)
+    mv $PREFIX/share/GUI $PREFIX/share/GUI_old
   fi
   # Remove empty dirs in httpd/htdocs
   find $PREFIX/httpd/htdocs -depth -type d -exec rmdir {} \;

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -222,7 +222,7 @@ if [ -d $PREFIX/httpd/htdocs ]; then
   if [ -f $PREFIX/httpd/htdocs/preserve_during_upgrade.txt ]; then
     # Purge all files in httpd/htdocs with exceptions listed in preserve_during_upgrade.txt
     cf_console echo "Keeping only what's listed in preserve_during_upgrade.txt file"
-    $PRESERVE_FILTER="`generate_preserve_filter`"
+    PRESERVE_FILTER="`generate_preserve_filter`"
     find "$PREFIX/httpd/htdocs" $PRESERVE_FILTER -type f -print0 | xargs -0 rm
   elif [ -d $PREFIX/share/GUI ]; then
     # Remove only files copied from share/GUI to httpd/htdocs

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -210,7 +210,7 @@ generate_preserve_filter() {
     \_/$_!{   # for lines not ending with /
               # treat them as filenames to be excluded:
     s_.*_-not \( -name "&" \)_
-    }' -e "s/PREFIX/$PREFIX/" $PREFIX/httpd/htdocs/preserve_during_upgrade.txt
+    }' -e "s_PREFIX_${PREFIX}_" $PREFIX/httpd/htdocs/preserve_during_upgrade.txt
 }
 
 if [ -d $PREFIX/httpd/htdocs ]; then


### PR DESCRIPTION
Now, during upgrade only files and dirs listed in
preserve_during_upgrade.txt file will be preserved.

Relevant commit in Mission-Portal repo is cce364d30cdf26a91a2932ef77b3a5a6d9ef83f1
Relevant PR: https://github.com/cfengine/mission-portal/pull/649

Signed-off-by: Aleksei Shpakovskii <aleksei.shpakovskii@cfengine.com>
(cherry picked from commit 4fce1749b14c7e42690e3891e92ecffd81f51766)
Signed-off-by: aleksandrychev <leopolis.best@gmail.com>