### PR TITLE
Give httpd time to stop listening on 80/443 on upgrades

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -116,8 +116,13 @@ then
     HTTPD_RUNNING=`filter_netstat_listen ":80\s|:443\s"`
     if [ ! -z "$HTTPD_RUNNING" ];
     then
-      cf_console echo "Could not shutdown the process, aborting the installation"
-      exit 1
+      sleep 5s
+      HTTPD_RUNNING=`filter_netstat_listen ":80\s|:443\s"`
+      if [ ! -z "$HTTPD_RUNNING" ];
+      then
+        cf_console echo "Could not shutdown the process, aborting the installation"
+        exit 1
+      fi
     fi
   else
     cf_console echo "No apachectl found, aborting the installation!"


### PR DESCRIPTION
If 'apachectl stop' finishes with exit code 0, but something is
still listening on the HTTP(S) port(s), it's worth it to try and
give 'httpd' some more time to finish terminating properly before
just giving up.