### PR TITLE
ENT-4170 Explicitly set unix_socket_group

### DIFF
--- a/deps-packaging/postgresql-hub/postgresql.conf.cfengine.patch
+++ b/deps-packaging/postgresql-hub/postgresql.conf.cfengine.patch
@@ -23,7 +23,8 @@
  #superuser_reserved_connections = 3	# (change requires restart)
  #unix_socket_directories = '/tmp'	# comma-separated list of directories
  					# (change requires restart)
- #unix_socket_group = ''			# (change requires restart)
+-#unix_socket_group = ''			# (change requires restart)
++#unix_socket_group = 'cfpostgres'			# (change requires restart)
 -#unix_socket_permissions = 0777		# begin with 0 to use octal notation
 +unix_socket_permissions = 0770		# begin with 0 to use octal notation
  					# (change requires restart)


### PR DESCRIPTION
If the group ownership is not correct on the socket file, then cfapache will not
be able to connect to the cfsettings database and user authentication will fail.

Changelog: Title