### PR TITLE
3.12.x: Upgrade: assume PostgreSQL is running on 3.7.x if running cf-hub

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -6,6 +6,13 @@ if is_upgrade; then
 
     # Save the pre-upgrade state so that it can be restored
     get_cfengine_state > "${PREFIX}/UPGRADED_FROM_STATE.txt"
+
+    # 3.7.x has broken reporting of postgres status, let's assume it was running
+    # if cf-hub was running
+    if grep '^3\.7\.' "${PREFIX}/UPGRADED_FROM.txt" >/dev/null &&
+       grep "cf-hub" "${PREFIX}/UPGRADED_FROM_STATE.txt" > /dev/null; then
+        echo "postgres" >> "${PREFIX}/UPGRADED_FROM_STATE.txt"
+    fi
 fi
 
 BACKUP_DIR=$PREFIX/backup-before-postgres10-migration


### PR DESCRIPTION
3.7.x has broken detection of the PostgreSQL status and
'postgres' is always reported as 'not running'. Thus when we
capture the pre-upgrade state of runnig processes, PostgreSQL is
missing there and as a consequence it is not started when the
upgrade is finished.

To workaround this, let's assume that PostgreSQL is running on
3.7.x if cf-hub is also running.

Ticket: ENT-4082
(cherry picked from commit 5f0f0d691b41c0035d6021cb240ad083c49ad313)