### PR TITLE
Get running services from lines matching exactly what we expect

### DIFF
--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -43,7 +43,7 @@ esac
 
 get_cfengine_state() {
     if type systemctl >/dev/null 2>&1; then
-        systemctl list-units -l | sed -r -e '/^\s*(cf-[-a-z]+|cfengine3)/!d' -e 's/\s*(cf-[-a-z]+|cfengine3)\.service.*/\1/'
+        systemctl list-units -l | sed -r -e '/^\s*(cf-[-a-z]+|cfengine3)\.service/!d' -e 's/\s*(cf-[-a-z]+|cfengine3)\.service.*/\1/'
     else
         platform_service cfengine3 status | sed -r -e '/is running/!d' -e 's/^([-a-z]+).*/\1/'
     fi


### PR DESCRIPTION
When saving state we are extracting names of CFEngine services
that are running. The recognized sevices are the ones starting
with the 'cf-' prefix and the 'cfengine3.service'. Everything
else has to be ignored, otherwise the 's//' sed command fails and
we get full lines from the 'systemct list-units' output in the
state snapshot which is supposed to only list the running
services and nothing else.

Ticket: ENT-4082