### PR TITLE
ENT-4231: Preserve the 'pg_hba.conf' file on upgrades

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -399,6 +399,10 @@ if [ ! -d $PREFIX/state/pg/data ]; then
     cp -a "$new_pgconfig_file" $PREFIX/state/pg/data/postgresql.conf
     chown cfpostgres $PREFIX/state/pg/data/postgresql.conf
   else
+    # Always use the original pg_hba.conf file, it defines access control to PostgreSQL
+    cp -a "$BACKUP_DIR/data/pg_hba.conf" "$PREFIX/state/pg/data/pg_hba.conf"
+    chown cfpostgres "$PREFIX/state/pg/data/pg_hba.conf"
+
     # Determine which postgresql.conf file to use and put it in the right place.
     if [ -f "$BACKUP_DIR/data/postgresql.conf.modified" ]; then
       # User-modified file from the previous old version of CFEngine exists, try to use it.

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -431,6 +431,14 @@ if [ ! -d $PREFIX/state/pg/data ]; then
       cp -a "$new_pgconfig_file" "$PREFIX/state/pg/data/postgresql.conf"
       chown cfpostgres "$PREFIX/state/pg/data/postgresql.conf"
     fi
+
+    # Preserve the recovery.conf file if it existed, it defines how this
+    # PostgreSQL should behave as a slave (has to be done AFTER checking/writing
+    # the postgresql.conf file above).
+    if [ -f "$BACKUP_DIR/data/recovery.conf" ]; then
+      cp -a "$BACKUP_DIR/data/recovery.conf" "$PREFIX/state/pg/data/recovery.conf"
+      chown cfpostgres "$PREFIX/state/pg/data/recovery.conf"
+    fi
   fi
 fi
 


### PR DESCRIPTION
This file defines access control for PostgreSQL and must be
preserved on upgrade. It may be granting extra access (e.g. in
the HA setup), but it may also be blocking some of the defaults.

Changelog: None