### PR TITLE
CFE-2949: Do not use '-r' with 'sed' when saving state on upgrade

### DIFF
--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -45,7 +45,7 @@ get_cfengine_state() {
     if type systemctl >/dev/null 2>&1; then
         systemctl list-units -l | sed -r -e '/^\s*(cf-[-a-z]+|cfengine3)\.service/!d' -e 's/\s*(cf-[-a-z]+|cfengine3)\.service.*/\1/'
     else
-        platform_service cfengine3 status | sed -r -e '/is running/!d' -e 's/^([-a-z]+).*/\1/'
+        platform_service cfengine3 status | sed -e '/is running/!d' -e 's/^\([-a-z]\+\).*/\1/'
     fi
 }
 


### PR DESCRIPTION
Some platforms don't have this fancy feature of their 'sed'
tool. It's okay to use it on the systemd-based platforms though,
these are new enough.