### PR TITLE
[3.12.x] CFE-2949: Use 'awk' instead of 'sed' to save state on upgrade

### DIFF
--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -45,7 +45,7 @@ get_cfengine_state() {
     if type systemctl >/dev/null 2>&1; then
         systemctl list-units -l | sed -r -e '/^\s*(cf-[-a-z]+|cfengine3)\.service/!d' -e 's/\s*(cf-[-a-z]+|cfengine3)\.service.*/\1/'
     else
-        platform_service cfengine3 status | sed -e '/is running/!d' -e 's/^\([-a-z]\+\).*/\1/'
+        platform_service cfengine3 status | awk '/is running/ { print $1 }'
     fi
 }
 


### PR DESCRIPTION
'sed' doesn't support the '-r' option on old platforms (exotics)
and also its interpretation of regular expressions is a
mystery. 'awk' seems to work much more reliably.

(cherry picked from commit 9ce8e6dfcb5a1d37ed5ceca81d244cdafffcc15a)