### PR TITLE
[3.12.x] Fix platform_service() on AIX in RPM packages

### DIFF
--- a/packaging/common/script-templates/rpm-script-common.sh
+++ b/packaging/common/script-templates/rpm-script-common.sh
@@ -30,7 +30,7 @@ platform_service()
   if [ -x /bin/systemctl ]; then
     /bin/systemctl "$2" "$1".service
   else
-    /etc/init.d/"$1" "$2"
+    `rc_d_path`/init.d/"$1" "$2"
   fi
 }
 


### PR DESCRIPTION
The 'cfengine3' init script is under /etc/rc.d/init.d on AIX. We
already have functions for these tweaks, let's just use them
more.

Ticket: ENT-4305
Changelog: Fix running cfengine3 init script in AIX RPMs
(cherry picked from commit f30d69e2e0ce203d7ced2777fa97ff3e2c53d740)