### PR TITLE
ENT-4126: Set phar read only off for PHP

### DIFF
--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -149,6 +149,9 @@ sed -ri 's/^\s*memory_limit\s*=.*/memory_limit = 256M/g' ${RPM_BUILD_ROOT}%{pref
 # Set the default timezone for php
 sed -ri 's/^(\s|;)*date.timezone\s*=.*/date.timezone = "UTC"/g' ${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/php.ini
 
+# Set the phar readonly Off for php
+sed -ri 's/^(\s|;)phar.readonly = On/phar.readonly = Off/' ${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/php.ini
+
 echo "extension=curl.so" >> ${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/curl.ini
 echo "extension=openssl.so" >>${RPM_BUILD_ROOT}%{prefix}/httpd/php/lib/openssl.ini
 rm -rf ${RPM_BUILD_ROOT}%{prefix}/httpd/conf

--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -139,6 +139,9 @@ install: build
 	# Set the default timezone for php to UTC
 	sed -ri 's/^(\s|;)*date.timezone\s*=.*/date.timezone = "UTC"/g' $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/php.ini
 
+	# Set the phar readonly Off for php
+	sed -ri 's/^(\s|;)phar.readonly = On/phar.readonly = Off/' $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/php.ini
+
 	echo "extension=curl.so" >> $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/curl.ini
 	echo "extension=openssl.so" >> $(CURDIR)/debian/tmp$(PREFIX)/httpd/php/lib/openssl.ini
 


### PR DESCRIPTION
New Export/Import tooling requires phar