### PR TITLE
The logic in pkg-install-solaris first checks to see if a package is …

### DIFF
--- a/deps-packaging/pkg-install-solaris
+++ b/deps-packaging/pkg-install-solaris
@@ -11,7 +11,7 @@ for pkg in "$@"; do
   P_FILENAME=`basename $pkg`
   P_NAME=${P_FILENAME%.pkg}
 
-  if pkginfo ${P_NAME}; then
+  if pkginfo ${P_NAME} > /dev/null 2>&1; then
     sudo /usr/sbin/pkgrm -n ${P_NAME}
   fi
   sudo /usr/sbin/pkgadd -n -d $pkg ${P_NAME}


### PR DESCRIPTION
…installed with pkginfo

and then will pkgrm it if it is and then pkgadd it. The goal is to ensure a fresh install
of the package. In this commit I am silencing errors from pkginfo for missing packages
since the command is only run to determine state not notice errors at that stage.

Changelog: None
Ticket: ENT-4070