### PR TITLE
Disable pr-pipeline builds on Solaris 10 SPARC64

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -12,7 +12,6 @@ PACKAGES_i386_linux_redhat_4
 PACKAGES_i386_mingw
 PACKAGES_ia64_hpux_11.23
 PACKAGES_ppc64_aix_53
-PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_linux_debian_4
 PACKAGES_x86_64_linux_debian_7


### PR DESCRIPTION
The Solaris 10 zone is heavily unreliable and is causing builds
to fail almost every day. It's better to have green builds and
only make sure everything is fine on Solaris 10 before the
release. Note that we are still running tests on Solaris 11
SPARC64.