### PR TITLE
Disable Solaris 9 and 10 SPARC64 on pr-pipeline

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -13,7 +13,6 @@ PACKAGES_i386_mingw
 PACKAGES_ia64_hpux_11.23
 PACKAGES_ppc64_aix_53
 PACKAGES_sparc64_solaris_11
-PACKAGES_sparc64_solaris_9
 PACKAGES_x86_64_linux_debian_4
 PACKAGES_x86_64_linux_debian_7
 PACKAGES_x86_64_linux_redhat_4

--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -12,7 +12,6 @@ PACKAGES_i386_linux_redhat_4
 PACKAGES_i386_mingw
 PACKAGES_ia64_hpux_11.23
 PACKAGES_ppc64_aix_53
-PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_sparc64_solaris_9
 PACKAGES_x86_64_linux_debian_4


### PR DESCRIPTION
See commit message(s) for details.