### PR TITLE
Add an option to get ONLY exotic labels with get_labels_expr.py

### DIFF
--- a/build-scripts/get_labels_expr.py
+++ b/build-scripts/get_labels_expr.py
@@ -18,6 +18,8 @@ def get_args():
     ap.add_argument("-e", "--run-on-exotics", nargs="?", default=False, const=True,
                     help="Run on exotic labels if RUN_ON_EXOTICS is not specified " +
                     "or it is not one of '0', 'no'.")
+    ap.add_argument("-E", "--only-exotics", nargs="?", default=False, const=True,
+                    help="Run ONLY on the exotic labels")
     ap.add_argument("labels_file")
     ap.add_argument("exotics_file")
 
@@ -31,14 +33,21 @@ def non_empty_lines(file_obj):
         if content:
             yield content
 
-def main(labels_f_path, exotics_f_path, run_on_exotics):
-    labels_to_run = set()
-    with open(labels_f_path, "r") as f:
+def get_labels_from_file(f_path):
+    with open(f_path, "r") as f:
         for label in non_empty_lines(f):
+            yield label
+
+def main(labels_f_path, exotics_f_path, run_on_exotics, only_exotics):
+    labels_to_run = set()
+    if only_exotics:
+        for label in get_labels_from_file(exotics_f_path):
             labels_to_run.add(label.strip())
-    if not run_on_exotics:
-        with open(exotics_f_path, "r") as f:
-            for label in non_empty_lines(f):
+    else:
+        for label in get_labels_from_file(labels_f_path):
+            labels_to_run.add(label.strip())
+        if not run_on_exotics:
+            for label in get_labels_from_file(exotics_f_path):
                 labels_to_run.discard(label.strip())
 
     print("(", end="")
@@ -50,5 +59,6 @@ def main(labels_f_path, exotics_f_path, run_on_exotics):
 if __name__ == "__main__":
     args = get_args()
     ret = main(args.labels_file, args.exotics_file,
-               args.run_on_exotics not in (False, '0', 0, "no"))
+               args.run_on_exotics not in (False, '0', 0, "no"),
+               args.only_exotics not in (False, '0', 0, "no"))
     sys.exit(ret)


### PR DESCRIPTION
This will allow us to split the full run of tests into two jobs
-- one for non-exotic platforms and one for exotic platforms. We
can then treat their results, stability issues,... differently.