### PR TITLE
ENT-4506 New files created during package changes are restricted

### DIFF
--- a/packaging/common/script-templates/script-common-header-last.sh
+++ b/packaging/common/script-templates/script-common-header-last.sh
@@ -23,6 +23,9 @@ is_nova()
 
 INSTLOG=/var/log/CFEngineHub-Install.log
 mkdir -p "$(dirname "$INSTLOG")"
+touch "$INSTLOG"
+chown root:root "$INSTLOG"
+chmod 600 "$INSTLOG"
 CONSOLE=7
 # Redirect most output to log file, but keep console around for custom output.
 case "$SCRIPT_TYPE" in


### PR DESCRIPTION
Changelog: Title

To ensure that we do not accidentally leak sensitive information, we set the
umask so that new files are only readable by the owner.