### PR TITLE
Drop 'Hub' from the installation log filename

### DIFF
--- a/packaging/common/script-templates/script-common-header-last.sh
+++ b/packaging/common/script-templates/script-common-header-last.sh
@@ -21,7 +21,7 @@ is_nova()
   test "$PROJECT_TYPE" = "cfengine-nova" || test "$PROJECT_TYPE" = "cfengine-nova-hub"
 }
 
-INSTLOG=/var/log/CFEngineHub-Install.log
+INSTLOG=/var/log/CFEngine-Install.log
 mkdir -p "$(dirname "$INSTLOG")"
 CONSOLE=7
 # Redirect most output to log file, but keep console around for custom output.


### PR DESCRIPTION
The log is produced on both hub and client installations. Instead
of adding complexity to differentiate between the cases, let's
just use a neutral filename.

Ticket: ENT-4564