### PR TITLE
Package libyaml.so as part of the cfbuild-libyaml package

### DIFF
--- a/deps-packaging/libyaml/debian/cfbuild-libyaml-devel.install
+++ b/deps-packaging/libyaml/debian/cfbuild-libyaml-devel.install
@@ -1,2 +1,1 @@
 /var/cfengine/include/
-/var/cfengine/lib/

--- a/deps-packaging/libyaml/debian/cfbuild-libyaml.install
+++ b/deps-packaging/libyaml/debian/cfbuild-libyaml.install
@@ -1,1 +1,2 @@
 /var/cfengine/bin
+/var/cfengine/lib


### PR DESCRIPTION
If it's part of the -devel package it is not going to end up in
the cfengine package because we only install the -devel packages
for the building phase and then uninstall them before
packaging. Only the non-devel packages remain installed for the
packaging phase and thus only their contests are included in the
final cfengine package.

Ticket: CFE-3065
Changelog: None