### PR TITLE
Revert "Disable pr-pipeline builds on Solaris 10 SPARC64"

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -14,6 +14,7 @@ PACKAGES_i386_mingw
 PACKAGES_ia64_hpux_11.23
 PACKAGES_ppc64_aix_53
 PACKAGES_ppc64_aix_71
+PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_linux_debian_4
 PACKAGES_x86_64_linux_debian_7


### PR DESCRIPTION
This reverts commit 7dcfa5190b2d3a8875d1e564747e5e6283303b24.

Conflicts:
  build-scripts/labels.txt