### PR TITLE
ENT-4733 Set group ownership for install log to system on aix

### DIFF
--- a/packaging/common/script-templates/script-common-header-last.sh
+++ b/packaging/common/script-templates/script-common-header-last.sh
@@ -22,7 +22,7 @@ is_nova()
 }
 
 INSTLOG=/var/log/CFEngineHub-Install.log
-case os_type() in
+case "`os_type`" in
     aix)
         INSTLOGGROUP="system"
         ;;

--- a/packaging/common/script-templates/script-common-header-last.sh
+++ b/packaging/common/script-templates/script-common-header-last.sh
@@ -22,9 +22,18 @@ is_nova()
 }
 
 INSTLOG=/var/log/CFEngineHub-Install.log
+case os_type() in
+    aix)
+        INSTLOGGROUP="system"
+        ;;
+    *)
+        INSTLOGGROUP="root"
+        ;;
+esac
+
 mkdir -p "$(dirname "$INSTLOG")"
 touch "$INSTLOG"
-chown root:root "$INSTLOG"
+chown root:$INSTLOGGROUP "$INSTLOG"
 chmod 600 "$INSTLOG"
 CONSOLE=7
 # Redirect most output to log file, but keep console around for custom output.


### PR DESCRIPTION
There is no root group on aix hosts, instead we should use a group that exists
by default.

The following accounts are predefined in the operating system:

- adm

  The adm user account owns the following basic system functions:

  - Diagnostics, the tools for which are stored in the /usr/sbin/perf/diag_tool
    directory.
  - Accounting, the tools for which are stored in the following directories:
    - /usr/sbin/acct
    - /usr/lib/acct
    - /var/adm
    - /var/adm/acct/fiscal
    - /var/adm/acct/nite
    - /var/adm/acct/sum

- bin

  The bin user account typically owns the executable files for most user
  commands. This account's primary purpose is to help distribute the ownership
  of important system directories and files so that everything is not owned
  solely by the root and sys user accounts.

- daemon

  The daemon user account exists only to own and run system server processes and
  their associated files. This account guarantees that such processes run with
  the appropriate file access permissions.

- nobody

  The nobody user account is used by the Network File System (NFS) to enable
  remote printing. This account exists so that a program can permit temporary
  root access to root users. For example, before enabling Secure RPC or Secure
  NFS, check the /etc/public key on the master NIS server to find a user who
  has not been assigned a public key and a secret key. As root user, you can
  create an entry in the database for each unassigned user by entering:

  ```
  newkey -u username
  ```

  Or, you can create an entry in the database for the nobody user account, and
  then any user can run the chkey program to create their own entries in the
  database without logging in as root.

- root

  The root user account, UID 0, through which you can perform system maintenance
  tasks and troubleshoot system problems.

- sys

  The sys user owns the default mounting point for the Distributed File
  Service (DFS) cache, which must exist before you can install or configure
  DFS on a client. The /usr/sys directory can also store installation images.

- system

  System group is a system-defined group for system administrators. Users of the
  system group have the privilege to perform some system maintenance tasks
  without requiring root authority.

https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.security/sysspecaccts.htm

Ticket: ENT-4733
Changelog: Title
(cherry picked from commit d932325141c9353fe7691d7cefab8950bea10adf)