### PR TITLE
Fixed syntax error in sh script header

### DIFF
--- a/packaging/common/script-templates/script-common-header-last.sh
+++ b/packaging/common/script-templates/script-common-header-last.sh
@@ -21,7 +21,7 @@ is_nova()
   test "$PROJECT_TYPE" = "cfengine-nova" || test "$PROJECT_TYPE" = "cfengine-nova-hub"
 }
 
-case os_type() in
+case "`os_type`" in
     aix)
         INSTLOGGROUP="system"
         ;;


### PR DESCRIPTION
Introduced in d932325141c9353fe7691d7cefab8950bea10adf.