### PR TITLE
Add a patch fixing x86_64 assembly in OpenSSL

### DIFF
--- a/deps-packaging/openssl/0001-cfi-build-fixes-in-x86-64-ghash-assembly.patch
+++ b/deps-packaging/openssl/0001-cfi-build-fixes-in-x86-64-ghash-assembly.patch
@@ -1,0 +1,36 @@
+From 54d00677f305375eee65a0c9edb5f0980c5f020f Mon Sep 17 00:00:00 2001
+From: Shane Lontis <shane.lontis@oracle.com>
+Date: Tue, 19 Feb 2019 13:56:33 +1000
+Subject: [PATCH] cfi build fixes in x86-64 ghash assembly
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+(Merged from https://github.com/openssl/openssl/pull/8281)
+---
+ crypto/modes/asm/ghash-x86_64.pl | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/crypto/modes/asm/ghash-x86_64.pl b/crypto/modes/asm/ghash-x86_64.pl
+index d6d0d7527e..a5d216abc9 100644
+--- a/crypto/modes/asm/ghash-x86_64.pl
++++ b/crypto/modes/asm/ghash-x86_64.pl
+@@ -1155,6 +1155,7 @@ ___
+ } else {
+ $code.=<<___;
+ 	jmp	.L_init_clmul
++.cfi_endproc
+ .size	gcm_init_avx,.-gcm_init_avx
+ ___
+ }
+@@ -1594,6 +1595,7 @@ ___
+ } else {
+ $code.=<<___;
+ 	jmp	.L_ghash_clmul
++.cfi_endproc
+ .size	gcm_ghash_avx,.-gcm_ghash_avx
+ ___
+ }
+-- 
+2.20.1
+

--- a/deps-packaging/openssl/cfbuild-openssl.spec
+++ b/deps-packaging/openssl/cfbuild-openssl.spec
@@ -9,6 +9,7 @@ License: MIT
 Group: Other
 Url: http://example.com/
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
+Patch0: 0001-cfi-build-fixes-in-x86-64-ghash-assembly.patch
 
 AutoReqProv: no
 
@@ -17,6 +18,7 @@ AutoReqProv: no
 %prep
 mkdir -p %{_builddir}
 %setup -q -n openssl-%{openssl_version}
+%patch0 -p1
 
 %build
 

--- a/deps-packaging/openssl/debian/rules
+++ b/deps-packaging/openssl/debian/rules
@@ -12,6 +12,8 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
+	patch -p1 -i 0001-cfi-build-fixes-in-x86-64-ghash-assembly.patch
+
 	echo ==================== BUILD_TYPE is $$BUILD_TYPE ====================
 
 	test -d /var/cfengine || ( sudo mkdir /var/cfengine && sudo chmod 777 /var/cfengine )


### PR DESCRIPTION
Upstream has this fix, but it didn't make it to OpenSSL-1.1.1b so
we have to apply it ourselves.

(cherry picked from commit 3c0155f0a50c323199a079f6d77b13da6bcc9a7c)