### PR TITLE
Enable HTTP/2.0 protocol in apache

### DIFF
--- a/deps-packaging/apache/cfbuild-apache.spec
+++ b/deps-packaging/apache/cfbuild-apache.spec
@@ -27,6 +27,7 @@ CPPFLAGS=-I%{buildprefix}/include
     --prefix=%{prefix}/httpd \
     --enable-so \
     --enable-mods-shared="all ssl ldap authnz_ldap" \
+    --enable-http2 \
     --with-z=%{prefix} \
     --with-ssl=%{prefix} \
     --with-ldap=%{prefix} \

--- a/deps-packaging/apache/cfbuild-apache.spec
+++ b/deps-packaging/apache/cfbuild-apache.spec
@@ -16,6 +16,13 @@ AutoReqProv: no
 
 %define prefix %{buildprefix}
 
+wget https://github.com/nghttp2/nghttp2/releases/download/v1.37.0/nghttp2-1.37.0.tar.gz
+tar -xvf nghttp2-1.37.0.tar.gz
+cd ./nghttp2-1.37.0
+./configure
+make
+make install
+
 %prep
 mkdir -p %{_builddir}
 %setup -q -n httpd-%{apache_version}

--- a/deps-packaging/apache/debian/rules
+++ b/deps-packaging/apache/debian/rules
@@ -17,6 +17,7 @@ build-stamp:
 --prefix=$(PREFIX)/httpd \
 --enable-so \
 --enable-mods-shared="all ssl ldap authnz_ldap" \
+--enable-http2 \
 --with-z=$(PREFIX) \
 --with-ssl=$(PREFIX) \
 --with-ldap=$(PREFIX) \

--- a/deps-packaging/apache/debian/rules
+++ b/deps-packaging/apache/debian/rules
@@ -3,6 +3,13 @@ PREFIX=$(BUILDPREFIX)
 
 CPPFLAGS=-I$(BUILDPREFIX)/include
 
+wget https://github.com/nghttp2/nghttp2/releases/download/v1.37.0/nghttp2-1.37.0.tar.gz
+tar -xvf nghttp2-1.37.0.tar.gz
+cd ./nghttp2-1.37.0
+./configure
+make
+make install
+
 clean:
 	dh_testdir
 	dh_testroot

--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -69,6 +69,9 @@ LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
 # Required to log into mission portal
 LoadModule authz_core_module modules/mod_authz_core.so
 
+# Required to support HTTP/2.0 protocol
+LoadModule http2_module modules/mod_http2.so
+
 
 # TRACE can be useful for debugging, but can be abused to perform Cross-Site
 # Tracing (XST) attacheks in order to obtain access to user cooking via
@@ -196,6 +199,8 @@ LogLevel warn
     SSLEngine on
     SSLCertificateFile "INSERT_CERT_HERE"
     SSLCertificateKeyFile "INSERT_CERT_KEY_HERE"
+
+    Protocols h2 h2c http/1.1
 
     # Enable Strict Transport Security to prevent HTTPS users from
     # accessing http content.


### PR DESCRIPTION
Allow using http/2.0 protocol which is significantly better then http/1.1