### PR TITLE
ENT-2828: Build PHP with --with-zlib option

### DIFF
--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -36,6 +36,7 @@ fi
 --with-pdo-pgsql=%{prefix} \
 --with-json \
 --with-iconv \
+--with-zlib=%{prefix} \
 --without-aolserver \
 --without-caudium \
 --without-continuity \

--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -23,6 +23,7 @@ build-stamp:
 --with-pdo \
 --with-json \
 --with-iconv \
+--with-zlib=$(PREFIX) \
 --with-pdo-pgsql=$(PREFIX) \
 --without-aolserver \
 --without-caudium \


### PR DESCRIPTION
ChangeLog: Enable Zlib extension in PHP to support png images with alpa channel