### PR TITLE
[3.12.x] Patch LMDB to not abort on assert failure

### DIFF
--- a/deps-packaging/lmdb/0001-Do-not-abort-if-a-user-define-assert-function-is-cal.patch
+++ b/deps-packaging/lmdb/0001-Do-not-abort-if-a-user-define-assert-function-is-cal.patch
@@ -1,0 +1,31 @@
+From 7b66c52e833f49a71a8a2900fb8452217395ef03 Mon Sep 17 00:00:00 2001
+From: Vratislav Podzimek <v.podzimek@mykolab.com>
+Date: Wed, 4 Sep 2019 16:25:53 +0200
+Subject: [PATCH] Do not abort() if a user-define assert function is called
+
+It's up to the user code to handle the problem. If it wants to
+abort(), it can do it itself, there's no point in enforcing it.
+---
+ libraries/liblmdb/mdb.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+index f685421..214a0eb 100644
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -1766,8 +1766,10 @@ mdb_assert_fail(MDB_env *env, const char *expr_txt,
+ 		file, line, expr_txt, func);
+ 	if (env->me_assert_func)
+ 		env->me_assert_func(env, buf);
+-	fprintf(stderr, "%s\n", buf);
+-	abort();
++    else {
++        fprintf(stderr, "%s\n", buf);
++        abort();
++    }
+ }
+ #else
+ # define mdb_assert0(env, expr, expr_txt) ((void) 0)
+-- 
+2.20.1
+


### PR DESCRIPTION
We want to have a chance to handle the failure gracefully.

(cherry picked from commit 5ab94702103e09dbee27e3c4a52445ee7220766d)

Merge together:
https://github.com/cfengine/core/pull/3827
https://github.com/cfengine/buildscripts/pull/615