### PR TITLE
Package the SELinux policy module in RHEL 8 agent community packages

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -93,6 +93,12 @@ rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 %prefix/bin/mdb_copy
 %prefix/bin/mdb_stat
 
+%if %{?rhel}%{!?rhel:0} > 7
+# SELinux policy
+%dir %prefix/selinux
+%prefix/selinux/cfengine-enterprise.pp
+%endif
+
 # Globally installed configs, scripts
 %attr(644,root,root) /etc/sysconfig/cfengine3
 %attr(755,root,root) /etc/profile.d/cfengine3.sh


### PR DESCRIPTION
The RHEL 8 community packages need the SELinux policy module too
so we install it as part of `make install`. We then need to
include it in the `%files` section of the RPM SPEC so that it
gets into the RPM.