### PR TITLE
Patch LMDB to not abort on assert failure

### DIFF
--- a/build-scripts/get_labels_expr.py
+++ b/build-scripts/get_labels_expr.py
@@ -39,16 +39,20 @@ def get_labels_from_file(f_path):
             yield label
 
 def main(labels_f_path, exotics_f_path, run_on_exotics, only_exotics):
+    all_labels = set()
+    exotics = set()
+    for label in get_labels_from_file(labels_f_path):
+        all_labels.add(label.strip())
+    for label in get_labels_from_file(exotics_f_path):
+        exotics.add(label.strip())
+
     labels_to_run = set()
     if only_exotics:
-        for label in get_labels_from_file(exotics_f_path):
-            labels_to_run.add(label.strip())
+        labels_to_run = all_labels.intersection(exotics)
+    elif not run_on_exotics:
+        labels_to_run = all_labels.difference(exotics)
     else:
-        for label in get_labels_from_file(labels_f_path):
-            labels_to_run.add(label.strip())
-        if not run_on_exotics:
-            for label in get_labels_from_file(exotics_f_path):
-                labels_to_run.discard(label.strip())
+        labels_to_run = all_labels
 
     print("(", end="")
     labels_eqs = ('label == "%s"' % label for label in sorted(labels_to_run))

--- a/build-scripts/get_labels_expr.py
+++ b/build-scripts/get_labels_expr.py
@@ -18,6 +18,8 @@ def get_args():
     ap.add_argument("-e", "--run-on-exotics", nargs="?", default=False, const=True,
                     help="Run on exotic labels if RUN_ON_EXOTICS is not specified " +
                     "or it is not one of '0', 'no'.")
+    ap.add_argument("-E", "--only-exotics", nargs="?", default=False, const=True,
+                    help="Run ONLY on the exotic labels")
     ap.add_argument("labels_file")
     ap.add_argument("exotics_file")
 
@@ -31,14 +33,21 @@ def non_empty_lines(file_obj):
         if content:
             yield content
 
-def main(labels_f_path, exotics_f_path, run_on_exotics):
-    labels_to_run = set()
-    with open(labels_f_path, "r") as f:
+def get_labels_from_file(f_path):
+    with open(f_path, "r") as f:
         for label in non_empty_lines(f):
+            yield label
+
+def main(labels_f_path, exotics_f_path, run_on_exotics, only_exotics):
+    labels_to_run = set()
+    if only_exotics:
+        for label in get_labels_from_file(exotics_f_path):
             labels_to_run.add(label.strip())
-    if not run_on_exotics:
-        with open(exotics_f_path, "r") as f:
-            for label in non_empty_lines(f):
+    else:
+        for label in get_labels_from_file(labels_f_path):
+            labels_to_run.add(label.strip())
+        if not run_on_exotics:
+            for label in get_labels_from_file(exotics_f_path):
                 labels_to_run.discard(label.strip())
 
     print("(", end="")
@@ -50,5 +59,6 @@ def main(labels_f_path, exotics_f_path, run_on_exotics):
 if __name__ == "__main__":
     args = get_args()
     ret = main(args.labels_file, args.exotics_file,
-               args.run_on_exotics not in (False, '0', 0, "no"))
+               args.run_on_exotics not in (False, '0', 0, "no"),
+               args.only_exotics not in (False, '0', 0, "no"))
     sys.exit(ret)

--- a/deps-packaging/lmdb/0001-Do-not-abort-if-a-user-define-assert-function-is-cal.patch
+++ b/deps-packaging/lmdb/0001-Do-not-abort-if-a-user-define-assert-function-is-cal.patch
@@ -1,0 +1,31 @@
+From 7b66c52e833f49a71a8a2900fb8452217395ef03 Mon Sep 17 00:00:00 2001
+From: Vratislav Podzimek <v.podzimek@mykolab.com>
+Date: Wed, 4 Sep 2019 16:25:53 +0200
+Subject: [PATCH] Do not abort() if a user-define assert function is called
+
+It's up to the user code to handle the problem. If it wants to
+abort(), it can do it itself, there's no point in enforcing it.
+---
+ libraries/liblmdb/mdb.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+index f685421..214a0eb 100644
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -1766,8 +1766,10 @@ mdb_assert_fail(MDB_env *env, const char *expr_txt,
+ 		file, line, expr_txt, func);
+ 	if (env->me_assert_func)
+ 		env->me_assert_func(env, buf);
+-	fprintf(stderr, "%s\n", buf);
+-	abort();
++    else {
++        fprintf(stderr, "%s\n", buf);
++        abort();
++    }
+ }
+ #else
+ # define mdb_assert0(env, expr, expr_txt) ((void) 0)
+-- 
+2.20.1
+


### PR DESCRIPTION
We want to have a chance to handle the failure gracefully.

(cherry picked from commit 5ab94702103e09dbee27e3c4a52445ee7220766d)
(cherry picked from commit 64537d1d218fdcaaaafcf5126161e39522fce934)