### PR TITLE
ENT-4754: Enabled nova repo to decide which tests to run

### DIFF
--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -226,9 +226,8 @@ case "$JOB" in
         s3cmd get --no-progress $DEB_PACKAGE cfe.deb
         install_package
         sudo service cfengine3 restart
-        sudo bash nova/tests/schema/check_reqs.sh
         cd nova/tests/schema
-        sudo --preserve-env sh -c "prove -v *.test 2>&1"
+        sudo --preserve-env sh -c "./runtests.sh 2>&1"
     ;;
         
     ( deployment-test )


### PR DESCRIPTION
runtests.sh looks at TRAVIS environment variable and if present then skips tests which don't currently work there: migration and generate since they have dependencies which are not met.

merge with https://github.com/cfengine/nova/pull/1510