### PR TITLE
Dependency updates for 3.10.x

### DIFF
--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -49,7 +49,7 @@ Hub specific dependencies:
 * [PHP](http://php.net/) 5.6.40
 * [libmcrypt](https://sourceforge.net/projects/mcrypt/files/Libmcrypt/) 2.5.8
   * Needed for php module
-* [Git](https://www.kernel.org/pub/software/scm/git/) 2.13.7
+* [Git](https://www.kernel.org/pub/software/scm/git/) 2.24.0
 * [rsync](https://download.samba.org/pub/rsync/) 3.1.3
 
 Other dependencies (**find out why they are needed!**)

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -44,7 +44,7 @@ Hub specific dependencies:
 * [APR](https://apr.apache.org/) 1.7.0
 * [apr-util](https://apr.apache.org/) 1.6.1
 * [Apache](http://httpd.apache.org/) 2.4.41
-* [PostgreSQL](http://www.postgresql.org/) for the hub 9.6.15
+* [PostgreSQL](http://www.postgresql.org/) for the hub 9.6.16
 * [Redis](http://redis.io/) 3.2.13
 * [PHP](http://php.net/) 5.6.40
 * [libmcrypt](https://sourceforge.net/projects/mcrypt/files/Libmcrypt/) 2.5.8

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -20,7 +20,7 @@ Agent dependencies:
   * Needed by libxml2
 * [libacl](http://download.savannah.gnu.org/releases/acl/) 2.2.53
 * [libattr](http://download.savannah.gnu.org/releases/attr/) 2.4.48
-* [libcurl](http://curl.haxx.se/download.html) 7.66.0
+* [libcurl](http://curl.haxx.se/download.html) 7.67.0
 * libgcc
   * Currently only in use on AIX, Solaris, GCC dynamically links to it in order
     to substitute missing system functions

--- a/deps-packaging/git/cfbuild-git.spec
+++ b/deps-packaging/git/cfbuild-git.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- git
 Name: cfbuild-git
 Version: %{version}
 Release: 1
-Source0: git-2.13.7.tar.gz
+Source0: git-2.24.0.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -14,7 +14,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n git-2.13.7
+%setup -q -n git-2.24.0
 
 ./configure --prefix=%{prefix} --with-libpcre=%{prefix} --with-openssl=%{prefix} --without-iconv --with-gitconfig=%{prefix}/config/gitconfig --with-gitattributes=%{prefix}/config/gitattributes --with-zlib=%{prefix} --with-curl=%{prefix}  --libexecdir=%{prefix}/lib
 
@@ -65,4 +65,5 @@ CFEngine Build Automation -- git
 %{prefix}/lib/git-core
 
 %changelog
+
 

--- a/deps-packaging/git/distfiles
+++ b/deps-packaging/git/distfiles
@@ -1,1 +1,1 @@
-5a982c3ef10cdafa249a188c334a16f0  git-2.13.7.tar.gz
+ed39361a3ae362c8af852d1a06992bc2  git-2.24.0.tar.gz

--- a/deps-packaging/libcurl-hub/cfbuild-libcurl-hub.spec
+++ b/deps-packaging/libcurl-hub/cfbuild-libcurl-hub.spec
@@ -1,4 +1,4 @@
-%define curl_version 7.66.0
+%define curl_version 7.67.0
 
 Summary: CFEngine Build Automation -- libcurl
 Name: cfbuild-libcurl-hub
@@ -93,6 +93,7 @@ CFEngine Build Automation -- libcurl
 %prefix/lib/pkgconfig
 
 %changelog
+
 
 
 

--- a/deps-packaging/libcurl-hub/distfiles
+++ b/deps-packaging/libcurl-hub/distfiles
@@ -1,1 +1,1 @@
-8cb2898a9adc106075ac3cdc2b965bf6  curl-7.66.0.tar.gz
+e91e478a7fbd8c6dc1636b11cdd3c1f5  curl-7.67.0.tar.gz

--- a/deps-packaging/libcurl/cfbuild-libcurl.spec
+++ b/deps-packaging/libcurl/cfbuild-libcurl.spec
@@ -1,4 +1,4 @@
-%define curl_version 7.66.0
+%define curl_version 7.67.0
 
 Summary: CFEngine Build Automation -- libcurl
 Name: cfbuild-libcurl
@@ -98,6 +98,7 @@ CFEngine Build Automation -- libcurl
 %prefix/lib/pkgconfig
 
 %changelog
+
 
 
 

--- a/deps-packaging/libcurl/distfiles
+++ b/deps-packaging/libcurl/distfiles
@@ -1,1 +1,1 @@
-8cb2898a9adc106075ac3cdc2b965bf6  curl-7.66.0.tar.gz
+e91e478a7fbd8c6dc1636b11cdd3c1f5  curl-7.67.0.tar.gz

--- a/deps-packaging/postgresql-hub/cfbuild-postgresql-hub.spec
+++ b/deps-packaging/postgresql-hub/cfbuild-postgresql-hub.spec
@@ -1,4 +1,4 @@
-%define postgresql_version 9.6.15
+%define postgresql_version 9.6.16
 
 Summary: CFEngine Build Automation -- postgresql
 Name: cfbuild-postgresql
@@ -206,6 +206,7 @@ CFEngine Build Automation -- postgresql -- dev files
 %{prefix}/lib/pkgconfig/*
 
 %changelog
+
 
 
 

--- a/deps-packaging/postgresql-hub/distfiles
+++ b/deps-packaging/postgresql-hub/distfiles
@@ -1,1 +1,1 @@
-7de685822793a2f6ce44a11729dba4e0  postgresql-9.6.15.tar.gz
+f2cc048133744ffb2f0ab0283a835320  postgresql-9.6.16.tar.gz

--- a/deps-packaging/postgresql-hub/source
+++ b/deps-packaging/postgresql-hub/source
@@ -1,1 +1,1 @@
-https://ftp.postgresql.org/pub/source/v9.6.15/
+https://ftp.postgresql.org/pub/source/v9.6.16/


### PR DESCRIPTION
Update libcurl-hub from 7.66.0 to 7.67.0
Update git from 2.13.7 to 2.24.0
Update postgresql-hub from 9.6.15 to 9.6.16
Update libcurl from 7.66.0 to 7.67.0