### PR TITLE
ENT-4981 Add build number to coreos and generic tarballs

### DIFF
--- a/build-scripts/package
+++ b/build-scripts/package
@@ -181,7 +181,7 @@ case "$PACKAGING" in
             tar czf "$P/coreos/cfengine3.img.tar.gz" --sparse -C "$(dirname "$IMAGE")" "$(basename "$IMAGE")"
             rm "$IMAGE"
             # create tarball containing everything
-            NAME="$PKG-$VERSION.$ARCH.fs-img.pkg"
+            NAME="$PKG-$VERSION-$RPM_RELEASE.$ARCH.fs-img.pkg"
             TARBALL="$BASEDIR/$PKG/RPMS/$NAME.tar.gz"
             mv "$P/coreos" "$P/$NAME"
             tar czvf "$TARBALL" -C "$P" "$NAME" > "$TARBALL.filelist"


### PR DESCRIPTION
Only coreos tarballs are modified here in the 3.12.x port of the
original commit because generic tarballs don't even have the safe
prefix from commit 631125b7cba here.

(cherry picked from commit 8dc9c707574f2caba6c763b135d513f27996097f)

Conflicts:
  build-scripts/package