### PR TITLE
Do not stop postinstall script if 'systemctl enable' fails

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -911,6 +911,8 @@ if ! is_upgrade; then
     # Reload systemd config to pick up newly installed units
     /bin/systemctl daemon-reload > /dev/null 2>&1
     # Enable service units
+    # Enabling services is OK to fail (they can be masked, for example)
+    set +e
     /bin/systemctl enable cf-apache.service > /dev/null 2>&1
     /bin/systemctl enable cf-execd.service > /dev/null 2>&1
     /bin/systemctl enable cf-serverd.service > /dev/null 2>&1
@@ -919,6 +921,7 @@ if ! is_upgrade; then
     /bin/systemctl enable cf-postgres.service > /dev/null 2>&1
     /bin/systemctl enable cf-hub.service > /dev/null 2>&1
     /bin/systemctl enable cfengine3.service > /dev/null 2>&1
+    set -e
   else
     case "`os_type`" in
       redhat)

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -78,10 +78,13 @@ case `os_type` in
       # Reload systemd config to pick up newly installed units
       /bin/systemctl daemon-reload > /dev/null 2>&1
       # Enable service units
+      # Enabling services is OK to fail (they can be masked, for example)
+      set +e
       /bin/systemctl enable cf-execd.service > /dev/null 2>&1
       /bin/systemctl enable cf-serverd.service > /dev/null 2>&1
       /bin/systemctl enable cf-monitord.service > /dev/null 2>&1
       /bin/systemctl enable cfengine3.service > /dev/null 2>&1
+      set -e
     else
       case `os_type` in
         redhat)


### PR DESCRIPTION
If some service is masked, for example, 'systemctl enable' would
fail on it. And since our scriptlets are using 'set -e', they
exit on every error. We need to disable this behavior for the
part doing 'systemctl enable' on our services.

Ticket: ENT-5188
Changelog: 'systemctl enable' failure no longer stops the postinstall package scripts