### PR TITLE
ENT-5255 Made Mission Portal application log relocation more resilient

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -111,7 +111,9 @@ chown $MP_APACHE_USER:$MP_APACHE_USER $PREFIX/httpd/htdocs/tmp
 chown -R $MP_APACHE_USER:$MP_APACHE_USER $PREFIX/httpd/htdocs/api/static
 
 if [ -d "$PREFIX/httpd/htdocs/application/logs" ]; then
-    mv "$PREFIX/httpd/htdocs/application/logs" "$PREFIX/httpd/logs/application"
+    mkdir -p "$PREFIX/httpd/logs/application/logs"
+    mv "$PREFIX/httpd/htdocs/application/logs/"* "$PREFIX/httpd/logs/application/logs/"
+    rm -rf "$PREFIX/httpd/htdocs/application/logs"
 fi
 if [ ! -d "$PREFIX/httpd/logs/application" ]; then
     mkdir -p "$PREFIX/httpd/logs/application"


### PR DESCRIPTION
Need to make this safer for cases where the target directory is
already present and has files.

Ticket: ENT-5255
Changelog: title

merge together
https://github.com/cfengine/buildscripts/pull/661
https://github.com/cfengine/masterfiles/pull/1645
https://github.com/cfengine/mission-portal/pull/993