### PR TITLE
Do not use '--with-tokyocabinet=/usr' when building tarballs

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -39,7 +39,7 @@ cd $BASEDIR/core
 rm cfengine-3.*.tar.gz || true
 git rev-parse HEAD > $BASEDIR/output/core-commitID
 # Configure in order to run "make dist", deleted later.
-./configure --with-tokyocabinet=/usr
+./configure
 make dist
 mv cfengine-3.*.tar.gz $BASEDIR/output/tarballs/
 make distclean


### PR DESCRIPTION
We need to run './configure' to be able to run 'make dist' to get
a tarball. And './configure' requires one of LMDB or TokyoCabinet
to be installed (inlc. devel files). But we might as well just
install 'liblmdb-dev' on our bootstrap machines and let the
defaults do their job.