### PR TITLE
Adapt inventory refresh in the postinstall script

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -893,7 +893,7 @@ fi
 
 su $MP_APACHE_USER -c "$PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php cli_tasks migrate_ldap_settings https://localhost/ldap"
 
-$PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php cli_tasks inventory_refresh
+$PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php cli_tasks inventory_variables_refresh
 
 # Shut down Apache and Postgres again, because we may need them to start through
 # systemd later.


### PR DESCRIPTION
There is a new 'inventory_variables_refresh' task introduced in
cfengine/mission-portal@d2550582. We no longer need to do full
inventory refresh.
    
Ticket: ENT-4864
Changelog: None
