### PR TITLE
Tighten Postgresql access permissions (3.15.x)

### DIFF
--- a/deps-packaging/postgresql/cfbuild-postgresql.spec
+++ b/deps-packaging/postgresql/cfbuild-postgresql.spec
@@ -39,9 +39,10 @@ rm -rf ${RPM_BUILD_ROOT}
 $MAKE install DESTDIR=${RPM_BUILD_ROOT}
 $MAKE -C contrib install DESTDIR=${RPM_BUILD_ROOT}
 patch -d ${RPM_BUILD_ROOT}%{prefix}/share/postgresql/ -o postgresql.conf.cfengine < ${RPM_BUILD_ROOT}/../../SOURCES/postgresql.conf.cfengine.patch
+patch ${RPM_BUILD_ROOT}%{prefix}/share/postgresql/postgresql.conf.sample ${RPM_BUILD_ROOT}/../../SOURCES/postgresql.conf.sample.patch
 chmod --reference ${RPM_BUILD_ROOT}%{prefix}/share/postgresql/postgresql.conf.sample ${RPM_BUILD_ROOT}%{prefix}/share/postgresql/postgresql.conf.cfengine
 chown --reference ${RPM_BUILD_ROOT}%{prefix}/share/postgresql/postgresql.conf.sample ${RPM_BUILD_ROOT}%{prefix}/share/postgresql/postgresql.conf.cfengine
-
+patch ${RPM_BUILD_ROOT}%{prefix}/share/postgresql/pg_hba.conf.sample ${RPM_BUILD_ROOT}/../../SOURCES/pg_hba.conf.sample.patch
 rm -f ${RPM_BUILD_ROOT}%{prefix}/lib/*.a
 
 %clean

--- a/deps-packaging/postgresql/debian/rules
+++ b/deps-packaging/postgresql/debian/rules
@@ -28,8 +28,10 @@ install: build
 	make -C contrib install DESTDIR=$(CURDIR)/debian/tmp
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/postgresl.conf.cfengine
 	patch -d $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/ -o postgresql.conf.cfengine < $(CURDIR)/postgresql.conf.cfengine.patch
+	patch $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/postgresql.conf.sample $(CURDIR)/postgresql.conf.sample.patch
 	chmod --reference $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/postgresql.conf.sample $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/postgresql.conf.cfengine
 	chown --reference $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/postgresql.conf.sample $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/postgresql.conf.cfengine
+	patch $(CURDIR)/debian/tmp$(PREFIX)/share/postgresql/pg_hba.conf.sample $(CURDIR)/pg_hba.conf.sample.patch
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/lib/*.a
 
 binary-indep: build install

--- a/deps-packaging/postgresql/pg_hba.conf.sample.patch
+++ b/deps-packaging/postgresql/pg_hba.conf.sample.patch
@@ -1,0 +1,18 @@
+--- pg_hba.conf.sample	2019-11-11 16:03:10.000000000 -0600
++++ pg_hba.conf.socket-only	2020-01-21 13:22:44.119994084 -0600
+@@ -79,11 +79,11 @@
+ @remove-line-for-nolocal@# "local" is for Unix domain socket connections only
+ @remove-line-for-nolocal@local   all             all                                     @authmethodlocal@
+ # IPv4 local connections:
+-host    all             all             127.0.0.1/32            @authmethodhost@
++#host    all             all             127.0.0.1/32            @authmethodhost@
+ # IPv6 local connections:
+-host    all             all             ::1/128                 @authmethodhost@
++#host    all             all             ::1/128                 @authmethodhost@
+ # Allow replication connections from localhost, by a user with the
+ # replication privilege.
+ @remove-line-for-nolocal@local   replication     all                                     @authmethodlocal@
+-host    replication     all             127.0.0.1/32            @authmethodhost@
+-host    replication     all             ::1/128                 @authmethodhost@
++#host    replication     all             127.0.0.1/32            @authmethodhost@
++#host    replication     all             ::1/128                 @authmethodhost@

--- a/deps-packaging/postgresql/postgresql.conf.cfengine.patch
+++ b/deps-packaging/postgresql/postgresql.conf.cfengine.patch
@@ -26,7 +26,7 @@
 -#unix_socket_group = ''			# (change requires restart)
 -#unix_socket_permissions = 0777		# begin with 0 to use octal notation
 +unix_socket_group = 'cfpostgres'			# (change requires restart)
-+unix_socket_permissions = 0770		# begin with 0 to use octal notation
++unix_socket_permissions = 0660		# begin with 0 to use octal notation
  					# (change requires restart)
  #bonjour = off				# advertise server via Bonjour
  					# (change requires restart)

--- a/deps-packaging/postgresql/postgresql.conf.sample.patch
+++ b/deps-packaging/postgresql/postgresql.conf.sample.patch
@@ -1,0 +1,13 @@
+--- postgresql.conf.sample	2019-11-11 16:03:10.000000000 -0600
++++ postgresql.conf.sample	2020-01-21 13:07:32.232910689 -0600
+@@ -65,8 +65,8 @@
+ #superuser_reserved_connections = 3	# (change requires restart)
+ #unix_socket_directories = '/tmp'	# comma-separated list of directories
+ 					# (change requires restart)
+-#unix_socket_group = ''			# (change requires restart)
+-#unix_socket_permissions = 0777		# begin with 0 to use octal notation
++unix_socket_group = 'cfpostgres'			# (change requires restart)
++unix_socket_permissions = 0660		# begin with 0 to use octal notation
+ 					# (change requires restart)
+ #bonjour = off				# advertise server via Bonjour
+ 					# (change requires restart)


### PR DESCRIPTION
- Removed executable bit from unix socket
- Removed local TCP access rules

Ticket: ENT-2747
Changelog: Commit
(cherry picked from commit dfca1ffde2953db4b70bd7ba0d3bdcce201eb282)
Signed-off-by: Ihor Aleksandrychiev <ihor.aleksandrychiev@northern.tech>

Merge together:
https://github.com/cfengine/buildscripts/pull/680
https://github.com/cfengine/mission-portal/pull/1025
https://github.com/cfengine/nova/pull/1608