### PR TITLE
Fall back to 'pg_ctl stop -m fast' if '-m smart' fails

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -906,7 +906,7 @@ $PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php cli_tasks inventory_var
 # Shut down Apache and Postgres again, because we may need them to start through
 # systemd later.
 $PREFIX/httpd/bin/apachectl stop
-(cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart")
+(cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart" || su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m fast")
 
 ##
 # ENT-3921: Make bin/runalerts.php executable


### PR DESCRIPTION
The default timeout for stopping PostgreSQL with '-m smart'
(which tries to wait for connections to terminate) is 60
seconds. For some reason that is not always enough in the hub
postinstall scriptlet. So let's give it 120 seconds and fall back
to '-m fast' which terminates the connections (gracefully).