### PR TITLE
[3.12.x] Fall back to 'pg_ctl stop -m fast' if '-m smart' fails

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -855,7 +855,7 @@ $PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/index.php cli_tasks inventory_ref
 # Shut down Apache and Postgres again, because we may need them to start through
 # systemd later.
 $PREFIX/httpd/bin/apachectl stop
-(cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart")
+(cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart" || su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m fast")
 
 #
 # Delete temporarily stored key.


### PR DESCRIPTION
For some reason PostgreSQL fails to stop with '-m smart' (which
tries to wait for connections to be terminated) in the hub
postinstall scriptlet. So let's fall back to '-m fast' which
terminates the connections (gracefully).

(cherry picked from commit 5f01f5ca6ab671cf2d94d5e58a2725b09466446d)