### PR TITLE
Do not copy repository definitions to a test chroot

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -367,6 +367,9 @@ EOF
 - /run/*
 + /run
 - /var/lib/lxcfs
+- /etc/yum.repos.d/*
+- /etc/zypp/repos.d/*
+- /etc/apt/*
 EOF
       ;;
   esac


### PR DESCRIPTION
This can potentially speed up the packaging tests because the
packaging tools will not go to the default repositories and fetch
metadata for them.