### PR TITLE
Preserve state/pg/data/pg_arch directory on upgrades

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -391,6 +391,14 @@ init_postgres_dir()
       cp -a "$BACKUP_DIR/data/recovery.conf" "$PREFIX/state/pg/data/recovery.conf"
       chown cfpostgres "$PREFIX/state/pg/data/recovery.conf"
     fi
+
+    # Make sure the 'pg_arch' directory exists if it existed before the
+    # upgrade. This directory is used in HA setups. Files from the directory
+    # should be discarded so we can just recreate the directory if needed.
+    if [ -d "$BACKUP_DIR/data/pg_arch" ]; then
+      mkdir "$PREFIX/state/pg/data/pg_arch"
+      chown cfpostgres:cfpostgres "$PREFIX/state/pg/data/pg_arch"
+    fi
   fi
 }
 


### PR DESCRIPTION
This directory is used by HA setups for speeding up recovery and
re-synchronizations. If it existed before the upgrade, it should
be recreated after it.

Ticket: ENT-5352
Changelog: None