### PR TITLE
Fix permissions on /opt/cfengine for FR cftransport user

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -149,7 +149,7 @@ export PKEY="\${PKEY}"
 export GIT_SSH="\${SCRIPT_DIR}/ssh-wrapper.sh"
 EOHIPPUS
   chown -R $MP_APACHE_USER:$MP_APACHE_USER $DCWORKDIR
-  chmod -R 700 $DCWORKDIR
+  chmod -R 700 $DCWORKDIR/userworkdir
   if [ ! -f /usr/bin/curl ]; then
     ln -sf $PREFIX/bin/curl /usr/bin/curl
   fi


### PR DESCRIPTION
chmod 700 on $DCWORKDIR causes problems with Federated Reporting
cftransport user ssh permissions.

Ticket: ENT-5438
Changelog: title