### PR TITLE
Install JavaScript dependencies in bootstrap job

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -84,3 +84,16 @@ while [ ! -z "$(eval "echo \$GIT_COMMIT_$i")" ] ; do
 	fi
 	i=$((i+1))
 done
+
+(
+if test -f "$BASEDIR/mission-portal/scripts/package.json"; then
+  cd $BASEDIR/mission-portal/scripts
+  # install dependencies from npmjs
+  npm i --prefix $BASEDIR/mission-portal/scripts/
+  # make a build of jquery-ui from sources
+  cd node_modules/jquery-ui
+  npm i --prefix $BASEDIR/mission-portal/scripts/node_modules/jquery-ui
+  nodejs node_modules/grunt-cli/bin/grunt sizer concat
+  rm -rf ./node_modules
+fi
+)


### PR DESCRIPTION
We started to fetch JS dependencies from NPM (https://www.npmjs.com/) and we need to install them in bootsrap job
Ticket: ENT-5458