### PR TITLE
Make sure version information is available when building tarballs

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -3,6 +3,7 @@
 . `dirname "$0"`/functions
 . detect-environment
 . compile-options
+. version
 
 get_GH_PR_info() {
     # Args:


### PR DESCRIPTION
So that the tarballs (some of which we also release) can have
proper names and version information.

Ticket: ENT-5429
Changelog: None

Merge together:
https://github.com/cfengine/masterfiles/pull/1737
https://github.com/cfengine/buildscripts/pull/726