### PR TITLE
Copied jquery-ui images to dist directory

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -94,6 +94,7 @@ if test -f "$BASEDIR/mission-portal/public/scripts/package.json"; then
   cd node_modules/jquery-ui
   npm i --prefix $BASEDIR/mission-portal/public/scripts/node_modules/jquery-ui
   nodejs node_modules/grunt-cli/bin/grunt sizer concat
+  cp -r ./themes/base/images/ ./dist/
   rm -rf ./node_modules
 fi
 )

--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -108,6 +108,7 @@ case "$JOB" in
             cd node_modules/jquery-ui
             npm i
             nodejs node_modules/grunt-cli/bin/grunt sizer concat
+            cp -r ./themes/base/images/ ./dist/
             rm -rf ./node_modules
         fi
         )


### PR DESCRIPTION
ChangeLog: None
Jquery UI grunt tasks miss images copying to dist and images are required to be into dist in css styles