### PR TITLE
[3.12.x] Make sure version information is available when building tarballs

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -3,6 +3,7 @@
 . `dirname "$0"`/functions
 . detect-environment
 . compile-options
+. version
 
 
 mkdir -p $BASEDIR/output/tarballs


### PR DESCRIPTION
So that the tarballs (some of which we also release) can have
proper names and version information.

Ticket: ENT-5429
Changelog: None
(cherry picked from commit 2169d9a3b5dd1f5dc53d659371406a06cfaf7fae)