### PR TITLE
Use GCC 6 on new AIX 7.1 VMs

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -91,6 +91,9 @@ export_variables ()
     # TODO: remove the generic PATH setting completely,
     #       all should be under conditionals
     case $UNAME_S in
+        AIX)
+            # We need to use GCC6 on new AIX 7 VMs (AIX 5 doesn't have the folder).
+            PATH="/opt/freeware/gcc6/bin/:$PATH" ;;
         SunOS)
             # Currently we rely strongly on OpenCSW packages.
             PATH="/opt/csw/bin:/usr/xpg4/bin:$PATH"  ;;


### PR DESCRIPTION
The new IBM CECC VMs have GCC 8 as the default compiler
(yum install gcc), but it is broken or at least doesn't work
properly with our specific codebase because it produces binaries
that fail in weird ways. Thus we need to use GCC 6 (from the
'gcc6' package), but that is installed under a non-standard path
which we thus need to add to $PATH for things to work.

Ticket: ENT-5418