### PR TITLE
Enabled mbstring PHP extension

### DIFF
--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -33,6 +33,9 @@ fi
   --with-pdo-pgsql=%{prefix} \
   --with-iconv \
   --with-zlib=%{prefix} \
+  --with-libmbfl=%{prefix} \
+  --enable-mbstring \
+  --disable-mbregex \
   --without-fpm-user \
   --without-fpm-group \
   --without-fpm-systemd \

--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -21,6 +21,9 @@ build-stamp:
 --with-pdo-pgsql=$(PREFIX) \
 --with-iconv \
 --with-zlib=$(PREFIX) \
+--with-libmbfl=$(PREFIX) \
+--enable-mbstring \
+--disable-mbregex \
 --without-fpm-user \
 --without-fpm-group \
 --without-fpm-systemd \


### PR DESCRIPTION
ChangeLog: Title

mbstring functions are required in PHP dependencies.