### PR TITLE
[3.12.x] Use system-provided OpenSSL on RHEL 8

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -51,6 +51,13 @@ case "$OS_FAMILY" in
     LDFLAGS="-L$BUILDPREFIX/lib -Wl,-R$BUILDPREFIX/lib"
     ;;
 esac
+
+# We don't bundle OpenSSL on RHEL 8 (and newer in the future) so we need to pull
+# it from /usr/lib64.
+if [ "$OS" = "rhel" ] && expr "$OS_VERSION" ">=" "8" >/dev/null
+then
+  LDFLAGS="$LDFLAGS -L/usr/lib64"
+fi
 export LDFLAGS
 
 # For Debian builds, which do not automatically inherit build flags
@@ -74,9 +81,15 @@ case "$OS_FAMILY" in
     solaris|aix)  var_append DEPS "libgcc" ;;
 esac
 
-# FIXME: Why do we need zlib?
-# ANSWER: Openssl uses it optionally, TODO DISABLE
-var_append DEPS "zlib $EMBEDDED_DB openssl pcre"
+# We don't bundle OpenSSL on RHEL 8 (and newer in the future)
+if [ "$OS" = "rhel" ] && expr "$OS_VERSION" ">=" "8" >/dev/null
+then
+  var_append DEPS "$EMBEDDED_DB pcre"
+else
+  # FIXME: Why do we need zlib?
+  # ANSWER: Openssl uses it optionally, TODO DISABLE
+  var_append DEPS "zlib $EMBEDDED_DB openssl pcre"
+fi
 
 # libsasl needed for solaris
 case "$OS_FAMILY" in

--- a/deps-packaging/libcurl/cfbuild-libcurl.spec
+++ b/deps-packaging/libcurl/cfbuild-libcurl.spec
@@ -18,9 +18,16 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n curl-%{curl_version}
 
+# we don't bundle OpenSSL on RHEL 8 (and newer in the future)
+%if %{?rhel}%{!?rhel:0} > 7
+%define ssl_prefix /usr
+%else
+%define ssl_prefix %{prefix}
+%endif
+
 ./configure \
     --with-sysroot=%{prefix} \
-    --with-ssl=%{prefix} \
+    --with-ssl=%{ssl_prefix} \
     --with-zlib=%{prefix} \
     --disable-ldap \
     --disable-ldaps \

--- a/deps-packaging/openldap/cfbuild-openldap.spec
+++ b/deps-packaging/openldap/cfbuild-openldap.spec
@@ -18,7 +18,12 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n openldap-%{openldap_version}
 
+# we don't bundle OpenSSL on RHEL 8 (and newer in the future)
+%if %{?rhel}%{!?rhel:0} > 7
+CPPFLAGS=-I%{buildprefix}/include:/usr/include
+%else
 CPPFLAGS=-I%{buildprefix}/include
+%endif
 
 #
 # glibc-2.8 errorneously hides peercred(3) under #ifdef __USE_GNU.

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -13,6 +13,12 @@ BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3, cfengine-community
 Requires: coreutils gzip
 
+# we don't bundle OpenSSL on RHEL 8 (and newer in the future)
+%if %{?rhel}%{!?rhel:0} > 7
+Requires: libssl.so.1.1()(64bit) libssl.so.1.1(OPENSSL_1_1_0)(64bit) libssl.so.1.1(OPENSSL_1_1_1)(64bit)
+Requires: libcrypto.so.1.1()(64bit) libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)
+%endif
+
 AutoReqProv: no
 
 %if %{?with_debugsym}%{!?with_debugsym:0}


### PR DESCRIPTION
RHEL 8 version of OpenSSL ships with a downstream patch that adds
the EVP_KDF API which is not part of any stable release of
OpenSSL yet. This new API is required by some of the PAM modules
commonly installed on RHEL 8 systems and is thus required if we
want to use PAM from CFEngine binaries (for 'users'
promises). Instead of shipping our own version of OpenSSL with a
similar big EVP_KDF patch like Red Hat does, let's use their
version of OpenSSL which is definitely installed on every RHEL 8
system (required by many core components).

Ticket: ENT-5564
Changelog: RHEL 8 CFEngine packages now rely on system OpenSSL libraries
(cherry picked from commit 3a3ad02670d397a6b94a3960b1266299a3ad1a4c)