### PR TITLE
Keep going if 'kill' fails on httpd processes left behind

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -953,11 +953,11 @@ $PREFIX/httpd/bin/apachectl stop
 # sure none are left behind.
 httpds="$(ps -eo pid,cmd|awk '/\/var\/cfengine\/httpd\/bin\/httpd/ { print $1; }')"
 if [ -n "$httpds" ]; then
-  echo "$httpds" | xargs kill
+  echo "$httpds" | xargs kill || true "kill failed, but moving on"
   sleep 1s
   httpds="$(ps -eo pid,cmd|awk '/\/var\/cfengine\/httpd\/bin\/httpd/ { print $1; }')"
   if [ -n "$httpds" ]; then
-    echo "$httpds" | xargs kill -9
+    echo "$httpds" | xargs kill -9 || true "kill -9 failed, but moving on"
   fi
 fi
 


### PR DESCRIPTION
They may have terminated in the meantime which is a good thing.

Ticket: ENT-6103
Changelog: None