### PR TITLE
Revert LMDB back to version 0.9.24

### DIFF
--- a/deps-packaging/lmdb/cfbuild-lmdb.spec
+++ b/deps-packaging/lmdb/cfbuild-lmdb.spec
@@ -1,4 +1,4 @@
-%define lmdb_version 0.9.26
+%define lmdb_version 0.9.24
 
 Summary: CFEngine Build Automation -- lmdb
 Name: cfbuild-lmdb

--- a/deps-packaging/lmdb/distfiles
+++ b/deps-packaging/lmdb/distfiles
@@ -1,1 +1,1 @@
-f21ba80678bf45f2bef5a49a9a1cd77e  openldap-LMDB_0.9.26.tar.gz
+f5a5d499b3a486a0948db36235950a8a  openldap-LMDB_0.9.24.tar.gz

--- a/deps-packaging/lmdb/source
+++ b/deps-packaging/lmdb/source
@@ -1,1 +1,1 @@
-https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.26/
+https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.24/


### PR DESCRIPTION
For an unknown reason, 0.9.26 causes a spurious failure during
bootstrap on Ubuntu 14 hubs.