### PR TITLE
Updated dependency markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,18 @@ File `install-dependencies` and the relevant subdirectories in `deps-packaging` 
 
 | CFEngine version                                                                 | 3.12.x | 3.15.x | master | Notes                    |
 | -------------------------------------------------------------------------------- | ------ | ------ | ------ | ------------------------ |
+| [diffutils](https://ftpmirror.gnu.org/diffutils/)                                |        |        | 3.7    |                          |
 | [SASL2](https://cyrusimap.org/mediawiki/index.php/Downloads)                     | 2.1.27 | 2.1.27 | 2.1.27 | Solaris Enterprise agent |
 | [libacl](http://download.savannah.gnu.org/releases/acl/)                         | 2.2.53 | 2.2.53 | 2.2.53 |                          |
 | [libattr](http://download.savannah.gnu.org/releases/attr/)                       | 2.4.48 | 2.4.48 | 2.4.48 |                          |
-| [libcurl](http://curl.haxx.se/download.html)                                     | 7.70.0 | 7.70.0 | 7.68.0 |                          |
+| [libcurl](http://curl.haxx.se/download.html)                                     | 7.72.0 | 7.72.0 | 7.72.0 |                          |
 | [libgnurx](http://www.gnu.org/software/rx/rx.html)                               | 2.5.1  | 2.5.1  | 2.5.1  | Windows Enterprise agent |
 | [libiconv](http://ftp.gnu.org/gnu/libiconv/)                                     | 1.16   | 1.16   | 1.16   | Needed by libxml2        |
 | [libxml2](http://xmlsoft.org/sources/)                                           | 2.9.10 | 2.9.10 | 2.9.10 |                          |
-| [libyaml](http://pyyaml.org/wiki/LibYAML)                                        | 0.2.4  | 0.2.4  | 0.2.2  |                          |
-| [LMDB](https://github.com/LMDB/lmdb/)                                            | 0.9.24 | 0.9.24 | 0.9.24 |                          |
-| [OpenLDAP](http://www.openldap.org/software/download/OpenLDAP/openldap-release/) | 2.4.50 | 2.4.50 | 2.4.49 | Enterprise agent only    |
-| [OpenSSL](http://openssl.org/)                                                   | 1.1.1g | 1.1.1g | 1.1.1f |                          |
+| [libyaml](http://pyyaml.org/wiki/LibYAML)                                        | 0.2.5  | 0.2.5  | 0.2.5  |                          |
+| [LMDB](https://github.com/LMDB/lmdb/)                                            | 0.9.26 | 0.9.26 | 0.9.24 |                          |
+| [OpenLDAP](http://www.openldap.org/software/download/OpenLDAP/openldap-release/) | 2.4.53 | 2.4.53 | 2.4.53 | Enterprise agent only    |
+| [OpenSSL](http://openssl.org/)                                                   | 1.1.1g | 1.1.1g | 1.1.1g |                          |
 | [PCRE](http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/)                  | 8.44   | 8.44   | 8.44   |                          |
 | [pthreads-w32](ftp://sourceware.org/pub/pthreads-win32/)                         | 2-9-1  | 2-9-1  | 2-9-1  | Windows Enterprise agent |
 | [zlib](http://www.zlib.net/)                                                     | 1.2.11 | 1.2.11 | 1.2.11 |                          |
@@ -103,13 +104,13 @@ File `install-dependencies` and the relevant subdirectories in `deps-packaging` 
 
 | CFEngine version                                    | 3.12.x | 3.15.x | master |
 | --------------------------------------------------- | ------ | ------ | ------ |
-| [Apache](http://httpd.apache.org/)                  | 2.4.43 | 2.4.43 | 2.4.41 |
+| [Apache](http://httpd.apache.org/)                  | 2.4.43 | 2.4.46 | 2.4.46 |
 | [APR](https://apr.apache.org/)                      | 1.7.0  | 1.7.0  | 1.7.0  |
 | [apr-util](https://apr.apache.org/)                 | 1.6.1  | 1.6.1  | 1.6.1  |
-| [Git](https://www.kernel.org/pub/software/scm/git/) | 2.26.2 | 2.26.2 | 2.25.1 |
-| [PHP](http://php.net/)                              | 7.2.30 | 7.4.5  | 7.4.2  |
-| [PostgreSQL](http://www.postgresql.org/)            | 10.12  | 12.2   | 12.2   |
-| [rsync](https://download.samba.org/pub/rsync/)      | 3.1.3  | 3.1.3  | 3.1.3  |
+| [Git](https://www.kernel.org/pub/software/scm/git/) | 2.28.0 | 2.28.0 | 2.28.0 |
+| [PHP](http://php.net/)                              | 7.2.34 | 7.4.10 | 7.4.10 |
+| [PostgreSQL](http://www.postgresql.org/)            | 10.14  | 12.4   | 12.4   |
+| [rsync](https://download.samba.org/pub/rsync/)      | 3.2.3  | 3.2.3  | 3.2.3  |
 
 * [MinGW-w64](http://sourceforge.net/projects/mingw-w64/) **OUTDATED** needed
   for [redmine#2932](https://dev.cfengine.com/issues/2932)


### PR DESCRIPTION
3.12.x commits:

3ac208b764e26e9571029e51d8da73cf95a6296e Upgrade rsync from 3.1.3 to 3.2.3 and migrate from ibiblio mirror to samba.org
b3804777ce3785f1d393bfeafc35ec7b73f3bee9 Update LMDB from 0.9.24 to 0.9.26 and migrate from github to gitlab.
82d9ff642869cc0ca6296f02c9cabe02a1d2cfc8 Update libcurl from 7.70.0 to 7.72.0
e24f8f167e380e1df47903444e0d10c1eb025686 Update php from 7.2.30 to 7.2.34
e82fa70d452eb510b04aa6321b9a7dd061d94bc6 Update postgresql from 10.12 to 10.14
ed77e79aed9e07a34082fe6a3e047f7b41f561f0 Update git from 2.26.2 to 2.28.0
a8e3170d867ce29f92f7683f7202498a66ae04c0 Update apache from 2.4.43 to 2.4.46
4713657bd7369f6804fed7e48c3b35af57b1c021 Update libcurl-hub from 7.70.0 to 7.72.0
fc6b4268fa68ba2172f2728c8a2e1f497ee45555 Update openldap from 2.4.50 to 2.4.53
17ee50c4ee1de9ad3975e4394f2b45798efe9c9f Update libyaml from 0.2.4 to 0.2.5

3.15.x commits:

db1f1698022c00b2937fe93b836242dab278493c Update postgresql from 12.2 to 12.4
5c8e124f32ec8e37ad90f14efc73192dd3080747 Upgrade rsync from 3.1.3 to 3.2.3 and migrate from ibiblio mirror to samba.org
b14f42ca2dc6b51c98deff9cb4f3e9cdfd1f222c Update LMDB from 0.9.24 to 0.9.26 and migrate from github to gitlab.
4a22474ff4e25182e629975f9f6cf8145d8fa4a1 Update libcurl from 7.70.0 to 7.72.0
9f31cdebebed23beb08ff09b666b7f1cc9f5dc15 Update php from 7.4.5 to 7.4.10
02b1f0463753229d0d73363d75fbe248d0e3486b Update git from 2.26.2 to 2.28.0
1ad45c1e9cb7638ee97ddcc54b837a1cb1a8a8ac Update apache from 2.4.43 to 2.4.46
32d3f2c5ab2a9781160cca6cbbe653d73460dc8c Update libcurl-hub from 7.70.0 to 7.72.0
2638396f4952f2a840274a52de0de4300b8421e6 Update openldap from 2.4.50 to 2.4.53
204633e283b1b97abb026c1e77c57341631460b9 Update libyaml from 0.2.4 to 0.2.5

master commits:

3e5c383c1691be56cc08563907308ccf7759c36d Revert LMDB back to version 0.9.24
e2bd2f545ffd7cbe726a1bf497c92d23e74e3017 Upgrade rsync from 3.1.3 to 3.2.3 and migrate from ibiblio mirror to samba.org
bbde1560e8f0237fc74641942672a8fd4db71c23 Update LMDB from 0.9.24 to 0.9.26 and migrate from github to gitlab.
ff18dd31e585469599c67bfad62d9554ae626c34 Update libcurl from 7.70.0 to 7.72.0
69d21d6e9150cf29043d524ce9197bcde7e3fe9b Update php from 7.4.6 to 7.4.10
8769cf3e6deb365703642a4be9b7e418e5be29c6 Update postgresql from 12.3 to 12.4
88e4754cde777f9a55c4a2e93feff0f239b84137 Update git from 2.27.0 to 2.28.0
0b94269dbb09125aa122b7b6ee19946e65fa2442 Update apache from 2.4.43 to 2.4.46
9b0494c52d48466c45bf6522250a00cae5c678f9 Update libcurl-hub from 7.70.0 to 7.72.0
9f51b290e2927bea52624180fdace471ff9cfe51 Update openldap from 2.4.50 to 2.4.53
9c5d29900304539ad692955dd6c9c6497960c353 Update libyaml from 0.2.2 to 0.2.5
4880ea6582ec8de0c579e48c8f2a55143e00d107 Update openssl from 1.1.1f to 1.1.1g