### PR TITLE
ENT-6783/3.12.x: Disabled TLSv1 by default for Mission Portal's web server

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -181,8 +181,8 @@ LogLevel warn
   # A more secure setting might be:
   # SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
 
-  # Some versions of SSL are known to be insecure
-  SSLProtocol all -SSLv2 -SSLv3
+  # Some versions of SSL and TLS are known to be insecure, so we disable them by default
+  SSLProtocol all -SSLv2 -SSLv3 -TLSv1
 
   SSLRandomSeed startup builtin
   SSLRandomSeed connect builtin


### PR DESCRIPTION

Ticket: ENT-6783
Changelog: None
(cherry picked from commit 1447ed7516eef3629b3295dbb5932e24045bcc1a)