### PR TITLE
DEBUG: Do not override options from --enable-debug

### DIFF
--- a/build-scripts/configure
+++ b/build-scripts/configure
@@ -82,9 +82,6 @@ case "$BUILD_TYPE" in
     ;;
   DEBUG)
     ARGS="$ARGS --enable-debug"
-    # Override the default "-g3 -O0" that comes with ./configure --enable-debug
-    # in order to reduce the size of the packages
-    CFLAGS="-g2 -O1 $CFLAGS"
     ;;
   CODE_COVERAGE)
     ARGS="$ARGS --enable-debug"


### PR DESCRIPTION
Because they actually produce binaries that can be debugged.