### PR TITLE
CFE-3518: Removed unused plugins directory (master)

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -107,10 +107,16 @@ chmod 755 $PREFIX/httpd
 chown -R $MP_APACHE_USER:$MP_APACHE_USER $PREFIX/httpd/htdocs
 chmod a+rx $PREFIX/httpd/htdocs/api/dc-scripts/*.sh
 
-# plugins directory, empty by default
-mkdir -p ${PREFIX}/plugins
-chown -R root:root ${PREFIX}/plugins
-chmod 700 ${PREFIX}/plugins
+#
+# Cleanup deprecated plugins directory
+#
+if ! rmdir $PREFIX/plugins 2> /dev/null; then
+    # CFE-3618
+    echo "$PREFIX/plugins has been removed from the default distribution, we \
+tried to clean up the unused directory but found it was not empty. Please \
+review your policy, if you believe this directory should remain part of the \
+default distribution, please open a ticket in the CFEngine bug tracker."
+fi
 
 #these directories should be write able by apache
 chown root:$MP_APACHE_USER $PREFIX/httpd/logs

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -25,11 +25,14 @@ if is_community; then
 fi
 
 #
-# Create a plugins directory if it doesnot exist
+# Cleanup deprecated plugins directory
 #
-if ! [ -d $PREFIX/plugins ]; then
-  mkdir -p $PREFIX/plugins
-  chmod 700 $PREFIX/plugins
+if ! rmdir $PREFIX/plugins 2> /dev/null; then
+    # CFE-3618
+    echo "$PREFIX/plugins has been removed from the default distribution, we \
+tried to clean up the unused directory but found it was not empty. Please \
+review your policy, if you believe this directory should remain part of the \
+default distribution, please open a ticket in the CFEngine bug tracker."
 fi
 
 if [ -f $PREFIX/bin/cf-twin ]; then


### PR DESCRIPTION
merge together: https://github.com/cfengine/masterfiles/pull/1956

The plugins directory has gone unused since it's introduction in 2013. This
change cleans up the plugins directory if it exists and is not empty. If it is
not empty the user is informed and asked to review their policy.

Ticket: CFE-3518
Changelog: Title