### PR TITLE
ENT-6448 Removed references to ldap-api repo

### DIFF
--- a/build-remote
+++ b/build-remote
@@ -239,7 +239,6 @@ checkout() {
       git clone --recursive $SOURCE/nova build/nova
       git clone --recursive $SOURCE/mission-portal build/mission-portal
       git clone --recursive $SOURCE/masterfiles build/masterfiles
-      git clone --recursive $SOURCE/ldap-api build/mission-portal/ldap
       ;;
     nova-3.6.x)
       VERSION=$BRANCH
@@ -257,11 +256,10 @@ checkout() {
 
     nova-cp)
       rsync -avr --exclude='workdir-*' $AUTOBUILD_PATH/ build/buildscripts  >>rsync.log
-      for d in core nova enterprise masterfiles mission-portal ldap-api
+      for d in core nova enterprise masterfiles mission-portal
       do
         rsync -avr $SOURCE/$d build  >>rsync.log
       done
-      mv build/ldap-api build/mission-portal/ldap
       ;;
 
     nova-stable)

--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -65,7 +65,7 @@ case "$JOB" in
         # (while we need PHP7 minimum)
         mv /home/travis/.phpenv /home/travis/.phpenv.del || true
 
-        for i in core nova enterprise mission-portal masterfiles ldap-api
+        for i in core nova enterprise mission-portal masterfiles
         do
             if [ -d $i ]
             then
@@ -96,7 +96,6 @@ case "$JOB" in
             fi
         done
 
-        mv -T ldap-api mission-portal/ldap
         (
         if test -f "mission-portal/public/scripts/package.json"; then
             # packages needed for installing Mission portal dependencies


### PR DESCRIPTION
ldap-api repo has been copied to mission-portal/ldap

Ticket: ENT-6448
Changelog: title

merge together:
https://github.com/cfengine/buildscripts/pull/815
https://github.com/cfengine/mission-portal/pull/1323
