### PR TITLE
Update release-monitoring project used for php7.1

### DIFF
--- a/deps-packaging/release-monitoring.json
+++ b/deps-packaging/release-monitoring.json
@@ -16,7 +16,7 @@
         "openldap":"2551",
         "openssl":"20334",
         "pcre":"2610",
-        "php":"19261",
+        "php":"188484",
         "postgresql":"20335",
         "pthreads-w32":"17517",
         "rsync":"4217",


### PR DESCRIPTION
Issue was that old "project" was deleted from release-monitoring.org website.
Reason for it is probably because php 7.1 is EOL according to php.net, so they
migrated from "(current) downloads" to "(unsupported historical) releases" page.


----

#