### PR TITLE
Update release-monitoring project for php

### DIFF
--- a/deps-packaging/release-monitoring.json
+++ b/deps-packaging/release-monitoring.json
@@ -16,7 +16,7 @@
         "openldap":"2551",
         "openssl":"2566",
         "pcre":"2610",
-        "php":"3627",
+        "php":"57896",
         "postgresql":"138114",
         "pthreads-w32":"17517",
         "rsync":"4217",


### PR DESCRIPTION
It was set to generic "php" before, which tries to download php8 now.
Now it's "php74".


----

#