### PR TITLE
ENT-6448 Removed references to ldap-api repo (3.15.x)

### DIFF
--- a/build-remote
+++ b/build-remote
@@ -244,7 +244,6 @@ checkout() {
       git clone --recursive $SOURCE/mission-portal build/mission-portal
       git clone --recursive $SOURCE/design-center build/design-center
       git clone --recursive $SOURCE/masterfiles build/masterfiles
-      git clone --recursive $SOURCE/ldap-api build/mission-portal/ldap
       ;;
     nova-3.6.x)
       VERSION=$BRANCH
@@ -264,11 +263,10 @@ checkout() {
 
     nova-cp)
       rsync -avr --exclude='workdir-*' $AUTOBUILD_PATH/ build/buildscripts  >>rsync.log
-      for d in core nova enterprise masterfiles design-center mission-portal ldap-api
+      for d in core nova enterprise masterfiles design-center mission-portal
       do
         rsync -avr $SOURCE/$d build  >>rsync.log
       done
-      mv build/ldap-api build/mission-portal/ldap
       ;;
 
     nova-stable)

--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -65,7 +65,7 @@ case "$JOB" in
         # (while we need PHP7 minimum)
         mv /home/travis/.phpenv /home/travis/.phpenv.del || true
 
-        for i in core nova enterprise mission-portal masterfiles ldap-api
+        for i in core nova enterprise mission-portal masterfiles
         do
             if [ -d $i ]
             then
@@ -96,7 +96,6 @@ case "$JOB" in
             fi
         done
 
-        mv -T ldap-api mission-portal/ldap
 
         # packages needed for autogen
         sudo apt-get install git autoconf automake m4 make bison flex \


### PR DESCRIPTION
ldap-api repo has been copied to mission-portal/ldap

Ticket: ENT-6448
Changelog: title
(cherry picked from commit 6a115b634d80f7a7fe969202d5a8c1ff7c3611c8)

Conflicts:
	build-remote
	build-scripts/travis


merge together
https://github.com/cfengine/mission-portal/pull/1336
https://github.com/cfengine/buildscripts/pull/826