### PR TITLE
CFE-3526 Skip 13_binary_path.cf test on travis due to missing binary

### DIFF
--- a/build-scripts/travis
+++ b/build-scripts/travis
@@ -176,7 +176,8 @@ case "$JOB" in
             ./05_processes/01_matching/promiser_match_is_correct.cf \
             ./07_packages/00*.cf \
             ./10_files/11_xml_edits \
-            ./25_cf-execd
+            ./25_cf-execd \
+            ./30_custom_promise_types/13_binary_path.cf
         set +e
         sudo ./testall \
             --bindir="$PREFIX/bin" \


### PR DESCRIPTION
custom_promise_binary is not available in travis CI for
mission-portal CI. The test will be run in core CI because
acceptance tests are run with core/travis-scripts/script.sh
instead of this buildscripts script.

Ticket: CFE-3526
Changelog: none