### PR TITLE
Use config.cache when producing core tarballs

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -40,7 +40,7 @@ cd $BASEDIR/core
 rm cfengine-3.*.tar.gz || true
 git rev-parse HEAD > $BASEDIR/output/core-commitID
 # Configure in order to run "make dist", deleted later.
-./configure
+./configure -C
 make dist
 mv cfengine-3.*.tar.gz $BASEDIR/output/tarballs/
 make distclean


### PR DESCRIPTION
To speed up './configure' in core which recursively runs
'./configure' in libntech and the two runs can share the cached
values.