### PR TITLE
TEMPORARY switch to PostgreSQL 13.x project in release-monitoring.org

### DIFF
--- a/deps-packaging/release-monitoring.json
+++ b/deps-packaging/release-monitoring.json
@@ -18,7 +18,7 @@
         "openssl":"2566",
         "pcre":"2610",
         "php":"3627",
-        "postgresql":"5601",
+        "postgresql":"210464",
         "pthreads-w32":"17517",
         "rsync":"4217",
         "sasl2":"13280",


### PR DESCRIPTION
NOTE TO SELF: remember to revert this commit on master after 3.18.x branched off!

Reason my to do it - to perform dependency updates on master.
They must follow to 3.18.x branch and be kept on master.

Otherwise, it would look silly to have deps on master with versions lower than
on a stabilisation branch :) And who knows how long will it take for PostgreSQL
guys to release a version 14.