### PR TITLE
ENT-6552 ensure hostname -f works inside chroot - 3.18.x

### DIFF
--- a/build-scripts/test-chroot
+++ b/build-scripts/test-chroot
@@ -4,6 +4,9 @@
 . detect-environment
 . compile-options
 
+# Ensure hostname -f is working (required for some tests)
+hostname -f || echo "127.0.0.1 $(hostname).example.com $(hostname)" >>/etc/hosts
+
 # We should already be root inside the chroot, so sudo is not necessary,
 # and "GAINROOT=env" might be faster.
 env GAINROOT=env UNSAFE_TESTS=1 $BASEDIR/buildscripts/build-scripts/test-on-thismachine


### PR DESCRIPTION
After reading some Internets, I believe that the way for hostname -f is supposed
to work is this:

* First, get IP of current hostname
* Second, get FQDN of this IP (consulting /etc/hosts, if necessary)

I'm not sure how it works outside of chroot, and why that way stopped working
inside of chroot in Ubuntu 20, but looks like adding this line makes hostname -f work.

(cherry picked from commit c9fbc0b121e7f4dd061e5f44381c641c9b494e0f)