### PR TITLE
Add localhost for 127.0.0.1 in /etc/hosts in test chroot

### DIFF
--- a/build-scripts/test-chroot
+++ b/build-scripts/test-chroot
@@ -5,7 +5,7 @@
 . compile-options
 
 # Ensure hostname -f is working (required for some tests)
-hostname -f || echo "127.0.0.1 $(hostname).example.com $(hostname)" >>/etc/hosts
+hostname -f || echo "127.0.0.1 localhost localhost.localdomain $(hostname).example.com $(hostname)" >>/etc/hosts
 
 # We should already be root inside the chroot, so sudo is not necessary,
 # and "GAINROOT=env" might be faster.


### PR DESCRIPTION
So that connections from 127.0.0.1 appear as connections coming
from localhost with reverse lookup.

Ticket: ENT-7362
Changelog: None