### PR TITLE
ENT-7554: Changed 4th octet in Windows package version to match package release number

### DIFF
--- a/build-scripts/package-msi
+++ b/build-scripts/package-msi
@@ -39,10 +39,10 @@ pre()
   # I couldn't find an easy way to dynamically find the path to this dll so hard-coded
   # it is. :(
   case "$ARCH" in
-    x86) 
+    x86)
         cp -a /usr/i686-w64-mingw32/lib/libwinpthread-1.dll $P/bin/libwinpthread-1.dll
         cp -a $BASEDIR/enterprise/libcfenterprise/cf.events.i686.dll $P/bin/cf.events.dll;;
-    x64) 
+    x64)
         cp -a /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll $P/bin/libwinpthread-1.dll
         cp -a $BASEDIR/enterprise/libcfenterprise/cf.events.x86_64.dll $P/bin/cf.events.dll;;
     *)


### PR DESCRIPTION
With this change the 4th octet in the version of the package meta data and
ultimately stored in the registry should match the release number in the package
filename.

Ticket: ENT-7554
Changelog: Title