### PR TITLE
[3.18.x] ENT-7898: Make sure files and dirs created in scriptlets have correct SELinux labels

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1023,4 +1023,10 @@ fi
 
 rm -f "$PREFIX/UPGRADED_FROM.txt"
 
+# Let's make sure all files and directories created above have correct SELinux
+# labels.
+if command -v restorecon >/dev/null; then
+  restorecon -iR /var/cfengine /opt/cfengine
+fi
+
 exit 0

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -140,4 +140,10 @@ fi
 
 rm -f "$PREFIX/UPGRADED_FROM.txt"
 
+# Let's make sure all files and directories created above have correct SELinux
+# labels.
+if command -v restorecon >/dev/null; then
+  restorecon -iR /var/cfengine /opt/cfengine
+fi
+
 exit 0


### PR DESCRIPTION
In particular, simple `mkdir` doesn't create the folder(s) with
correct SELinux label, unless the `-Z` option is used.

Ticket: ENT-7898
Changelog: VCS configuration now works on RHEL 8 hubs
(cherry picked from commit 5916ff7232c66406ff81ce9ed7a0f7cf9125773e)