### PR TITLE
ENT-7955 Use third arg in distfiles for pkg-cache if provided

### DIFF
--- a/deps-packaging/diffutils/01-mingw-signals.patch
+++ b/deps-packaging/diffutils/01-mingw-signals.patch
@@ -93,3 +93,16 @@
  # else
  #  define strcasecoll(a, b) strcasecmp (a, b) /* best we can do */
  # endif
+--- lib/cmpbuf.c.orig	2021-11-11 12:48:36.407735837 +0100
++++ lib/cmpbuf.c	2021-11-11 12:48:51.001818765 +0100
+@@ -32,6 +32,10 @@
+ # define SSIZE_MAX TYPE_MAXIMUM (ssize_t)
+ #endif
+
++#ifndef SA_RESTART
++# define SA_RESTART 0
++#endif
++
+ #undef MIN
+ #define MIN(a, b) ((a) <= (b) ? (a) : (b))
+

--- a/deps-packaging/pkg-get-src
+++ b/deps-packaging/pkg-get-src
@@ -119,6 +119,7 @@ get_src()
     exec <"$DISTFILE"
     read CHECKSUM FILENAME OPTS
 
+    [ -n "$OPTS" ] && FILENAME="$OPTS" # rename file if third arg is provided
     local_filename=`pkg-cache listfile $FILENAME`  ||  true
 
     if [ -f "$local_filename" ]  &&  checksum "$local_filename" "$CHECKSUM"


### PR DESCRIPTION
For sourceforge we needed the download URL and resulting filename
to be different. This commit fixes the filename provided to pkg-cache.

Ticket: ENT-7955
Changelog: none