### PR TITLE
ENT-7966: Added creation of postgresql.log to nova hub package build (3.15)

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -117,8 +117,8 @@ cp %{_basedir}/nova/db/schema.sql $RPM_BUILD_ROOT%prefix/share/db/
 cp %{_basedir}/nova/db/schema_settings.sql $RPM_BUILD_ROOT%prefix/share/db/
 cp %{_basedir}/nova/db/ootb_settings.sql $RPM_BUILD_ROOT%prefix/share/db/
 cp %{_basedir}/nova/db/ootb_import.sql $RPM_BUILD_ROOT%prefix/share/db/
-
-
+mkdir -p $RPM_BUILD_ROOT/var/log/postgresql.log
+touch $RPM_BUILD_ROOT/var/log/postgresql.log
 
 %clean
 #rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
rpmbuild fails if a listed file is not present at build time. This change makes
sure the file exists in the build root. Also, having the postgresql.log listed
in files will make rpm understand that the CFEngine hub package actually owns
the file, which is a great improvement.

Ticket: ENT-7966
Changelog: None
(cherry picked from commit f2de79ee7be5bfe4c88bd4f810dccac8f2934a73)