### PR TITLE
ENT-7955 Use third arg in distfiles for pkg-cache if provided (3.15)

### DIFF
--- a/deps-packaging/pkg-get-src
+++ b/deps-packaging/pkg-get-src
@@ -119,7 +119,9 @@ get_src()
     exec <"$DISTFILE"
     read CHECKSUM FILENAME OPTS
 
-    local_filename=`pkg-cache listfile $FILENAME`  ||  true
+    # if OPTS, then check package cache for renamed file (OPTS arg)
+    [ -n "$OPTS" ] && tmp_filename="$OPTS" || tmp_filename="$FILENAME"
+    local_filename=`pkg-cache listfile $tmp_filename`  ||  true
 
     if [ -f "$local_filename" ]  &&  checksum "$local_filename" "$CHECKSUM"
     then


### PR DESCRIPTION
For sourceforge we needed the download URL and resulting filename
to be different. This commit fixes the filename provided to pkg-cache.

Ticket: ENT-7955
Changelog: none
(cherry picked from commit a9869e476e7e78a32da5f6ee93a4f1d5d3eee545)