### PR TITLE
ENT-8065 Gave cfapache group full access to httpd contents

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -321,7 +321,7 @@ exit 0
 %prefix/httpd/bin
 %prefix/httpd/cgi-bin
 
-%defattr(644,root,root,755)
+%defattr(460,root,cfapache,570)
 %prefix/httpd/conf
 %prefix/httpd/error
 %prefix/httpd/htdocs


### PR DESCRIPTION
This is a fix for umask changes in ENT-7948

Ticket: ENT-8065
Changelog: none

merge together
https://github.com/cfengine/mission-portal/pull/1578
https://github.com/cfengine/masterfiles/pull/2168
https://github.com/cfengine/buildscripts/pull/908