### PR TITLE
Create /opt/cfengine/notification_scripts in post-install

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -195,8 +195,13 @@ fi
 
 # Dir to store SSH key to access git repo
 mkdir -p "$DCWORKDIR/userworkdir/admin/.ssh"
-chown -R $MP_APACHE_USER:$MP_APACHE_USER $DCWORKDIR
 chmod -R 700 $DCWORKDIR/userworkdir
+
+# Dir for notification/alert scripts
+mkdir "$DCWORKDIR/notification_scripts"
+chmod -R 700 "$DCWORKDIR/notification_scripts"
+
+chown -R $MP_APACHE_USER:$MP_APACHE_USER "$DCWORKDIR"
 
 if [ -f $PREFIX/bin/cf-twin ]; then
     /bin/rm $PREFIX/bin/cf-twin


### PR DESCRIPTION
So that it is created as part of the installation process and,
among other things, gets the right SELinux label.

Ticket: ENT-8029
Changelog: None