### PR TITLE
ENT-8065: Gave cfapache group full access to httpd contents (3.18)

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -321,7 +321,7 @@ exit 0
 %prefix/httpd/bin
 %prefix/httpd/cgi-bin
 
-%defattr(644,root,root,755)
+%defattr(460,root,cfapache,570)
 %prefix/httpd/conf
 %prefix/httpd/error
 %prefix/httpd/htdocs


### PR DESCRIPTION
This is a fix for umask changes in ENT-7948

Ticket: ENT-8065
Changelog: none
(cherry picked from commit 540d5505b44cf8ae219695a6da1ba1d6b10ec411)