### PR TITLE
Add '-p' when creating the /opt/cfengine/notification_scripts dir

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -198,7 +198,7 @@ mkdir -p "$DCWORKDIR/userworkdir/admin/.ssh"
 chmod -R 700 $DCWORKDIR/userworkdir
 
 # Dir for notification/alert scripts
-mkdir "$DCWORKDIR/notification_scripts"
+mkdir -p "$DCWORKDIR/notification_scripts"
 chmod -R 700 "$DCWORKDIR/notification_scripts"
 
 chown -R $MP_APACHE_USER:$MP_APACHE_USER "$DCWORKDIR"


### PR DESCRIPTION
Otherwise it will fail if the directory already exists.

Ticket: ENT-8029
Changelog: None