### PR TITLE
ENT-8293 Improve check for 'ss' command on newer debian distros

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -156,7 +156,7 @@ fi
 filter_netstat_listen()
 {
   set +e
-  if [ -x /usr/sbin/ss ]; then
+  if command -v ss >/dev/null; then
     ss -natp | egrep "LISTEN.*($1)"
   else
     netstat -natp | egrep "($1).*LISTEN"


### PR DESCRIPTION
Location on debian 9 is /bin/ss so prefer to use command -v
to check for existence.

netstat is not available by default on newer debian based
distributions.

Ticket: ENT-8293
Changelog: title