### PR TITLE
ENT-8293 Improve check for 'ss' command on newer debian distros (3.15)

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -154,7 +154,7 @@ fi
 filter_netstat_listen()
 {
   set +e
-  if [ -x /usr/sbin/ss ]; then
+  if command -v ss >/dev/null; then
     ss -natp | egrep "LISTEN.*($1)"
   else
     netstat -natp | egrep "($1).*LISTEN"


### PR DESCRIPTION
Location on debian 9 is /bin/ss so prefer to use command -v
to check for existence.

netstat is not available by default on newer debian based
distributions.

Ticket: ENT-8293
Changelog: title
(cherry picked from commit b684ff1947893f3564d3be299552fa3e202decc0)