### PR TITLE
ENT-8372 Improved postinstall scriptlet for rpm upgrades (master)

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -91,7 +91,7 @@ EOF
 )
 true "Done creating httpd/secrets.ini file"
 
-cp -r $PREFIX/share/GUI/* $PREFIX/httpd/htdocs
+cp -r --remove-destination $PREFIX/share/GUI/* $PREFIX/httpd/htdocs
 
 # If old files were moved aside during upgrade, we should move them back so that
 # rpm can do its cleanup procedures. But avoid overwriting new files with the


### PR DESCRIPTION
Problem was that a dangling symlink was caused during rpm upgrade
procedure and so was breaking the postinstall scriptlet.

Ticket: ENT-8372
Changelog: none
(cherry picked from commit f1b3509cb462ee7d9bd38362df2cbed39f3f6bca)