### PR TITLE
Check for existence of pg/data/postgresql.conf file, instead of data dir

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -368,7 +368,11 @@ init_postgres_dir()
   new_pgconfig_file="$1"
   pgconfig_type="$2"
 
-  rm -rf $PREFIX/state/pg/data
+  if test -e $PREFIX/state/pg/data; then
+    if ! rm -rf $PREFIX/state/pg/data; then
+      cf_console echo "Warning: $PREFIX/state/pg/data couldn't be deleted"
+    fi
+  fi
   mkdir -p $PREFIX/state/pg/data
   chown -R cfpostgres $PREFIX/state/pg
 
@@ -714,7 +718,7 @@ chown root:cfpostgres "$PREFIX/state" "$PREFIX/state/pg"
 chmod 0750 "$PREFIX/state" "$PREFIX/state/pg"
 
 test -z "$BACKUP_DIR" && BACKUP_DIR=$PREFIX/state/pg/backup
-if [ ! -d $PREFIX/state/pg/data ]; then
+if [ ! -f $PREFIX/state/pg/data/postgresql.conf ]; then
   new_pgconfig_file=`generate_new_postgres_conf`
   if [ `basename "$new_pgconfig_file"` = "postgresql.conf.cfengine" ]; then
     pgconfig_type="CFEngine recommended"

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -331,7 +331,7 @@ if [ -d $PREFIX/httpd/htdocs ]; then
     mv $PREFIX/share/GUI $PREFIX/share/GUI_old
   fi
   # Remove empty dirs in httpd/htdocs
-  find $PREFIX/httpd/htdocs -depth -type d -exec rmdir {} \;
+  find $PREFIX/httpd/htdocs -depth -type d -empty -exec rmdir {} \;
 fi
 
 if [ -d $PREFIX/httpd/php/lib/php/extensions/no-debug-non-zts-20170718 ]; then


### PR DESCRIPTION
Issue was that when /var/cfengine/state/pg/data is a mounted volume, it can't be deleted. First, it makes `rm -rf` fail, and second, it confuses migration logic which checks lack of this directory as a signal to create new postgresql database there (including postgresql.conf file). But when this directory is a mounted volume - `rm -rf` can delete everything inside it, except the directory itself. Empty directory is not a valid postgresql database, what confuses rest of postinstall script.

Note that we don't want to use plain is_upgrade here, because the generate_new_postgres_conf must be executed in two cases:
* on a fresh install
* when a major upgrade of PostgreSQL requires DB migration - happens only during minor CFEngine upgrade (3.15 -> 3.18)

and is_upgrade is, well, _any_ CFEngine upgrade.

Ticket: ENT-8423