### PR TITLE
ENT-8506: Stopped loading mod_status by default

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -43,7 +43,6 @@ LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 LoadModule mime_module modules/mod_mime.so
-LoadModule status_module modules/mod_status.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule asis_module modules/mod_asis.so
 LoadModule info_module modules/mod_info.so


### PR DESCRIPTION
Merge together:
- https://github.com/cfengine/masterfiles/pull/2284

Since we don't make active use of this module, we don't need to load it by default.

Ticket: ENT-8506
Changelog: Title