### PR TITLE
ENT-8506: Stopped loading mod_status by default (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -43,7 +43,6 @@ LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 LoadModule mime_module modules/mod_mime.so
-LoadModule status_module modules/mod_status.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule asis_module modules/mod_asis.so
 LoadModule vhost_alias_module modules/mod_vhost_alias.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/masterfiles/pull/2292

Since we don't make active use of this module, we don't need to load it by default.

Ticket: ENT-8506
Changelog: Title
(cherry picked from commit fa718ee1f9b8daf0c1be37ed9c2ec20a8b419343)