### PR TITLE
ENT-8498: Stopped loading Apache substitute module by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -29,7 +29,6 @@ LoadModule reqtimeout_module modules/mod_reqtimeout.so
 LoadModule ext_filter_module modules/mod_ext_filter.so
 LoadModule include_module modules/mod_include.so
 LoadModule filter_module modules/mod_filter.so
-LoadModule substitute_module modules/mod_substitute.so
 LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule log_forensic_module modules/mod_log_forensic.so


### PR DESCRIPTION
Merge Together:
- https://github.com/cfengine/masterfiles/pull/2295

Since we do not use the functionality provided by this module, we should not
load it by default.

Ticket: ENT-8498
Changelog: Title
(cherry picked from commit dd6610c4dd9ef27395670f187f179869ea22f885)