### PR TITLE
ENT-8514: Stopped loading Apache mod_autoindex by default on Enterprise Hubs (3.18)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -43,7 +43,6 @@ LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 LoadModule mime_module modules/mod_mime.so
-LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule asis_module modules/mod_asis.so
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule negotiation_module modules/mod_negotiation.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8514
Changelog: Title
(cherry picked from commit 2a35b284118c85f8e1a5af8bef07b679dd0e33c2)