### PR TITLE
ENT-8507: Stopped loading Apache mod_include by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -27,7 +27,6 @@ LoadModule dbd_module modules/mod_dbd.so
 LoadModule dumpio_module modules/mod_dumpio.so
 LoadModule reqtimeout_module modules/mod_reqtimeout.so
 LoadModule ext_filter_module modules/mod_ext_filter.so
-LoadModule include_module modules/mod_include.so
 LoadModule filter_module modules/mod_filter.so
 LoadModule substitute_module modules/mod_substitute.so
 LoadModule deflate_module modules/mod_deflate.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8507
Changelog: Title
(cherry picked from commit d2a6b30a1a936e48c7b94d579786d01b5ede30cd)