### PR TITLE
ENT-8509: Stopped loading Apache mod_ldap by default on Enterprise Hubs (3.18)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -53,7 +53,6 @@ LoadModule speling_module modules/mod_speling.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
-LoadModule ldap_module modules/mod_ldap.so
 LoadModule ssl_module modules/mod_ssl.so
 
 # Required to drop privledges


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8509
Changelog: Title
(cherry picked from commit cd37b0f99bcf90b96d64485f73bc1c7d06de6d08)