### PR TITLE
ENT-8512: Stopped loading Apache mod_authnz_ldap by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -43,7 +43,6 @@ LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
-LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule ssl_module modules/mod_ssl.so
 
 # Required to drop privledges


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by
default.

