### PR TITLE
ENT-8513: Stopped loading Apache mod_vhost_alias by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -39,7 +39,6 @@ LoadModule usertrack_module modules/mod_usertrack.so
 LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
-LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by
default.

