### PR TITLE
ENT-8521: Stopped loading Apache mod_usertrack by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -34,7 +34,6 @@ LoadModule log_forensic_module modules/mod_log_forensic.so
 LoadModule logio_module modules/mod_logio.so
 LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so
-LoadModule usertrack_module modules/mod_usertrack.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule dir_module modules/mod_dir.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8521
Changelog: Title
(cherry picked from commit 817c8ae2da066353181566bddc8fa3bb122b8a00)