### PR TITLE
ENT-8522: Stopped loading Apache mod_env by default on Enterprise Hubs

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -34,7 +34,6 @@ LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule log_forensic_module modules/mod_log_forensic.so
 LoadModule logio_module modules/mod_logio.so
-LoadModule env_module modules/mod_env.so
 LoadModule mime_magic_module modules/mod_mime_magic.so
 LoadModule expires_module modules/mod_expires.so
 LoadModule headers_module modules/mod_headers.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by
default.

Ticket: ENT-8522
Changelog: Title