### PR TITLE
ENT-8571: Merged share/CoreBase/masterfiles and share/NovaBase/masterfiles to share/masterfiles

### DIFF
--- a/packaging/cfengine-community/aix/lpp_name.in
+++ b/packaging/cfengine-community/aix/lpp_name.in
@@ -17,7 +17,7 @@ cfengine.cfengine-community @@VERSION@@.0 01 N U en_US Cfengine Nova, Data Cente
 /var/cfengine/share/doc/examples 1277
 /var/cfengine/share/man 2
 /var/cfengine/share/man/man8 55
-/var/cfengine/share/CoreBase 118
+/var/cfengine/share/masterfiles 118
 /var/cfengine/lib 25042
 INSTWORK 384 384
 %

--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -34,8 +34,8 @@ maintain systems.
 mkdir -p $RPM_BUILD_ROOT%{prefix}
 cp -a %{prefix}/* $RPM_BUILD_ROOT%{prefix}
 cp -a %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT%{prefix}/share/CoreBase
-cp -R $RPM_BUILD_ROOT%{prefix}/masterfiles $RPM_BUILD_ROOT%prefix/share/CoreBase/masterfiles
+mkdir -p $RPM_BUILD_ROOT%{prefix}/share/masterfiles
+cp -R $RPM_BUILD_ROOT%{prefix}/masterfiles/* $RPM_BUILD_ROOT%prefix/share/masterfiles
 rm -rf $RPM_BUILD_ROOT%{prefix}/masterfiles
 
 mkdir -p $RPM_BUILD_ROOT/etc/sysconfig
@@ -131,9 +131,9 @@ rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 %dir %prefix/share
 %prefix/share/doc
 
-# CoreBase
+# masterfiles
 %defattr(644,root,root,755)
-%prefix/share/CoreBase
+%prefix/share/masterfiles
 
 # Private directories
 %defattr(600,root,root,700)

--- a/packaging/cfengine-community/debian/cfengine-community.install
+++ b/packaging/cfengine-community/debian/cfengine-community.install
@@ -25,7 +25,7 @@
 /var/cfengine/lib/lib*.so.*
 /var/cfengine/lib/liblmdb.so
 /var/cfengine/share/doc
-/var/cfengine/share/CoreBase
+/var/cfengine/share/masterfiles
 /var/cfengine/inputs
 /var/cfengine/modules
 /var/cfengine/outputs

--- a/packaging/cfengine-community/debian/rules
+++ b/packaging/cfengine-community/debian/rules
@@ -21,8 +21,8 @@ install: build
 	mkdir -p $(CURDIR)/debian/tmp$(PREFIX)
 	cp -a $(PREFIX)/* $(CURDIR)/debian/tmp$(PREFIX)
 	cp -a ${BASEDIR}/cfengine/dist/* $(CURDIR)/debian/tmp
-	mkdir -p $(CURDIR)/debian/tmp$(PREFIX)/share/CoreBase
-	cp -R $(CURDIR)/debian/tmp$(PREFIX)/masterfiles $(CURDIR)/debian/tmp$(PREFIX)/share/CoreBase/masterfiles
+	mkdir -p $(CURDIR)/debian/tmp$(PREFIX)/share/masterfiles
+	cp -R $(CURDIR)/debian/tmp$(PREFIX)/masterfiles $(CURDIR)/debian/tmp$(PREFIX)/share/masterfiles
 	chmod -R 744 $(CURDIR)/debian/tmp$(PREFIX)/share
 	rm -rf $(CURDIR)/debian/tmp$(PREFIX)/masterfiles
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/bin/openssl

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -104,9 +104,9 @@ mv $RPM_BUILD_ROOT%prefix/share/GUI/public/index.php.tmp $RPM_BUILD_ROOT%prefix/
 rm -f $RPM_BUILD_ROOT%prefix/share/GUI/public/index.php.tmp
 
 find $RPM_BUILD_ROOT%prefix/share/GUI -type f -exec sed -i 's/cfapi_log/syslog/' {} \;
-# NovaBase
-mkdir -p $RPM_BUILD_ROOT%prefix/share/NovaBase
-cp -R $RPM_BUILD_ROOT%prefix/masterfiles $RPM_BUILD_ROOT%prefix/share/NovaBase/masterfiles
+# masterfiles
+mkdir -p $RPM_BUILD_ROOT%prefix/share/masterfiles
+cp -R $RPM_BUILD_ROOT%prefix/masterfiles/* $RPM_BUILD_ROOT%prefix/share/masterfiles
 rm -rf $RPM_BUILD_ROOT%prefix/masterfiles
 
 
@@ -303,7 +303,7 @@ exit 0
 
 # Base policy
 %defattr(644,root,root,755)
-%prefix/share/NovaBase
+%prefix/share/masterfiles
 %defattr(755,root,root,755)
 %prefix/modules
 

--- a/packaging/cfengine-nova-hub/debian/cfengine-nova-hub.install
+++ b/packaging/cfengine-nova-hub/debian/cfengine-nova-hub.install
@@ -47,7 +47,7 @@
 /var/cfengine/bin/cf-hub
 /var/cfengine/bin/cf-reactor
 /var/cfengine/lib/php
-/var/cfengine/share/NovaBase
+/var/cfengine/share/masterfiles
 /var/cfengine/share/GUI
 /var/cfengine/master_software_updates
 /var/cfengine/share/solaris_admin_files

--- a/packaging/cfengine-nova-hub/debian/rules
+++ b/packaging/cfengine-nova-hub/debian/rules
@@ -65,9 +65,9 @@ install: build
 	mv $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/public/index.php.tmp $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/public/index.php
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/public/index.php.tmp
 
-# NovaBase
-	mkdir -p $(CURDIR)/debian/tmp$(PREFIX)/share/NovaBase
-	cp -R $(CURDIR)/debian/tmp$(PREFIX)/masterfiles $(CURDIR)/debian/tmp$(PREFIX)/share/NovaBase/masterfiles
+# masterfiles
+	mkdir -p $(CURDIR)/debian/tmp$(PREFIX)/share/masterfiles
+	cp -R $(CURDIR)/debian/tmp$(PREFIX)/masterfiles $(CURDIR)/debian/tmp$(PREFIX)/share/masterfiles
 	rm -rf $(CURDIR)/debian/tmp$(PREFIX)/masterfiles
 
 #Postgres

--- a/packaging/cfengine-nova-hub/debian/rules
+++ b/packaging/cfengine-nova-hub/debian/rules
@@ -27,7 +27,7 @@ install: build
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/lib/libpromises.la
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/lib/libpromises.so
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/lib/cfengine-enterprise.la
-	rm -rf $(CURDIR)/debian/tmp$(PREFIX)/share/CoreBase
+	rm -rf $(CURDIR)/debian/tmp$(PREFIX)/share/masterfiles
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/bin/getfacl
 # cf-upgrade is not needed in hub packages
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/bin/cf-upgrade

--- a/packaging/cfengine-nova/aix/lpp_name.in
+++ b/packaging/cfengine-nova/aix/lpp_name.in
@@ -17,7 +17,7 @@ cfengine.cfengine-nova @@VERSION@@.0 01 N U en_US Cfengine Nova, Data Center Aut
 /var/cfengine/share/doc/examples 1277
 /var/cfengine/share/man 2
 /var/cfengine/share/man/man8 55
-/var/cfengine/share/CoreBase 118
+/var/cfengine/share/masterfiles 118
 /var/cfengine/lib 25042
 INSTWORK 384 384
 %

--- a/packaging/cfengine-nova/cfengine-nova.spec.aix.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.aix.in
@@ -36,7 +36,7 @@ rsync -rlp %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
 rm -f $RPM_BUILD_ROOT%{prefix}/lib/libpromises.la
 #rm -f $RPM_BUILD_ROOT%{prefix}/lib/libpromises.so
 rm -f $RPM_BUILD_ROOT%{prefix}/lib/cfengine-enterprise.la
-rm -rf $RPM_BUILD_ROOT%{prefix}/share/CoreBase
+rm -rf $RPM_BUILD_ROOT%{prefix}/share/masterfiles
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/getfacl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/openssl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -44,7 +44,7 @@ cp -a %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
 rm -f $RPM_BUILD_ROOT%{prefix}/lib/libpromises.la
 rm -f $RPM_BUILD_ROOT%{prefix}/lib/libpromises.so
 rm -f $RPM_BUILD_ROOT%{prefix}/lib/cfengine-enterprise.la
-rm -rf $RPM_BUILD_ROOT%{prefix}/share/CoreBase
+rm -rf $RPM_BUILD_ROOT%{prefix}/share/masterfiles
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/getfacl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/openssl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl

--- a/packaging/cfengine-nova/debian/rules
+++ b/packaging/cfengine-nova/debian/rules
@@ -33,7 +33,7 @@ install: build
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/lib/libpromises.la
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/lib/libpromises.so
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/lib/cfengine-enterprise.la
-	rm -rf $(CURDIR)/debian/tmp$(PREFIX)/share/CoreBase
+	rm -rf $(CURDIR)/debian/tmp$(PREFIX)/share/masterfiles
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/bin/getfacl
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/bin/openssl
 	rm -f $(CURDIR)/debian/tmp$(PREFIX)/bin/curl

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -49,7 +49,7 @@ if [ ! -f "$PREFIX/ppkeys/localhost.priv" ]; then
 fi
 
 if [ ! -f "$PREFIX/masterfiles/promises.cf" ]; then
-    /bin/cp -R "$PREFIX/share/NovaBase/masterfiles" "$PREFIX"
+    /bin/cp -R "$PREFIX/share/masterfiles" "$PREFIX"
     touch "$PREFIX/masterfiles/cf_promises_validated"
     find "$PREFIX/masterfiles" -type d -exec chmod 700 {} \;
     find "$PREFIX/masterfiles" -type f -exec chmod 600 {} \;

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -16,7 +16,7 @@ if is_community; then
   # Copy the stock policy for the new installations
   #
   if ! [ -f $PREFIX/masterfiles/promises.cf ]; then
-    /bin/cp -R $PREFIX/share/CoreBase/masterfiles $PREFIX
+    /bin/cp -R $PREFIX/share/masterfiles $PREFIX
     #
     # Create promises_validated
     #


### PR DESCRIPTION
Merge Together:
- Mission Portal: https://github.com/cfengine/mission-portal/pull/1663
- Documentation: https://github.com/cfengine/documentation/pull/2697

There is no difference in the base policy between CFEngine Community and CFEngine Enterprise. It makes sense that they not have different directories when packaged. The current difference only serves to confuse documentation.