### PR TITLE
ENT-8526: Stopped loading Apache mod_deflate by default on Enterprise Hubs (3.18)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -27,7 +27,6 @@ LoadModule dbd_module modules/mod_dbd.so
 LoadModule reqtimeout_module modules/mod_reqtimeout.so
 LoadModule ext_filter_module modules/mod_ext_filter.so
 LoadModule filter_module modules/mod_filter.so
-LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule logio_module modules/mod_logio.so
 LoadModule expires_module modules/mod_expires.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.