### PR TITLE
ENT-8524: Stopped loading Apache mod_filter and mod_ext_filter by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -24,8 +24,6 @@ LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule dbd_module modules/mod_dbd.so
-LoadModule ext_filter_module modules/mod_ext_filter.so
-LoadModule filter_module modules/mod_filter.so
 LoadModule deflate_module modules/mod_deflate.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule logio_module modules/mod_logio.so


### PR DESCRIPTION
We do not use the features provided by these modules, so we should not load them by default.