### PR TITLE
ENT-8525: Stopped loading Apache mod_reqtimeout by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -24,7 +24,6 @@ LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule dbd_module modules/mod_dbd.so
-LoadModule reqtimeout_module modules/mod_reqtimeout.so
 LoadModule ext_filter_module modules/mod_ext_filter.so
 LoadModule filter_module modules/mod_filter.so
 LoadModule deflate_module modules/mod_deflate.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.