### PR TITLE
ENT-8554: Added in-line reasoning for use of Apache modules (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -24,15 +24,34 @@ LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule dbd_module modules/mod_dbd.so
+LoadModule expires_module modules/mod_expires.so
+
+# Our default log format uses features provided by these modules
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule logio_module modules/mod_logio.so
-LoadModule expires_module modules/mod_expires.so
+
+# We use the Header directive which is provided by this module
 LoadModule headers_module modules/mod_headers.so
+
+# We use the BrowserMatch directive which is provided by this module
 LoadModule setenvif_module modules/mod_setenvif.so
+
+# Associates the requested filename's extensions with the file's behavior
+# (handlers and filters) and content (mime-type, language, character set and
+# encoding)
 LoadModule mime_module modules/mod_mime.so
+
+# Provides for "trailing slash" redirects and serving directory index files
 LoadModule dir_module modules/mod_dir.so
+
+# Used for mapping in some nicer URL names
+# TODO Consider removal after 3.20 is EOL (used by transition in 3.16)
 LoadModule alias_module modules/mod_alias.so
+
+# Required for http->https redirection and handling indexes
 LoadModule rewrite_module modules/mod_rewrite.so
+
+# Required for secure access
 LoadModule ssl_module modules/mod_ssl.so
 
 # Required to drop privledges


### PR DESCRIPTION
This change is intended to better document and understand our use of Apache
modules in the default configuration.