### PR TITLE
ENT-8598: Stopped loading Apache mod_authn_file by default on Enterprise Hubs (3.18)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -12,7 +12,6 @@ PidFile "/var/cfengine/httpd/httpd.pid"
 # Note: Not all modules that are built are loaded.
 # Find built modules in /var/cfengine/httpd/modules
 
-LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbd_module modules/mod_authn_dbd.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.