### PR TITLE
ENT-8600: Stopped loading Apache mod_authn_anon by default on Enterprise Hubs

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -13,7 +13,6 @@ PidFile "/var/cfengine/httpd/httpd.pid"
 # Find built modules in /var/cfengine/httpd/modules
 
 LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbd_module modules/mod_authn_dbd.so
 LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_groupfile_module modules/mod_authz_groupfile.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.