### PR TITLE
ENT-8610: Stopped loading Apache mod_expires by default on Enterprise Hubs (3.15)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -23,7 +23,6 @@ LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule dbd_module modules/mod_dbd.so
-LoadModule expires_module modules/mod_expires.so
 
 # Our default log format uses features provided by these modules
 LoadModule log_config_module modules/mod_log_config.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.