### PR TITLE
ENT-8604: Stopped loading Apache mod_authz_user by default on Enterprise Hubs (3.18)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -17,7 +17,6 @@ LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbd_module modules/mod_authn_dbd.so
 LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
-LoadModule authz_user_module modules/mod_authz_user.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule auth_basic_module modules/mod_auth_basic.so


### PR DESCRIPTION
We do not use the features provided by this module, so we should not load it by default.

