### PR TITLE
Don't build CentOS 6 HUB package

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -4,7 +4,6 @@ PACKAGES_HUB_x86_64_linux_debian_9
 PACKAGES_HUB_x86_64_linux_debian_10
 PACKAGES_HUB_x86_64_linux_debian_11
 
-PACKAGES_HUB_x86_64_linux_redhat_6
 PACKAGES_HUB_x86_64_linux_redhat_7
 PACKAGES_HUB_x86_64_linux_redhat_8
 


### PR DESCRIPTION
Changelog: drop support for CentOS 6 HUB package