### PR TITLE
Move ubuntu 22 arm builds out of exotics

### DIFF
--- a/build-scripts/exotics.txt
+++ b/build-scripts/exotics.txt
@@ -6,5 +6,3 @@ PACKAGES_ppc64_aix_71
 PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_solaris_10
-PACKAGES_arm_64_linux_ubuntu_22
-PACKAGES_HUB_arm_64_linux_ubuntu_22


### PR DESCRIPTION
They are fairly fast, cheaper than most instances in AWS,
and would be cool to provide them as nightlies to folks.

Ticket: none
Changelog: none