### PR TITLE
ENT-8837 Ensure that no valid hostname produces error during hub package install (3.15)

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -104,7 +104,7 @@ fi
 # hostname -f returns a valid name. If that is not the case then
 # we just abort the installation.
 #
-NAME=$(hostname -f)
+NAME=$(hostname -f) || true
 if [ -z "$NAME" ];
 then
   cf_console echo "hostname -f does not return a valid name, but this is a requirement for generating a"


### PR DESCRIPTION
Ticket: ENT-8837
Changelog: none
(cherry picked from commit 44ead9475a66e2dcd37f264d5d78dcb67a1b91b9)