### PR TITLE
Make sure our libraries are installed to /var/cfengine/lib not lib64

### DIFF
--- a/build-scripts/configure
+++ b/build-scripts/configure
@@ -15,7 +15,7 @@ esac
 
 P=$BUILDPREFIX
 
-ARGS="--prefix=$P --with-workdir=$P --sysconfdir=/etc --with-openssl=$P --with-pcre=$P --with-init-script"
+ARGS="--prefix=$P --libdir=$P/lib --with-workdir=$P --sysconfdir=/etc --with-openssl=$P --with-pcre=$P --with-init-script"
 
 if [ $EMBEDDED_DB = lmdb ]
 then


### PR DESCRIPTION
For some reason, on SUSE 15, cfengine-enterprise.so ends up in
/var/cfengine/lib64.