### PR TITLE
Take 64-bit library on sparc and 32-bit library elsewhere

### DIFF
--- a/deps-packaging/libgcc/solaris/build
+++ b/deps-packaging/libgcc/solaris/build
@@ -10,6 +10,12 @@ PREFIX=${BUILDPREFIX}
 #
 # Gross hack, but what we could do?
 #
-LIBGCC_LOC="/opt/csw/lib/"
+if [ "$(uname -p)" = "sparc" ]; then
+	# on 64-bit sparc CPUs, we take 64-bit library
+	LIBGCC_LOC="/opt/csw/lib/sparcv9/"
+else
+	# on 32-bit Intel CPUs, we take 32-bit library
+	LIBGCC_LOC="/opt/csw/lib/"
+fi
 mkdir -p ${BUILD_ROOT}/cfbuild-libgcc/${PREFIX}/lib
 cp "$LIBGCC_LOC"libgcc_s.so.1 ${BUILD_ROOT}/cfbuild-libgcc/${PREFIX}/lib


### PR DESCRIPTION
Note that this assumes that we build only 64-bit binaries on sparc, and 32-bit binaries on other platforms. As of writing, this is correct ("other platforms" being only 32-bit x86 Intel).

Ticket: ENT-9013

Issue was that recently we switched to building 64-bit binaries on sparc (apparently they can run both 32 and 64-bit), but we still were packaging 32-bit library, and thus all our binaries were crashing on start.