### PR TITLE
ENT-8978: Add debian 11 aarch64 labels

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -3,6 +3,7 @@
 PACKAGES_HUB_x86_64_linux_debian_9
 PACKAGES_HUB_x86_64_linux_debian_10
 PACKAGES_HUB_x86_64_linux_debian_11
+PACKAGES_HUB_arm_64_linux_debian_11
 
 PACKAGES_HUB_x86_64_linux_redhat_7
 PACKAGES_HUB_x86_64_linux_redhat_8
@@ -10,12 +11,12 @@ PACKAGES_HUB_x86_64_linux_redhat_8
 PACKAGES_HUB_x86_64_linux_ubuntu_16
 PACKAGES_HUB_x86_64_linux_ubuntu_18
 PACKAGES_HUB_x86_64_linux_ubuntu_20
-
 PACKAGES_HUB_arm_64_linux_ubuntu_22
 
 PACKAGES_x86_64_linux_debian_9
 PACKAGES_x86_64_linux_debian_10
 PACKAGES_x86_64_linux_debian_11
+PACKAGES_arm_64_linux_debian_11
 
 PACKAGES_x86_64_linux_redhat_6
 PACKAGES_x86_64_linux_redhat_7
@@ -28,6 +29,7 @@ PACKAGES_x86_64_linux_suse_15
 PACKAGES_x86_64_linux_ubuntu_16
 PACKAGES_x86_64_linux_ubuntu_18
 PACKAGES_x86_64_linux_ubuntu_20
+PACKAGES_arm_64_linux_ubuntu_22
 
 PACKAGES_i386_mingw
 PACKAGES_x86_64_mingw
@@ -38,4 +40,3 @@ PACKAGES_ppc64_aix_71
 PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_solaris_10
-PACKAGES_arm_64_linux_ubuntu_22


### PR DESCRIPTION
Possibly replace ubuntu 22 with debian 11 if the debian
packages work on ubuntu 22.

Ticket: ENT-8978
Changelog: title