### PR TITLE
Make sure liblmdb libraries are installed to /var/cfengine/lib not lib64

### DIFF
--- a/deps-packaging/libxml2/cfbuild-libxml2.spec
+++ b/deps-packaging/libxml2/cfbuild-libxml2.spec
@@ -27,6 +27,7 @@ then
     chmod a+x configure
 fi
 ./configure --prefix=%{prefix} --without-python --enable-shared --disable-static --with-zlib=%{prefix} \
+    --libdir=%{buildprefix}/lib \
     CPPFLAGS="-I%{prefix}/include" \
     LD_LIBRARY_PATH="%{prefix}/lib" LD_RUN_PATH="%{prefix}/lib"
 

--- a/deps-packaging/libyaml/cfbuild-libyaml.spec
+++ b/deps-packaging/libyaml/cfbuild-libyaml.spec
@@ -27,7 +27,7 @@ if [ -z $MAKE ]; then
   export MAKE=$MAKE_PATH
 fi
 
-./configure --prefix=%{prefix}
+./configure --prefix=%{prefix} --libdir=%{buildprefix}/lib
 $MAKE
 
 %install

--- a/deps-packaging/lmdb/cfbuild-lmdb.spec
+++ b/deps-packaging/lmdb/cfbuild-lmdb.spec
@@ -56,7 +56,7 @@ if [ -z $MAKE ]; then
   export MAKE=$MAKE_PATH
 fi
 
-./configure --prefix=%{prefix}
+./configure --prefix=%{prefix} --libdir=%{buildprefix}/lib
 $MAKE
 
 %install

--- a/deps-packaging/openldap/cfbuild-openldap-aix.spec
+++ b/deps-packaging/openldap/cfbuild-openldap-aix.spec
@@ -42,6 +42,7 @@ SYS=`uname -s`
             --disable-backends \
             --with-tls=openssl \
             --without-gssapi \
+	    --libdir=%{buildprefix}/lib \
             CPPFLAGS="$CPPFLAGS"
 
 %build

--- a/deps-packaging/pcre/cfbuild-pcre.spec
+++ b/deps-packaging/pcre/cfbuild-pcre.spec
@@ -18,7 +18,7 @@ AutoReqProv: no
 mkdir -p %{_builddir}
 %setup -q -n pcre-%{pcre_version}
 
-./configure --prefix=%{prefix} --enable-unicode-properties --disable-cpp --enable-shared
+./configure --prefix=%{prefix} --enable-unicode-properties --disable-cpp --enable-shared --libdir=%{buildprefix}/lib
 
 %build
 


### PR DESCRIPTION
For some reason, on SUSE 15, liblmdb.so ends up in /var/cfengine/lib64.