### PR TITLE
Remove extra 'cfengine' prefix from bff filename - 3.18.x

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.bff.sh
+++ b/packaging/cfengine-nova/cfengine-nova.bff.sh
@@ -114,3 +114,8 @@ cd $LPPBASE/lppdir/lpp/cfengine-nova-$VERSION
 
 # sometimes the following command needs to be done twice
 sudo -E mklpp || sudo -E mklpp
+
+# Remove extra 'cfengine.' from filename
+cd $HOME/lppdir/out/
+NEW_NAME="$(echo *.bff | sed 's/cfengine.cfengine/cfengine/')"
+sudo mv *.bff "$NEW_NAME"


### PR DESCRIPTION
Ticket: ENT-8941
(cherry picked from commit c252cc99de0a0ca6d6bead5aac4c6362d58cbf87)