### PR TITLE
ENT-9130: Fix masterfiles/tests/unit Makefile recreated during builds

### DIFF
--- a/build-scripts/test-on-thismachine
+++ b/build-scripts/test-on-thismachine
@@ -42,6 +42,12 @@ else
         # causes testall to pass "1" as an argument to cf-agent!
         # Workarount: VERBOSE=-I
         ls -l $BASEDIR/$project/tests/unit/Makefile* || true
+        ls -l /usr/bin/python || true
+        if test -x /usr/bin/python; then
+          echo "/usr/bin/python exists and is executable"
+        else
+          echo "/usr/bin/python does not exist or is not executable"
+        fi
         NETWORK_TESTS=0 $MAKE -C $BASEDIR/$project VERBOSE=-I check
     done
   elif [ "$TESTS" = unit ]

--- a/build-scripts/test-on-thismachine
+++ b/build-scripts/test-on-thismachine
@@ -41,7 +41,7 @@ else
         # "testall" script and automake. As a result, setting VERBOSE=1
         # causes testall to pass "1" as an argument to cf-agent!
         # Workarount: VERBOSE=-I
-        ls -l "$BASEDIR/$project/tests/unit/Makefile*"
+        ls -l "$BASEDIR/$project/tests/unit/Makefile*" || true
         NETWORK_TESTS=0 $MAKE -C $BASEDIR/$project VERBOSE=-I check
     done
   elif [ "$TESTS" = unit ]

--- a/build-scripts/test-on-thismachine
+++ b/build-scripts/test-on-thismachine
@@ -41,6 +41,7 @@ else
         # "testall" script and automake. As a result, setting VERBOSE=1
         # causes testall to pass "1" as an argument to cf-agent!
         # Workarount: VERBOSE=-I
+        ls -l "$BASEDIR/$project/tests/unit/Makefile*"
         NETWORK_TESTS=0 $MAKE -C $BASEDIR/$project VERBOSE=-I check
     done
   elif [ "$TESTS" = unit ]

--- a/build-scripts/test-on-thismachine
+++ b/build-scripts/test-on-thismachine
@@ -41,7 +41,7 @@ else
         # "testall" script and automake. As a result, setting VERBOSE=1
         # causes testall to pass "1" as an argument to cf-agent!
         # Workarount: VERBOSE=-I
-        ls -l "$BASEDIR/$project/tests/unit/Makefile*" || true
+        ls -l $BASEDIR/$project/tests/unit/Makefile* || true
         NETWORK_TESTS=0 $MAKE -C $BASEDIR/$project VERBOSE=-I check
     done
   elif [ "$TESTS" = unit ]


### PR DESCRIPTION
Ticket: ENT-9130
Changelog: none