### PR TITLE
CFE-3807: Added assert on EINVAL in mdb_mutex_failed()

### DIFF
--- a/deps-packaging/lmdb/0011-assert-on-mdb-mutex-failed.patch
+++ b/deps-packaging/lmdb/0011-assert-on-mdb-mutex-failed.patch
@@ -1,0 +1,30 @@
+From d73eeaacb333792f6eb6c0b113d22daaa64dc05b Mon Sep 17 00:00:00 2001
+From: Craig Comstock <craig.comstock@northern.tech>
+Date: Tue, 27 Sep 2022 11:21:36 -0500
+Subject: [PATCH] Added assert in mdb_mutex_failed for rc != EINVAL
+
+Ticket: CFE-3807
+---
+ libraries/liblmdb/mdb.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+index 8cecdb2e6..0ad477aa5 100644
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -1,3 +1,4 @@
++#include <assert.h>
+ /** @file mdb.c
+  *	@brief Lightning memory-mapped database library
+  *
+@@ -10250,6 +10251,7 @@ mdb_reader_check0(MDB_env *env, int rlocked, int *dead)
+ static int ESECT
+ mdb_mutex_failed(MDB_env *env, mdb_mutexref_t mutex, int rc)
+ {
++        assert(rc != EINVAL);
+ 	int rlocked, rc2;
+ 	MDB_meta *meta;
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
To debug issues related to the following log message:

error: Could not open database txn /var/cfengine/state/cf_lock.lmdb: Invalid argument

Ticket: CFE-3807
Changelog: title

related: 
https://github.com/cfengine/core/pull/5073
https://github.com/cfengine/buildscripts/pull/1131
https://github.com/cfengine/system-testing/pull/457