### PR TITLE
ENT-9517: Fixed zlib 1.2.12 details

### DIFF
--- a/deps-packaging/zlib/source
+++ b/deps-packaging/zlib/source
@@ -1,1 +1,1 @@
-http://zlib.net/
+https://zlib.net/fossils/


### PR DESCRIPTION
Probably package cache was avoiding this issue somehow.

Ticket: ENT-9517