### PR TITLE
ENT-8824: add support for redhat 9 agent package

### DIFF
--- a/build-scripts/configure
+++ b/build-scripts/configure
@@ -64,7 +64,7 @@ case "$WITH_SYSTEMD" in
 esac
 
 # RHEL 8 requires an SELinux policy
-if [ "x$OS" = "xrhel" ] && [ "x${VER:0:1}" = "x8" ]; then
+if [ "x$OS" = "xrhel" ] && [ "${VER%\.*}" -gt "7" ]; then
   var_append ARGS "--with-selinux-policy"
 fi
 

--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -22,6 +22,7 @@ PACKAGES_arm_64_linux_debian_11
 PACKAGES_x86_64_linux_redhat_6
 PACKAGES_x86_64_linux_redhat_7
 PACKAGES_x86_64_linux_redhat_8
+PACKAGES_x86_64_linux_redhat_9
 
 PACKAGES_x86_64_linux_suse_11
 PACKAGES_x86_64_linux_suse_12

--- a/deps-packaging/cache-sftp
+++ b/deps-packaging/cache-sftp
@@ -28,6 +28,10 @@ MYNAME=`basename $0`
 CACHE_HOST=jenkins_sftp_cache@build-artifacts-cache.cloud.cfengine.com
 REMOTE_CACHEDIR="buildscripts_cache"
 SSH_ARGS="-o GSSAPIAuthentication=no -o PreferredAuthentications=publickey"
+ssh_major_version=$(ssh -V 2>&1 | sed 's/OpenSSH_\([0-9]\+\).*$/\1/')
+if [ $ssh_major_version -gt 6 ]; then
+  SSH_ARGS="$SSH_ARGS -oPubkeyAcceptedKeyTypes=+ssh-rsa"
+fi
 
 
 sftp -b -  </dev/null  2>&1  \

--- a/packaging/common/cfengine-hub/preremove.sh
+++ b/packaging/common/cfengine-hub/preremove.sh
@@ -9,7 +9,7 @@ fi
 
 case "`os_type`" in
   redhat)
-    chkconfig --del cfengine3
+    test -x /sbin/chkconfig && chkconfig --del cfengine3
     ;;
   debian)
     update-rc.d -f cfengine3 remove

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -113,10 +113,19 @@ esac
 
 # (re)load SELinux policy if available and required
 if [ `os_type` = "redhat" ] &&
-   command -v semodule >/dev/null &&
    [ -f "$PREFIX/selinux/cfengine-enterprise.pp" ];
 then
-  semodule -n -i "$PREFIX/selinux/cfengine-enterprise.pp"
+  if command -v /usr/sbin/selinuxenabled >/dev/null &&
+      /usr/sbin/selinuxenabled;
+  then
+    command -v semodule >/dev/null || cf_console echo "warning! selinux exists and returns 0 but semodule not found"
+    test -x /usr/sbin/load_policy  || cf_console echo "warning! selinuxenabled exists and returns 0 but load_policy not found"
+    test -x /usr/sbin/restorecon   || cf_console echo "warning! selinuxenabled exists and returns 0 but restorecon not found"
+
+  fi
+  if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise.pp"; then
+    cf_console echo "warning! semodule failed"
+  fi
   if /usr/sbin/selinuxenabled; then
     /usr/sbin/load_policy
     /usr/sbin/restorecon -R /var/cfengine

--- a/packaging/common/cfengine-non-hub/preremove.sh
+++ b/packaging/common/cfengine-non-hub/preremove.sh
@@ -5,7 +5,7 @@ case `os_type` in
     #
     # Unregister CFEngine initscript on uninstallation.
     #
-    chkconfig --del cfengine3
+    test -x /sbin/chkconfig && chkconfig --del cfengine3
 
     #
     # systemd support


### PR DESCRIPTION
Ticket: ENT-8824

Summary of pending issues in CI:

- [x] fr-tests and sequential-tests failed with flaky ssh connections (known flakes)
- [x] redhat 6 and suse 11 testing-pr failed due to `Bad configuration option: PubkeyAcceptedKeyTypes` during retrieval of lcov in `pkg-get-src`
- [x] redhat 9 testing-pr failed in `./17_packages/10_new/unsafe/the_great_package_test.cf`
- [ ] ubuntu 16 hub failed sequential-tests/03-build/01-init, empty response to "Setting up the build project", will investigate and/or retry if manual testing doesn't break

merge together:
https://github.com/cfengine/buildscripts/pull/1137
https://github.com/cfengine/system-testing/pull/462
https://github.com/cfengine/masterfiles/pull/2529
https://github.com/cfengine/core/pull/5111