### PR TITLE
ENT-9595: add debian 11 and ubuntu 22 platforms, aarch64 and x86_64

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -3,6 +3,7 @@
 PACKAGES_HUB_x86_64_linux_debian_9
 PACKAGES_HUB_x86_64_linux_debian_10
 PACKAGES_HUB_x86_64_linux_debian_11
+PACKAGES_HUB_arm_64_linux_debian_11
 
 PACKAGES_HUB_x86_64_linux_redhat_6
 PACKAGES_HUB_x86_64_linux_redhat_7
@@ -11,12 +12,12 @@ PACKAGES_HUB_x86_64_linux_redhat_8
 PACKAGES_HUB_x86_64_linux_ubuntu_16
 PACKAGES_HUB_x86_64_linux_ubuntu_18
 PACKAGES_HUB_x86_64_linux_ubuntu_20
-
 PACKAGES_HUB_arm_64_linux_ubuntu_22
 
 PACKAGES_x86_64_linux_debian_9
 PACKAGES_x86_64_linux_debian_10
 PACKAGES_x86_64_linux_debian_11
+PACKAGES_arm_64_linux_debian_11
 
 PACKAGES_x86_64_linux_redhat_6
 PACKAGES_x86_64_linux_redhat_7
@@ -29,6 +30,7 @@ PACKAGES_x86_64_linux_suse_15
 PACKAGES_x86_64_linux_ubuntu_16
 PACKAGES_x86_64_linux_ubuntu_18
 PACKAGES_x86_64_linux_ubuntu_20
+PACKAGES_arm_64_linux_ubuntu_22
 
 PACKAGES_i386_mingw
 PACKAGES_x86_64_mingw
@@ -39,4 +41,3 @@ PACKAGES_ppc64_aix_71
 PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_solaris_10
-PACKAGES_arm_64_linux_ubuntu_22

--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -12,6 +12,7 @@ PACKAGES_HUB_x86_64_linux_redhat_8
 PACKAGES_HUB_x86_64_linux_ubuntu_16
 PACKAGES_HUB_x86_64_linux_ubuntu_18
 PACKAGES_HUB_x86_64_linux_ubuntu_20
+PACKAGES_HUB_x86_64_linux_ubuntu_22
 PACKAGES_HUB_arm_64_linux_ubuntu_22
 
 PACKAGES_x86_64_linux_debian_9
@@ -30,6 +31,7 @@ PACKAGES_x86_64_linux_suse_15
 PACKAGES_x86_64_linux_ubuntu_16
 PACKAGES_x86_64_linux_ubuntu_18
 PACKAGES_x86_64_linux_ubuntu_20
+PACKAGES_x86_64_linux_ubuntu_22
 PACKAGES_arm_64_linux_ubuntu_22
 
 PACKAGES_i386_mingw


### PR DESCRIPTION
For 3.18.3 release.