### PR TITLE
ENT-9595: Add Ubuntu 22 aarch64/arm agent and hub labels

### DIFF
--- a/build-scripts/exotics.txt
+++ b/build-scripts/exotics.txt
@@ -10,5 +10,3 @@ PACKAGES_ppc64_aix_71
 PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_solaris_10
-PACKAGES_arm_64_linux_ubuntu_22
-PACKAGES_HUB_arm_64_linux_ubuntu_22


### PR DESCRIPTION
By removing them from exotics this adds them to the list to use in nightlies/testing-pr job.

Ticket: ENT-9595
Changelog: title