### PR TITLE
ENT-9600: Added note about why SSLCompression is not explicitly off

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -152,6 +152,14 @@ LogLevel warn
   SSLUseStapling off
   # SSLStaplingCache "shmcb:logs/stabling-cache(150000)"
 
+  # TLS Compression should be disabled to avoid CRIME
+  # https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-4929
+  # SSLCompression off
+  # As part of security hardening we minimize the features provided by OpenSSL.
+  # Case in point, we build openssl 3 without support for compression. As such,
+  # we do not explicitly disable SSL Compression beginning with CFEngine
+  # Enteprprise 3.21.0 as apache is unable to then validate the configuration.
+
   # This is not explicitly enabled to allow the requesting client the first
   # choice of support ciphers
   #  SSLHonorCipherOrder On


### PR DESCRIPTION
merge together:
-  https://github.com/cfengine/masterfiles/pull/2545
 
When this was removed from buildscripts it also needed to be removed from the
template in masterfiles. We spent some time hunting down the issue before we
realized this was a change we made, not an upstream difference. Rather than
removing it from the config in masterfiles completely we stub it out with an
explanation.

Ticket: ENT-9600
Changelog: None