### PR TITLE
Require OpenSSL 3 on RHEL 9 and newer

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -14,9 +14,14 @@ Obsoletes: cfengine3, cfengine-community
 Requires: coreutils gzip
 
 # we don't bundle OpenSSL on RHEL 8 (and newer in the future)
-%if %{?rhel}%{!?rhel:0} > 7
+%if %{?rhel}%{!?rhel:0} == 8
 Requires: libssl.so.1.1()(64bit) libssl.so.1.1(OPENSSL_1_1_0)(64bit) libssl.so.1.1(OPENSSL_1_1_1)(64bit)
 Requires: libcrypto.so.1.1()(64bit) libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)
+%endif
+
+%if %{?rhel}%{!?rhel:0} > 8
+Requires: libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_3.0.0)(64bit) libcrypto.so.3(OPENSSL_3.0.1)(64bit)
+Requires: libssl.so.3()(64bit) libssl.so.3(OPENSSL_3.0.0)(64bit)
 %endif
 
 AutoReqProv: no


### PR DESCRIPTION
That's what our libraries are linked to:

  [vagrant@centos9s ~]$ ldd /var/cfengine/lib/libpromises.so.3.0.6 |grep -P '(ssl|crypto)'
    libssl.so.3 => /lib64/libssl.so.3 (0x00007fa73b37c000)
    libcrypto.so.3 => /lib64/libcrypto.so.3 (0x00007fa73ae00000)

and without this change, we pull in the 'compat-openssl11' package as a dependency which is unnecessary and potentially a problem for security scans, etc.

Ticket: ENT-8824
Changelog: None
(cherry picked from commit 983c4328e2a23a25f511c6ca26f78f3f34c1392e)