### PR TITLE
ENT-9605: Added rhel-9 hub package label

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -7,6 +7,7 @@ PACKAGES_HUB_arm_64_linux_debian_11
 
 PACKAGES_HUB_x86_64_linux_redhat_7
 PACKAGES_HUB_x86_64_linux_redhat_8
+PACKAGES_HUB_x86_64_linux_redhat_9
 
 PACKAGES_HUB_x86_64_linux_ubuntu_16
 PACKAGES_HUB_x86_64_linux_ubuntu_18

--- a/deps-packaging/pkg-build-rpm
+++ b/deps-packaging/pkg-build-rpm
@@ -103,6 +103,11 @@ case "$DEBUGSYM" in
     fatal "Unknown debugsym option: $DEBUGSYM";;
 esac
 
+
+if [ "$OS" = "rhel" ] && [ "$PKGNAME" = "git" ]; then
+  export RPM_BUILD_NCPUS=1
+fi
+
 # eval and double quoting is needed to separate args,
 # example cmd --define 'a b':
 #     - argv[1] = --define


### PR DESCRIPTION
Ticket: ENT-9605

together:
https://github.com/cfengine/nova/pull/1964
https://github.com/cfengine/buildscripts/pull/1173
