### PR TITLE
ENT-9665: Added correct permissions for build directory in Mission Portal

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -214,6 +214,10 @@ chmod -R 700 "$DCWORKDIR/notification_scripts"
 
 chown -R $MP_APACHE_USER:$MP_APACHE_USER "$DCWORKDIR"
 
+# Dir for build projects
+mkdir -p "$DCWORKDIR/build"
+chown -R root:$MP_APACHE_USER "$DCWORKDIR/build"
+
 if [ -f $PREFIX/bin/cf-twin ]; then
     /bin/rm $PREFIX/bin/cf-twin
 fi


### PR DESCRIPTION
Ticket: ENT-9665
Changelog: none

merge together:
https://github.com/cfengine/buildscripts/pull/1179
https://github.com/cfengine/masterfiles/pull/2562