### PR TITLE
ENT-9711: Added postinstall runalerts-temp directory management

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1001,6 +1001,14 @@ fi
 #
 chmod 755 $PREFIX/bin/runalerts.php
 
+# ENT-9711: Ensure $PREFIX/httpd/php/runalerts-stamp is created and has proper owner/permissions
+# Have to be careful here because httpd/php/bin wants to be root:root
+mkdir -p "$PREFIX/httpd/php/runalerts-stamp"
+chown root:$MP_APACHE_USER $PREFIX/httpd/php
+chown -R root:$MP_APACHE_USER $PREFIX/httpd/php/runalerts-stamp
+chmod g+rX "$PREFIX/httpd/php"
+chmod -R g+rX "$PREFIX/httpd/php/runalerts-stamp"
+
 #
 # Register CFEngine initscript, if not yet.
 #


### PR DESCRIPTION
Needs to be owned root:cfapache with execute from php up so that httpd can access.

Ticket: ENT-9711
Changelog: none