### PR TITLE
Add a warning to httpd.conf - 3.18.x

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -1,5 +1,6 @@
-# This file is rendered by CFEngine
-# manual edits will be reverted.
+# This file is copied into /var/cfengine/httpd/conf/ by install script.
+# It is later replaced by the one rendered from masterfiles.
+# It should NOT be its exact copy, otherwise ENT-9696 will happen again.
 
 ServerSignature Off
 ServerTokens ProductOnly


### PR DESCRIPTION
Otherwise, it's not getting replaced by the one rendered from masterfiles, and cf-agent restarts apache every five minutes.

Ticket: ENT-9696
(cherry picked from commit f50a67f00f0e207cf9e795ca4865eeeeaeccaa81)