### PR TITLE
ENT-9711: Added postinstall runalerts-temp directory management (3.18)

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -992,6 +992,14 @@ fi
 #
 chmod 755 $PREFIX/bin/runalerts.php
 
+# ENT-9711: Ensure $PREFIX/httpd/php/runalerts-stamp is created and has proper owner/permissions
+# Have to be careful here because httpd/php/bin wants to be root:root
+mkdir -p "$PREFIX/httpd/php/runalerts-stamp"
+chown root:$MP_APACHE_USER $PREFIX/httpd/php
+chown -R root:$MP_APACHE_USER $PREFIX/httpd/php/runalerts-stamp
+chmod g+rX "$PREFIX/httpd/php"
+chmod -R g+rX "$PREFIX/httpd/php/runalerts-stamp"
+
 #
 # Register CFEngine initscript, if not yet.
 #


### PR DESCRIPTION
Needs to be owned root:cfapache with execute from php up so that httpd can access.

Ticket: ENT-9711
Changelog: none
(cherry picked from commit 421193c3d8bb6673295bd1152b531c18e799f72e)

together:
https://github.com/cfengine/buildscripts/pull/1188
https://github.com/cfengine/masterfiles/pull/2569
https://github.com/cfengine/core/pull/5149