### PR TITLE
Make gzip a weak dependency

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -11,7 +11,8 @@ Group: Applications/System
 URL: http://cfengine.com/
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3
-Requires: coreutils gzip
+Requires: coreutils
+Recommends: gzip
 
 AutoReqProv: no
 

--- a/packaging/cfengine-community/debian/control
+++ b/packaging/cfengine-community/debian/control
@@ -11,6 +11,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}
 Provides: cfengine3
 Conflicts: cfengine3
 Replaces: cfengine3
+Recommends: gzip
 Description: CFEngine 3 Community
  CFEngine, or the configuration engine is an agent/software robot and a
  very high level language for building expert systems to administrate

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -13,7 +13,8 @@ Group: Applications/System
 URL: http://cfengine.com/
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3 < @@VERSION@@, cf-community < @@VERSION@@
-Requires: coreutils gzip
+Requires: coreutils
+Recommends: gzip
 Requires(pre): /usr/sbin/useradd, /usr/sbin/userdel, /usr/bin/getent
 Requires(post): /usr/sbin/usermod, /bin/sed
 

--- a/packaging/cfengine-nova-hub/debian/control
+++ b/packaging/cfengine-nova-hub/debian/control
@@ -10,7 +10,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Provides: cfengine-nova-hub
 Replaces: cfengine3, cfengine-community, cfengine-nova-hub
-Recommends: python3 (>= 3.5)
+Recommends: python3 (>= 3.5), gzip
 Description: CFEngine Nova : The next generation tool for data centre.
  CFEngine, or the configuration engine is an agent/software robot and a
  very high level language for building expert systems to administrate

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -11,7 +11,8 @@ Group: Applications/System
 URL: http://cfengine.com/
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3 < @@VERSION@@, cf-community < @@VERSION@@
-Requires: coreutils gzip
+Requires: coreutils
+Recommends: gzip
 
 # we require selinux-policy package version that matches or exceeds our build system version
 # this guarantees that our compiled selinux policy will work.

--- a/packaging/cfengine-nova/debian/control
+++ b/packaging/cfengine-nova/debian/control
@@ -11,6 +11,7 @@ Depends: ${ssl:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Provides: cfengine3, cfengine-community
 Conflicts: cfengine3, cfengine-community, cfengine-nova
 Replaces: cfengine3, cfengine-community, cfengine-nova
+Recommends: gzip
 Description: CFEngine Nova : The next generation tool for data centre.
  CFEngine, or the configuration engine is an agent/software robot and a
  very high level language for building expert systems to administrate

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -32,7 +32,12 @@ fi
 if [ -x /bin/systemctl ]; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
-  /bin/systemctl daemon-reload
+  if ! /bin/systemctl daemon-reload; then
+    cf_console echo "warning! /bin/systemctl daemon-reload failed."
+    cf_console echo "systemd seems to be installed, but not working."
+    cf_console echo "Relevant parts of CFEngine installation will fail."
+    cf_console echo "Please fix systemd or use other ways to start CFEngine."
+  fi
 fi
 
 #
@@ -274,7 +279,9 @@ do
   if [ -f /usr/share/man/man8/$i.8.gz ]; then
     rm -f /usr/share/man/man8/$i.8.gz
   fi
-  $PREFIX/bin/$i -M > /usr/share/man/man8/$i.8 && gzip /usr/share/man/man8/$i.8
+  if $PREFIX/bin/$i -M > /usr/share/man/man8/$i.8; then
+    gzip /usr/share/man/man8/$i.8 || true
+  fi
 done
 
 #

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -1,7 +1,12 @@
 if [ -x /bin/systemctl ]; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
-  /bin/systemctl daemon-reload
+  if ! /bin/systemctl daemon-reload; then
+    cf_console echo "warning! /bin/systemctl daemon-reload failed."
+    cf_console echo "systemd seems to be installed, but not working."
+    cf_console echo "Relevant parts of CFEngine installation will fail."
+    cf_console echo "Please fix systemd or use other ways to start CFEngine."
+  fi
 fi
 
 #
@@ -51,7 +56,9 @@ do
       if [ -f /usr/share/man/man8/$i.8.gz ]; then
         rm -f /usr/share/man/man8/$i.8.gz
       fi
-      $PREFIX/bin/$i -M > /usr/share/man/man8/$i.8 && gzip /usr/share/man/man8/$i.8
+      if $PREFIX/bin/$i -M > /usr/share/man/man8/$i.8; then
+        gzip /usr/share/man/man8/$i.8 || true
+      fi
       ;;
   esac
 done


### PR DESCRIPTION
Investigation shows that the only place where it's _required_ was when compressing man pages. But `man` can also work with uncompressed pages.

Other places which use gzip are Federated Reporting, watchdog script, and self-upgrade on Solaris, - all these parts are not "essential".

So it was decided to downgrade gzip requirement to "Recommends".

Also worth noting that it's essential part of system on many distibutions, and it's pretty hard to find a platform without gzip.

Ticket: ENT-9113