### PR TITLE
dependabot: Removed chore prefix for commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: pip
-    commit-message:
-      prefix: "chore"
     directory: /packaging/cfengine-nova-hub/
     schedule:
       interval: "daily"


### PR DESCRIPTION
We don't use this convention in CFEngine projects. See: https://github.com/cfengine/core/blob/master/CONTRIBUTING.md