### PR TITLE
ENT-10442: Switch together-javascript-action to main to avoid dependency update work

### DIFF
--- a/.github/workflows/build-using-buildscripts.yml
+++ b/.github/workflows/build-using-buildscripts.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cfengine/together-javascript-action
-          ref: v1.7
+          ref: main
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_TOGETHER_REPO }}
           ssh-known-hosts: github.com
 


### PR DESCRIPTION
We control the code, so no need to be "careful" here.

Ticket: ENT-10442
Changelog: none
