### PR TITLE
INF-3402: Removed aix71 exotic while build host is being built (3.21)

### DIFF
--- a/build-scripts/exotics.txt
+++ b/build-scripts/exotics.txt
@@ -6,7 +6,6 @@ PACKAGES_x86_64_linux_suse_15
 
 PACKAGES_ia64_hpux_11.23
 PACKAGES_ppc64_aix_53
-PACKAGES_ppc64_aix_71
 PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_solaris_10


### PR DESCRIPTION
Ticket: INF-3402
Changelog: none
(cherry picked from commit 177429615d76eb75908f86027fa29352834a01a3)