### PR TITLE
INF-3402: Removed aix71 label while build host is being built (3.18)

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -40,7 +40,6 @@ PACKAGES_x86_64_mingw
 
 PACKAGES_ia64_hpux_11.23
 PACKAGES_ppc64_aix_53
-PACKAGES_ppc64_aix_71
 PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
 PACKAGES_x86_64_solaris_10


### PR DESCRIPTION
(cherry picked from commit d5b8105a95e166d020d504834d9fa5234b5bc86e)

 Conflicts:
	build-scripts/labels.txt