### PR TITLE
INF-3402: Removed aix71 label while build host is being built (3.21)

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -38,5 +38,4 @@ PACKAGES_i386_mingw
 PACKAGES_x86_64_mingw
 
 PACKAGES_ia64_hpux_11.23
-PACKAGES_ppc64_aix_71
 PACKAGES_sparc64_solaris_11


### PR DESCRIPTION
(cherry picked from commit d5b8105a95e166d020d504834d9fa5234b5bc86e)