### PR TITLE
ENT-9170: Made deployment-tests workflow sharable by other projects (3.21)

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -46,10 +46,12 @@ jobs:
           path: masterfiles
           ref: ${{steps.together.outputs.masterfiles || github.base_ref}}
 
-      - name: Checkout Buildscripts (current project)
+      - name: Checkout Buildscripts
         uses: actions/checkout@v3
         with:
+          repository: cfengine/buildscripts
           path: buildscripts
+          ref: ${{steps.together.outputs.buildscripts || github.base_ref}}
           fetch-depth: 20
 
       - name: Checkout Nova
@@ -107,6 +109,7 @@ jobs:
             deps
 
       - name: Build package in docker
+        id: build_package
         env:
             GH_ACTIONS_SSH_KEY_BUILD_ARTIFACTS_CACHE: ${{ secrets.GH_ACTIONS_SSH_KEY_BUILD_ARTIFACTS_CACHE }}
         run: |
@@ -130,7 +133,7 @@ jobs:
           key: packages-${{ env.PACKAGE_SHA }}
 
       - name: Save artifacts
-        if: success() || failure()
+        if: ${{ success() || failure() && steps.build_package.conclusion != 'success' }}
         uses: actions/upload-artifact@v3
         with:
           name: artifacts

--- a/ci/package-sha.sh
+++ b/ci/package-sha.sh
@@ -10,7 +10,7 @@ CORE_SHA=$(git -C "${NTECH_ROOT}/core" log --pretty='format:%h' -1 -- .)
 echo "CORE_SHA: ${CORE_SHA}" >&2
 ENTERPRISE_SHA=$(git -C "${NTECH_ROOT}/enterprise" log --pretty='format:%h' -1 -- .)
 echo "ENTERPRISE_SHA: ${ENTERPRISE_SHA}" >&2
-NOVA_SHA=$(git -C "${NTECH_ROOT}/nova" log --pretty='format:%h' -1 -- .)
+NOVA_SHA=$("${NTECH_ROOT}/nova/ci/code-sha.sh")
 echo "NOVA_SHA: ${NOVA_SHA}" >&2
 MASTERFILES_SHA=$(git -C "${NTECH_ROOT}/masterfiles" log --pretty='format:%h' -1 -- .)
 echo "MASTERFILES_SHA: ${MASTERFILES_SHA}" >&2


### PR DESCRIPTION
Ticket: ENT-9170
Changelog: none
(cherry picked from commit 2c9591334bf1f7f9b5b6842ce9452dfa811a8284)

with https://github.com/cfengine/nova/pull/2096