### PR TITLE
ENT-10420 Remove s/cfapi_log/syslog/ replacement - 3.18.x

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -109,7 +109,6 @@ sed "s/define('ENVIRONMENT', 'development')/define('ENVIRONMENT','production')/g
 mv $RPM_BUILD_ROOT%prefix/share/GUI/public/index.php.tmp $RPM_BUILD_ROOT%prefix/share/GUI/public/index.php
 rm -f $RPM_BUILD_ROOT%prefix/share/GUI/public/index.php.tmp
 
-find $RPM_BUILD_ROOT%prefix/share/GUI -type f -exec sed -i 's/cfapi_log/syslog/' {} \;
 # NovaBase
 mkdir -p $RPM_BUILD_ROOT%prefix/share/NovaBase
 cp -R $RPM_BUILD_ROOT%prefix/masterfiles $RPM_BUILD_ROOT%prefix/share/NovaBase/masterfiles


### PR DESCRIPTION
It's not needed anymore, and takes 30 seconds on each build

Ticket: ENT-10420
(cherry picked from commit fe7bc33f81cb357fe38bc0260b769092b004bcd7)