### PR TITLE
Added cf-secret ComponentRef - 3.21.x

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.wxs
+++ b/packaging/cfengine-nova/cfengine-nova.wxs
@@ -182,6 +182,7 @@
             <ComponentRef Id='cf_net.exe' />
             <ComponentRef Id='cf_promises.exe' />
             <ComponentRef Id='cf_runagent.exe' />
+            <ComponentRef Id='cf_secret.exe' />
             <ComponentRef Id='cf_serverd.exe' />
             <ComponentRef Id='cf_upgrade.exe' />
             <ComponentRef Id='mdb_copy.exe' />


### PR DESCRIPTION
otherwise, cf-secret.exe was packaged into *.msi, but not installed on a target machine

Ticket: ENT-10405
(cherry picked from commit 1042d0bfce99ba294ac2e3c01b396514184b606c)

Merge together: https://github.com/cfengine/core/pull/5325