### PR TITLE
ENT-10429: Guarded against race condition in install scriptlets with restorecon

### DIFF
--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -149,11 +149,19 @@ systemctl restart cfengine3"
   fi
 fi
 
+restorecon_run=0
 if [ -f $PREFIX/policy_server.dat ]; then
   if ! [ -f "$PREFIX/UPGRADED_FROM.txt" ] || egrep '3\.([0-6]\.|7\.0)' "$PREFIX/UPGRADED_FROM.txt" > /dev/null; then
     # Versions <= 3.7.0 are unreliable in their daemon killing. Kill them one
     # more time now that we have upgraded.
     cf_console platform_service cfengine3 stop
+  fi
+
+  # Let's make sure all files and directories created above have correct SELinux labels.
+  # run this BEFORE we start services again to avoid race conditions in restorecon
+  if command -v restorecon >/dev/null; then
+    restorecon -iR /var/cfengine /opt/cfengine
+    restorecon_run=1
   fi
 
   if is_upgrade && [ -f "$PREFIX/UPGRADED_FROM_STATE.txt" ]; then
@@ -166,10 +174,11 @@ fi
 
 rm -f "$PREFIX/UPGRADED_FROM.txt"
 
-# Let's make sure all files and directories created above have correct SELinux
-# labels.
-if command -v restorecon >/dev/null; then
-  restorecon -iR /var/cfengine /opt/cfengine
+if [ $restorecon_run = 0 ]; then
+  # if we didn't run restorecon above in the already bootstrapped/upgrade case then run it now
+  if command -v restorecon >/dev/null; then
+    restorecon -iR /var/cfengine /opt/cfengine
+  fi
 fi
 
 exit 0


### PR DESCRIPTION
Try to run restorecon with the least number of processes/services running that might
make changes to /var/cfengine and /opt/cfengine

restorecon seems to gather a list of files up-front and then process which can take more
than a few seconds.

When services such as database or cf-execd/cf-agent/etc are running files can change
causing restorecon to error out when files are removed.

The files being removed doesn't create a risk of bad SELinux labels since they are gone.

Ticket: ENT-10429
Changelog: title
