### PR TITLE
ENT-10647: Fixed and improved postgresql server state handling in package scriptlets (3.18)

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -424,7 +424,7 @@ init_postgres_dir()
         # Started successfully, stop it again, the migration requires it to be not running.
         (cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl -w -D $PREFIX/state/pg/data -l /var/log/postgresql.log stop") || failure=1
         if [ $failure = 0 ]; then
-          wait_for_cfpostgres_down || failure=1
+          wait_for_cf_postgres_down || failure=1
         fi
         if [ $failure != 0 ]; then
           cf_console echo "Error: unable to shutdown postgresql server. Showing last of /var/log/postgresql.log for clues."
@@ -689,7 +689,7 @@ do_migration() {
     # Consult the last few lines of "/var/cfengine/state/pg/data/pg_upgrade_output.d/20230913T150025.959/log/pg_upgrade_server.log" for the probable cause of the failure.
     cf_console echo "Showing last lines of any related log files:"
     _daysearch=$(date +%Y%m%d)
-    find "$PREFIX"/state/pg/data/pg_upgrade_output.d -name *.log | grep "$_daysearch" | xargs tail
+    find "$PREFIX"/state/pg/data/pg_upgrade_output.d -name *.log | grep "$_daysearch" | cf_console xargs tail
     cf_console echo
     check_disk_space # will abort if low on disk space
     init_postgres_dir "$new_pgconfig_file" "$pgconfig_type"

--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -82,12 +82,12 @@ restore_cfengine_state() {
 }
 
 wait_for_cf_postgres() {
-    # wait for CFEngine Postgresql service to be available, up to 5 sec.
+    # wait for CFEngine Postgresql service to be available, up to 60 sec.
     # Returns 0 is psql command succeeds,
     # Returns non-0 otherwise (1 if exited by timeout)
-    for i in $(seq 1 5); do
+    for i in $(seq 1 60); do
         true "checking if Postgresql is available..."
-        if $PREFIX/bin/psql cfsettings -c "SELECT 1;" >/dev/null 2>&1; then
+        if cd /tmp && su cfpostgres -c "$PREFIX/bin/psql -l" >/dev/null 2>&1; then
             true "Postgresql is available, moving on"
             return 0
         fi
@@ -96,16 +96,16 @@ wait_for_cf_postgres() {
     done
     # Note: it is important that this is the last command of this function.
     # Return code of `psql` is the return code of whole function.
-    $PREFIX/bin/psql cfsettings -c "SELECT 1;" >/dev/null 2>&1
+    cd /tmp && su cfpostgres -c "$PREFIX/bin/psql -l" >/dev/null 2>&1
 }
 
 wait_for_cf_postgres_down() {
-    # wait for CFEngine Postgresql service to be shutdown, up to 5 sec.
+    # wait for CFEngine Postgresql service to be shutdown, up to 60 sec.
     # Returns 0 if postgresql service is not running
     # Returns non-0 otherwise (1 if exited by timeout)
-    for i in $(seq 1 5); do
+    for i in $(seq 1 60); do
         true "checking if Postgresql is shutdown..."
-        if ! "$PREFIX"/bin/pg_isready >/dev/null 2>&1; then
+        if cd /tmp && ! su cfpostgres -c "$PREFIX/bin/psql -l" >/dev/null 2>&1; then
             true "Postgresql is shutdown, moving on"
             return 0
         fi
@@ -113,8 +113,8 @@ wait_for_cf_postgres_down() {
         sleep 1
     done
     # Note: it is important that this is the last command of this function.
-    # Return code of `pg_isready` is the return code of whole function.
-    ! "$PREFIX"/bin/pg_isready >/dev/null 2>&1
+    # Return code of `psql` is the return code of whole function.
+    cd /tmp && ! su cfpostgres -c "$PREFIX/bin/psql -l" >/dev/null 2>&1
 }
 
 safe_cp() {


### PR DESCRIPTION
One typo fix. This was causing failure in ALL upgrades. Ouch.

Changed wait time for server stop/start from 5 seconds to 60.

Added cf_console to pg_upgrade failure tailing so it is visible in console.

Changed condition to test for stopped/started to something that works with tighter restrictions.
Using a select as root was failing due to lack of an account in postgresql at the moment we
were checking: bare database without any further manipulation by setup scripts.

Ticket: ENT-10647
Changelog: title
(cherry picked from commit 83c91b5796be5f910b8b710df86391f2da533e61)
