### PR TITLE
ENT-10429: Guarded against race condition in install scriptlets with restorecon (3.21)

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1080,6 +1080,14 @@ if ! [ -f "$PREFIX/UPGRADED_FROM.txt" ] || egrep '3\.([0-6]\.|7\.0)' "$PREFIX/UP
   cf_console platform_service cfengine3 stop
 fi
 
+# Let's make sure all files and directories created above have correct SELinux
+# labels. We do this while the database is stopped on purpose, restorecon caches its list of
+# files up-front and the database often adds/removes files as it starts up, especially pg_internal.init
+# files inside /var/cfengine/state/pg/data/base/<oid> directories. ENT-10429
+if command -v restorecon >/dev/null; then
+  restorecon -iR /var/cfengine /opt/cfengine
+fi
+
 if is_upgrade && [ -f "$PREFIX/UPGRADED_FROM_STATE.txt" ]; then
     cf_console restore_cfengine_state "$PREFIX/UPGRADED_FROM_STATE.txt"
     rm -f "$PREFIX/UPGRADED_FROM_STATE.txt"
@@ -1088,11 +1096,5 @@ else
 fi
 
 rm -f "$PREFIX/UPGRADED_FROM.txt"
-
-# Let's make sure all files and directories created above have correct SELinux
-# labels.
-if command -v restorecon >/dev/null; then
-  restorecon -iR /var/cfengine /opt/cfengine
-fi
 
 exit 0


### PR DESCRIPTION
Try to run restorecon with the least number of processes/services running that might
make changes to /var/cfengine and /opt/cfengine

restorecon seems to gather a list of files up-front and then process which can take more
than a few seconds.

When services such as database or cf-execd/cf-agent/etc are running files can change
causing restorecon to error out when files are removed.

The files being removed doesn't create a risk of bad SELinux labels since they are gone.

Ticket: ENT-10429
Changelog: title
(cherry picked from commit ee768186c07e45b2d9e9917e00afda79764597b1)
