### PR TITLE
ENT-10347: Added Debian 12 label to buildscripts

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -4,6 +4,7 @@ PACKAGES_HUB_x86_64_linux_debian_9
 PACKAGES_HUB_x86_64_linux_debian_10
 PACKAGES_HUB_x86_64_linux_debian_11
 PACKAGES_HUB_arm_64_linux_debian_11
+PACKAGES_HUB_x86_64_linux_debian_12
 
 PACKAGES_HUB_x86_64_linux_redhat_7
 PACKAGES_HUB_x86_64_linux_redhat_8
@@ -19,6 +20,7 @@ PACKAGES_x86_64_linux_debian_9
 PACKAGES_x86_64_linux_debian_10
 PACKAGES_x86_64_linux_debian_11
 PACKAGES_arm_64_linux_debian_11
+PACKAGES_x86_64_linux_debian_12
 
 PACKAGES_x86_64_linux_redhat_6
 PACKAGES_x86_64_linux_redhat_7


### PR DESCRIPTION
Merge together with:
 - https://github.com/mendersoftware/infra/pull/382
 - https://github.com/cfengine/system-testing/pull/506
 - https://github.com/cfengine/core/pull/5363