### PR TITLE
ENT-10710: Silence pg_upgrade check warning for debian-9

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -699,14 +699,17 @@ do_migration() {
       exit 0 # exits only from (...)
     fi
     cf_console echo "Migration using pg_upgrade failed."
-    # skip ubuntu-16 since there is an expected failure there
+    # skip ubuntu-16 and debian-9 since there is an expected failure there
     # check for "/var/cfengine/state/pg/backup/bin/postgres" failed: cannot execute
-    if [ "$BUILT_ON_OS" != "ubuntu" ] && [ "$BUILT_ON_OS_VERSION" != "16" ]; then
+    if { [ "$BUILT_ON_OS" = "debian" ] && [ "$BUILT_ON_OS_VERSION" = "9" ]; } || \
+       { [ "$BUILT_ON_OS" = "ubuntu" ] && [ "$BUILT_ON_OS_VERSION" = "16" ]; }; then
+      true # no-op
+    else
       # here pg_upgrade probably said something like
       # Consult the last few lines of "/var/cfengine/state/pg/data/pg_upgrade_output.d/20230913T150025.959/log/pg_upgrade_server.log" for the probable cause of the failure.
       cf_console echo "Showing last lines of any related log files:"
       _daysearch=$(date +%Y%m%d)
-      find "$PREFIX"/state/pg/data/pg_upgrade_output.d -name *.log | grep "$_daysearch" | cf_console xargs tail
+      find "$PREFIX"/state/pg/data/pg_upgrade_output.d -name '*.log' | grep "$_daysearch" | cf_console xargs tail
     fi
     cf_console echo
     check_disk_space # will abort if low on disk space


### PR DESCRIPTION
The failure warning about postgres cannot execute snags us in our tests but
is fine because we proceed to upgrade in a different way during upgrade.

Ticket: ENT-10710
Changelog: none
