### PR TITLE
ENT-10739: Improved locale env vars safety during installation for postgresql (3.21)

### DIFF
--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -1,18 +1,5 @@
-# These can have bad effects on certain commands if set incorrectly. Found
-# when investigating why PostgreSQL was not starting.
-unset LANG
-unset LC_ADDRESS
-unset LC_ALL
-unset LC_IDENTIFICATION
-unset LC_MEASUREMENT
-unset LC_MONETARY
-unset LC_NAME
-unset LC_NUMERIC
-unset LC_PAPER
-unset LC_TELEPHONE
-unset LC_TIME
-
-
+# postgresql docs, https://www.postgresql.org/docs/current/locale.html, recommend using C locale unless otherwise needed
+export LC_ALL=C # overrides all other env vars: https://www.gnu.org/software/libc/manual/html_node/Locale-Categories.html
 # Upgrade detection is a mess. It is often difficult to tell, especially from
 # the postinstall script, so we use the package-upgrade.txt file to remember.
 case "$PKG_TYPE" in


### PR DESCRIPTION
It was found that an LC_CTYPE=UTF-8 from iTerm2 on OSX was breaking the hub package install.

PostgreSQL docs suggest using 'C' locale unless otherwise needed
https://www.postgresql.org/docs/current/locale.html

> The drawback of using locales other than C or POSIX in PostgreSQL is its performance impact. It slows character handling and prevents ordinary indexes from being used by LIKE. For this reason use locales only if you actually need them.

Ticket: ENT-10739
Changelog: title
(cherry picked from commit 2db105c6a89c6e2d400bdd1d45f9210f1337ef3c)
