### PR TITLE
ENT-10801: Added checksums for wix tools coming from sftp cache

### DIFF
--- a/build-scripts/package-msi
+++ b/build-scripts/package-msi
@@ -17,8 +17,13 @@ else
     echo '
 get /export/images/windows/wix310-binaries.zip
 get /export/images/windows/wine-folder.tar.xz
-'  |  sftp -i ~/.ssh/build_artifacts_cache.id_rsa -b - jenkins_sftp_cache@build-artifacts-cache.cloud.cfengine.com
+'  |  sftp -b - jenkins_sftp_cache@build-artifacts-cache.cloud.cfengine.com
 
+    # check checksums
+    sha256sum -c - <<EOF || exit 42
+493145b3fac22bdf8c55142a9f96ef8136d56b38d78a2322f13f1ba11f9cf2f8  wix310-binaries.zip
+3510fd8c4ecb4a9c479dfe43849183c666f9e41b019fc7135dc8735d0032d16e  wine-folder.tar.xz
+EOF
     # Install Wix tools
     mkdir -p "$WIXPATH"
     cd "$WIXPATH" || exit


### PR DESCRIPTION
Just to be sure if sftp cache is compromised, fail if checksums don't match.

Ticket: ENT-10801
Changelog: none
