### PR TITLE
[3.18.x] Do not `systemctl enable` individual services

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1044,19 +1044,9 @@ if ! is_upgrade; then
   if [ -x /bin/systemctl ]; then
     # Reload systemd config to pick up newly installed units
     /bin/systemctl daemon-reload > /dev/null 2>&1
-    # Enable service units
-    # Enabling services is OK to fail (they can be masked, for example)
-    set +e
-    /bin/systemctl enable cf-apache.service > /dev/null 2>&1
-    /bin/systemctl enable cf-execd.service > /dev/null 2>&1
-    /bin/systemctl enable cf-serverd.service > /dev/null 2>&1
-    /bin/systemctl enable cf-runalerts.service > /dev/null 2>&1
-    /bin/systemctl enable cf-monitord.service > /dev/null 2>&1
-    /bin/systemctl enable cf-postgres.service > /dev/null 2>&1
-    /bin/systemctl enable cf-hub.service > /dev/null 2>&1
-    /bin/systemctl enable cf-reactor.service > /dev/null 2>&1
-    /bin/systemctl enable cfengine3.service > /dev/null 2>&1
-    set -e
+    # Enable cfengine3 service (starts all the other services)
+    # Enabling the service is OK to fail (can be masked, for example)
+    /bin/systemctl enable cfengine3.service > /dev/null 2>&1 || true
   else
     case "`os_type`" in
       redhat)

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -64,14 +64,9 @@ case `os_type` in
     if [ -x /bin/systemctl ]; then
       # Reload systemd config to pick up newly installed units
       /bin/systemctl daemon-reload > /dev/null 2>&1
-      # Enable service units
-      # Enabling services is OK to fail (they can be masked, for example)
-      set +e
-      /bin/systemctl enable cf-execd.service > /dev/null 2>&1
-      /bin/systemctl enable cf-serverd.service > /dev/null 2>&1
-      /bin/systemctl enable cf-monitord.service > /dev/null 2>&1
-      /bin/systemctl enable cfengine3.service > /dev/null 2>&1
-      set -e
+      # Enable cfengine3 service (starts all the other services)
+      # Enabling the service is OK to fail (can be masked, for example)
+      /bin/systemctl enable cfengine3.service > /dev/null 2>&1 || true
     else
       case `os_type` in
         redhat)


### PR DESCRIPTION
The `cfengine3.service` uses `Wants` to start all the other available CFEngine services. `systemctl enable` on one of the individual services causes them to be started in their respective `.target` (e.g. `multi-user.target`) and thus `systemctl disable cfengine3` is not enough to stop them from being started on boot.

Being able to enable individual services is useful, but it shouldn't be done by default.

(cherry picked from commit f53a8f12a66ed19b7a73fab582b2f354357e8023)