### PR TITLE
ENT-10966: Added missing dependency updates for 3.18.x

### DIFF
--- a/deps-packaging/autoconf/cfbuild-autoconf.spec
+++ b/deps-packaging/autoconf/cfbuild-autoconf.spec
@@ -1,18 +1,18 @@
 Summary: CFEngine Build Automation -- autoconf
 Name: cfbuild-autoconf
-Version: 2.69
+Version: 2.71
 Release: 1
-Source0: autoconf-2.69.tar.gz
+Source0: autoconf-2.71.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
-BuildRoot: %{_topdir}/BUILD/%{name}-2.60-buildroot
+BuildRoot: %{_topdir}/BUILD/%{name}-2.71-buildroot
 
 AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n autoconf-2.60
+%setup -q -n autoconf-2.71
 
 ./configure --prefix=/usr
 

--- a/deps-packaging/autoconf/distfiles
+++ b/deps-packaging/autoconf/distfiles
@@ -1,1 +1,1 @@
-82d05e03b93e45f5a39b828dc9c6c29b  autoconf-2.69.tar.gz
+f64e38d671fdec06077a41eb4d5ee476  autoconf-2.71.tar.gz

--- a/deps-packaging/automake/cfbuild-automake.spec
+++ b/deps-packaging/automake/cfbuild-automake.spec
@@ -1,18 +1,18 @@
 Summary: CFEngine Build Automation -- automake
 Name: cfbuild-automake
-Version: 1.10.1
+Version: 1.10.3
 Release: 1
-Source0: automake-1.10.1.tar.gz
+Source0: automake-1.10.3.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
-BuildRoot: %{_topdir}/BUILD/%{name}-1.10.1-buildroot
+BuildRoot: %{_topdir}/BUILD/%{name}-1.10.3-buildroot
 
 AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n automake-1.10.1
+%setup -q -n automake-1.10.3
 
 ./configure --prefix=/usr
 

--- a/deps-packaging/automake/distfiles
+++ b/deps-packaging/automake/distfiles
@@ -1,1 +1,1 @@
-a0acfd1b167ba55a256f0c1af2983975  automake-1.10.1.tar.gz
+03bc9ebfa805f9ee5635f1f53fa1fa5f  automake-1.10.3.tar.gz

--- a/deps-packaging/libcurl/cfbuild-libcurl.spec
+++ b/deps-packaging/libcurl/cfbuild-libcurl.spec
@@ -1,4 +1,4 @@
-%define curl_version 8.2.1
+%define curl_version 8.5.0
 
 Summary: CFEngine Build Automation -- libcurl
 Name: cfbuild-libcurl

--- a/deps-packaging/libcurl/distfiles
+++ b/deps-packaging/libcurl/distfiles
@@ -1,1 +1,1 @@
-f98bdb06c0f52bdd19e63c4a77b5eb19b243bcbbd0f5b002b9f3cba7295a3a42  curl-8.2.1.tar.gz
+05fc17ff25b793a437a0906e0484b82172a9f4de02be5ed447e0cab8c3475add  curl-8.5.0.tar.gz

--- a/deps-packaging/libgcc/cfbuild-libgcc.spec
+++ b/deps-packaging/libgcc/cfbuild-libgcc.spec
@@ -2,7 +2,7 @@
 
 Summary: The CFEngine Configuration System
 Name: cfbuild-libgcc
-Version: 4.2.0
+Version: 4.2.4
 Release: 0
 Vendor: IBM
 License: Proprietary

--- a/deps-packaging/libtool/cfbuild-libtool.spec
+++ b/deps-packaging/libtool/cfbuild-libtool.spec
@@ -1,18 +1,18 @@
 Summary: CFEngine Build Automation -- libtool
 Name: cfbuild-libtool
-Version: 1.5.24
+Version: 1.5.26
 Release: 1
-Source0: libtool-1.5.24.tar.gz
+Source0: libtool-1.5.26.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
-BuildRoot: %{_topdir}/BUILD/%{name}-1.5.24-buildroot
+BuildRoot: %{_topdir}/BUILD/%{name}-1.5.26-buildroot
 
 AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n libtool-1.5.24
+%setup -q -n libtool-1.5.26
 
 ./configure --prefix=/usr
 

--- a/deps-packaging/libtool/distfiles
+++ b/deps-packaging/libtool/distfiles
@@ -1,1 +1,1 @@
-d0071c890101fcf4f2be8934a37841b0  libtool-1.5.24.tar.gz
+aa9c5107f3ec9ef4200eb6556f3b3c29  libtool-1.5.26.tar.gz


### PR DESCRIPTION
Added missing dependency updates for 3.18.x after https://github.com/cfengine/buildscripts/pull/1351

* Updated libcurl-hub from 8.2.1 to 8.5.0
* Upgraded autoconf from 2.69 to 2.71
* Updated automake from 1.10.1 to 1.10.3
* Updated libgcc from 4.2.0 to 4.2.4
* Updated libtool from 1.5.24 to 1.5.26