### PR TITLE
ENT-10997: Added Debian 12 labels to buildscripts (3.18.x)

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -4,6 +4,7 @@ PACKAGES_HUB_x86_64_linux_debian_9
 PACKAGES_HUB_x86_64_linux_debian_10
 PACKAGES_HUB_x86_64_linux_debian_11
 PACKAGES_HUB_arm_64_linux_debian_11
+PACKAGES_HUB_x86_64_linux_debian_12
 
 PACKAGES_HUB_x86_64_linux_redhat_6
 PACKAGES_HUB_x86_64_linux_redhat_7
@@ -19,6 +20,7 @@ PACKAGES_x86_64_linux_debian_9
 PACKAGES_x86_64_linux_debian_10
 PACKAGES_x86_64_linux_debian_11
 PACKAGES_arm_64_linux_debian_11
+PACKAGES_x86_64_linux_debian_12
 
 PACKAGES_x86_64_linux_redhat_6
 PACKAGES_x86_64_linux_redhat_7

--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -5,6 +5,7 @@ PACKAGES_HUB_x86_64_linux_debian_10
 PACKAGES_HUB_x86_64_linux_debian_11
 PACKAGES_HUB_arm_64_linux_debian_11
 PACKAGES_HUB_x86_64_linux_debian_12
+PACKAGES_HUB_arm_64_linux_debian_12
 
 PACKAGES_HUB_x86_64_linux_redhat_6
 PACKAGES_HUB_x86_64_linux_redhat_7
@@ -21,6 +22,7 @@ PACKAGES_x86_64_linux_debian_10
 PACKAGES_x86_64_linux_debian_11
 PACKAGES_arm_64_linux_debian_11
 PACKAGES_x86_64_linux_debian_12
+PACKAGES_arm_64_linux_debian_12
 
 PACKAGES_x86_64_linux_redhat_6
 PACKAGES_x86_64_linux_redhat_7


### PR DESCRIPTION
Merge together:
* https://github.com/cfengine/core/pull/5411