### PR TITLE
Package Python bindings for our libraries

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -150,7 +150,7 @@ touch $RPM_BUILD_ROOT/var/log/postgresql.log
 # Make sure cfbs is available and in place
 mkdir -p $RPM_BUILD_ROOT/tmp/cfbs_root
 pip3 install --root $RPM_BUILD_ROOT/tmp/cfbs_root -r %{_basedir}/buildscripts/packaging/cfengine-nova-hub/requirements.txt
-mkdir $RPM_BUILD_ROOT%prefix/lib/python
+mkdir -p $RPM_BUILD_ROOT%{prefix}/lib/python
 mv $RPM_BUILD_ROOT/tmp/cfbs_root/usr/lib/python*/site-packages/cfbs $RPM_BUILD_ROOT%prefix/lib/python
 mv $RPM_BUILD_ROOT/tmp/cfbs_root/usr/bin/cfbs $RPM_BUILD_ROOT%prefix/bin/
 sed -i "/^from cfbs.*/i sys.path.append(\"%prefix/lib/python\")" $RPM_BUILD_ROOT%prefix/bin/cfbs
@@ -289,6 +289,7 @@ exit 0
 %prefix/lib/lib*.so*
 %prefix/lib/cfengine-enterprise.so
 %prefix/lib/cfengine-report-collect.so
+
 # PHP modules
 %prefix/lib/php
 #libs needed by apache ldapmodules
@@ -296,10 +297,10 @@ exit 0
 #libs of postgres
 %{prefix}/lib/postgresql/*
 
-# Python stuff (cfbs)
-%if %{?rhel}%{!?rhel:0} >= 7
+# Python stuff (bindings + cfbs)
 %dir %prefix/lib/python
 %prefix/lib/python/*
+%if %{?rhel}%{!?rhel:0} >= 7
 %attr(755,root,root) %prefix/bin/cfbs
 %endif
 

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -38,7 +38,7 @@ Requires: libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_3.0.0)(64bit) libcrypto
 Requires: libssl.so.3()(64bit) libssl.so.3(OPENSSL_3.0.0)(64bit)
 %endif
 
-# cfbs/Build requires Python 3.5+
+# cfbs/Build requires Python 3.5+ (not available on RHEL 6)
 %if %{?rhel}%{!?rhel:0} == 7
 Requires: python3 >= 3.5
 %endif
@@ -146,6 +146,7 @@ cp %{_basedir}/nova/db/ootb_import.sql $RPM_BUILD_ROOT%prefix/share/db/
 mkdir -p $RPM_BUILD_ROOT/var/log/
 touch $RPM_BUILD_ROOT/var/log/postgresql.log
 
+# RHEL 6 doesn't have Python 3 so no cfbs there.
 %if %{?rhel}%{!?rhel:0} >= 7
 # Make sure cfbs is available and in place
 mkdir -p $RPM_BUILD_ROOT/tmp/cfbs_root

--- a/packaging/cfengine-nova-hub/debian/rules
+++ b/packaging/cfengine-nova-hub/debian/rules
@@ -87,7 +87,7 @@ install: build
 # Make sure cfbs is available and in place
 	mkdir -p $(CURDIR)/debian/tmp/tmp/cfbs_root
 	pip3 install --root $(CURDIR)/debian/tmp/tmp/cfbs_root -r $(CURDIR)/requirements.txt
-	mkdir $(CURDIR)/debian/tmp$(PREFIX)/lib/python
+	mkdir -p $(CURDIR)/debian/tmp$(PREFIX)/lib/python
 	mv $(CURDIR)/debian/tmp/tmp/cfbs_root/usr/local/lib/python*/dist-packages/cfbs $(CURDIR)/debian/tmp$(PREFIX)/lib/python
 	mv $(CURDIR)/debian/tmp/tmp/cfbs_root/usr/local/bin/cfbs $(CURDIR)/debian/tmp$(PREFIX)/bin/
 	sed -i "/^from cfbs.*/i sys.path.append(\"$(PREFIX)/lib/python\")" $(CURDIR)/debian/tmp$(PREFIX)/bin/cfbs

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -126,6 +126,10 @@ exit 0
 %prefix/bin/mdb_dump
 %prefix/bin/mdb_load
 
+# Python stuff (if any)
+%dir %prefix/lib/python
+%prefix/lib/python/*
+
 # diffutils
 %prefix/bin/diff
 %prefix/bin/sdiff

--- a/packaging/cfengine-nova/debian/cfengine-nova.install
+++ b/packaging/cfengine-nova/debian/cfengine-nova.install
@@ -23,6 +23,7 @@
 /var/cfengine/bin/cf-support
 /var/cfengine/bin/cf-upgrade
 /var/cfengine/lib/lib*.so.*
+/var/cfengine/lib/python/*
 /var/cfengine/lib/cfengine-enterprise.so
 /var/cfengine/lib/liblmdb.so
 /var/cfengine/share/doc


### PR DESCRIPTION
For hubs we already package /var/cfengine/lib/python, we should
also do it in non-hub packages.


Ticket: CFE-4281
Changelog: None

Merge together:
https://github.com/cfengine/core/pull/5438
https://github.com/cfengine/buildscripts/pull/1367