### PR TITLE
Modified retry_wrapper to get more info about package manager retry reasons (3.21)

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -589,6 +589,8 @@ retry_wrapper()
             return 0
         else
             err_ret=$?
+            # in case say dpkg locks are held by automatic updates or something
+            ps -efl | grep -P '(apt|dpkg|yum|dnf|zypper|rpm|pkg)'
             maxtries=`expr $maxtries - 1`
 	    echo "* FAILURE $err_ret"
             echo "* Sleeping for:  $pause seconds"


### PR DESCRIPTION
See if another package manager process is locking the package manager database, like /var/lib/dpkg/lock and such

Ticket: ENT-11166
Changelog: none
(cherry picked from commit 0a2fd9947571eeca891ca8c6afa4e7de371d338e)
