### PR TITLE
ENT-11166: Removed not present ShellCheck package from rhel-9 and rhel-9 build host configs

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -110,7 +110,6 @@ bundle agent cfengine_build_host_setup
       "perl";
       "pkgconf" comment => "pkgconfig renamed to pkgconf in rhel8";
       "selinux-policy-devel" comment => "maybe add to _7 and _6?";
-      "ShellCheck" comment => "only rhel-8 and rhel-9 have a new enough version to be useful. via epel-release https://packages.fedoraproject.org/pkgs/ShellCheck/ShellCheck/";
       "openssl-devel";
 
     redhat_9::


### PR DESCRIPTION
Ticket: ENT-11166
Changelog: none
