### PR TITLE
ENT-11166: Fix typo in previous commit related to ci/cfengine-build-host-setup.cf

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -196,9 +196,9 @@ bundle agent cfengine_build_host_setup
         content => "%dist .suse11",
         comment => "ensure %dist works in RPM .spec files - needed to add OS name/version to rpm filename";
     redhat_8|centos_8|redhat_9::
-      "/etc/yum.conf" edit_line => set_variable_values(yum_conf)
+      "/etc/yum.conf" edit_line => set_variable_values(yum_conf),
         classes => if_ok("yum_conf_ok");
-      "/etc/dnf.conf" edit_line => set_variable_values(dnf_conf)
+      "/etc/dnf.conf" edit_line => set_variable_values(dnf_conf),
         classes => if_ok("dnf_conf_ok");
 
   commands:


### PR DESCRIPTION
Ticket: none
Changelog: none