### PR TITLE
[3.21.x] Create a symlink for cfbs in /usr/local/sbin

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -266,7 +266,10 @@ then
   fi
 fi
 
-for i in cf-agent cf-promises cf-key cf-secret cf-execd cf-serverd cf-monitord cf-runagent cf-hub cf-reactor cf-net cf-check cf-support;
+for i in cf-agent cf-promises cf-key cf-secret cf-execd cf-serverd cf-monitord cf-runagent \
+         cf-hub cf-reactor \
+         cf-net cf-check cf-support \
+         cfbs;
 do
   if [ -f $PREFIX/bin/$i -a -d /usr/local/sbin ]; then
     ln -sf $PREFIX/bin/$i /usr/local/sbin/$i || true


### PR DESCRIPTION
Just like we do with many other executables we ship in /var/cfengine/bin.

Ticket: ENT-10936
Changelog: /usr/local/sbin/cfbs now exists as a symlink
           to /var/cfengine/bin/cfbs making 'sudo cfbs' work in
           environments where /usr/local/sbin is in sudo secure_path
(cherry picked from commit 5881f0f670bb96c8ec8c3f8da0cb678cf3565dad)