### PR TITLE
Use reflinks if possible for copying masterfiles and web UI

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -64,7 +64,7 @@ if [ ! -f "$PREFIX/ppkeys/localhost.priv" ]; then
 fi
 
 if [ ! -f "$PREFIX/masterfiles/promises.cf" ]; then
-    /bin/cp -R "$PREFIX/share/NovaBase/masterfiles" "$PREFIX"
+    /bin/cp --reflink=auto -R "$PREFIX/share/NovaBase/masterfiles" "$PREFIX"
     touch "$PREFIX/masterfiles/cf_promises_validated"
     find "$PREFIX/masterfiles" -type d -exec chmod 700 {} \;
     find "$PREFIX/masterfiles" -type f -exec chmod 600 {} \;
@@ -114,7 +114,7 @@ EOF
 )
 true "Done creating httpd/secrets.ini file"
 
-cp -r --remove-destination $PREFIX/share/GUI/* $PREFIX/httpd/htdocs
+cp --reflink=auto -r --remove-destination $PREFIX/share/GUI/* $PREFIX/httpd/htdocs
 
 # If old files were moved aside during upgrade, we should move them back so that
 # rpm can do its cleanup procedures. But avoid overwriting new files with the


### PR DESCRIPTION
The postinstall scriptlet on hub copies masterfiles and web UI to separate the pristine original version from the working copy ready for customization. By using `--reflink=auto` will tell `cp` to try to use reflinks if possible which makes the copy much faster on file systems with reflinks enabled (XFS, btrfs, bcachefs,...). It also saves disk space, but checking `du -sh /var/cfengine` gives the same result because `du` doesn't inspect the FS into such detail.

Ticket: none
Changelog: Postinstallation scriptlets of hub packages now use
           reflinks to copy masterfiles and web UI files if
           possible