### PR TITLE
Drop cf-runalerts.service and the runalerts stamp directory

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -140,7 +140,6 @@ rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 /usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 
 # Documentation

--- a/packaging/cfengine-community/debian/cfengine-community.install
+++ b/packaging/cfengine-community/debian/cfengine-community.install
@@ -6,7 +6,6 @@
 /usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 /etc/default/cfengine3
 /etc/profile.d/cfengine3.sh

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -102,9 +102,6 @@ rm -f $RPM_BUILD_ROOT%{prefix}/lib/php/cfengine-enterprise-api.la
 
 cp -R %{_basedir}/mission-portal $RPM_BUILD_ROOT%prefix/share/GUI
 
-rm -f $RPM_BUILD_ROOT%prefix/share/GUI/runalerts.php
-cp -v %{_basedir}/mission-portal/runalerts.php $RPM_BUILD_ROOT%prefix/bin/runalerts.php
-
 cp -vR %{_basedir}/mission-portal/Apache-htaccess $RPM_BUILD_ROOT%prefix/share/GUI/htaccess
 mkdir -p $RPM_BUILD_ROOT%prefix/share/GUI/api
 cp -R %{_basedir}/nova/api/http/* $RPM_BUILD_ROOT%prefix/share/GUI/api
@@ -217,10 +214,9 @@ exit 0
 # Nova-only binaries
 %prefix/bin/cf-hub
 %prefix/bin/cf-reactor
-%prefix/bin/runalerts.php
+
 # Only verify owner group mode maj min symlink
 # Don't verify md5, size, mtime
-%verify(not md5 size mtime) %prefix/bin/runalerts.php
 #rsync
 %prefix/bin/rsync
 # init.d script enterprise part
@@ -334,7 +330,6 @@ exit 0
 /usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 
 %if %{?rhel}%{!?rhel:0} > 7

--- a/packaging/cfengine-nova-hub/debian/cfengine-nova-hub.install
+++ b/packaging/cfengine-nova-hub/debian/cfengine-nova-hub.install
@@ -8,7 +8,6 @@
 /usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 /var/cfengine/bin/cf-agent
 /var/cfengine/bin/cf-check
@@ -21,7 +20,6 @@
 /var/cfengine/bin/cf-secret
 /var/cfengine/bin/cf-serverd
 /var/cfengine/bin/cf-support
-/var/cfengine/bin/runalerts.php
 /var/cfengine/bin/rsync
 /var/cfengine/bin/cfengine3-nova-hub-init-d.sh
 /var/cfengine/bin/git

--- a/packaging/cfengine-nova-hub/debian/rules
+++ b/packaging/cfengine-nova-hub/debian/rules
@@ -42,9 +42,6 @@ install: build
 # GUI, REST, KB
 	cp -R $(BASEDIR)/mission-portal $(CURDIR)/debian/tmp$(PREFIX)/share/GUI
 
-	rm -f $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/runalerts.php
-	cp -v $(BASEDIR)/mission-portal/runalerts.php $(CURDIR)/debian/tmp$(PREFIX)/bin/runalerts.php
-
 	mkdir $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/api
 	cp -R $(BASEDIR)/nova/api/http/* $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/api
 	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/share/GUI/api/dc-scripts/*.sh

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -158,7 +158,6 @@ exit 0
 /usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 
 # Documentation

--- a/packaging/cfengine-nova/debian/cfengine-nova.install
+++ b/packaging/cfengine-nova/debian/cfengine-nova.install
@@ -8,7 +8,6 @@
 /usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 /var/cfengine/bin/cf-agent
 /var/cfengine/bin/cf-check

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1045,18 +1045,9 @@ fi
 
 (cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart" || su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m fast")
 
-##
-# ENT-3921: Make bin/runalerts.php executable
-#
-chmod 755 $PREFIX/bin/runalerts.php
-
-# ENT-9711: Ensure $PREFIX/httpd/php/runalerts-stamp is created and has proper owner/permissions
 # Have to be careful here because httpd/php/bin wants to be root:root
-mkdir -p "$PREFIX/httpd/php/runalerts-stamp"
 chown root:$MP_APACHE_USER $PREFIX/httpd/php
-chown -R root:$MP_APACHE_USER $PREFIX/httpd/php/runalerts-stamp
 chmod g+rX "$PREFIX/httpd/php"
-chmod -R g+rX "$PREFIX/httpd/php/runalerts-stamp"
 
 #
 # Register CFEngine initscript, if not yet.

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -395,4 +395,9 @@ if is_upgrade && egrep '^3\.([2-9]|1[012345])\.' "$PREFIX/UPGRADED_FROM.txt" >/d
   true "Done removing keys"
 fi
 
+# Since 3.24.0 runalerts is part of cf-reactor with no stamp files
+if is_upgrade && test -d "$PREFIX/httpd/php/runalerts-stamp"; then
+  rm -rf "$PREFIX/httpd/php/runalerts-stamp"
+fi
+
 exit 0


### PR DESCRIPTION
Runalerts is now part of cf-reactor with no stamp files.

Ticket: ENT-11538
Changelog: None

Merge together:
https://github.com/cfengine/nova/pull/2208
https://github.com/cfengine/core/pull/5487
https://github.com/cfengine/masterfiles/pull/2878
https://github.com/cfengine/buildscripts/pull/1407