### PR TITLE
ENT-11309: Added Ubuntu 24 to labels.txt

### DIFF
--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -21,7 +21,7 @@ case "$OS" in
         UNWANTED_DEPS="libtool-ltdl libtool-ltdl-devel"
         ;;
     debian|ubuntu)
-        DEP_LIST="dpkg-dev debhelper g++ libncurses5 pkg-config build-essential libpam0g-dev"
+        DEP_LIST="dpkg-dev debhelper g++ pkg-config build-essential libpam0g-dev"
         UNWANTED_DEPS="libltdl-dev libltdl7"
         ;;
 

--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -15,6 +15,8 @@ PACKAGES_HUB_x86_64_linux_ubuntu_18
 PACKAGES_HUB_x86_64_linux_ubuntu_20
 PACKAGES_HUB_x86_64_linux_ubuntu_22
 PACKAGES_HUB_arm_64_linux_ubuntu_22
+PACKAGES_HUB_x86_64_linux_ubuntu_24
+PACKAGES_HUB_arm_64_linux_ubuntu_24
 
 PACKAGES_x86_64_linux_debian_9
 PACKAGES_x86_64_linux_debian_10
@@ -36,6 +38,8 @@ PACKAGES_x86_64_linux_ubuntu_18
 PACKAGES_x86_64_linux_ubuntu_20
 PACKAGES_x86_64_linux_ubuntu_22
 PACKAGES_arm_64_linux_ubuntu_22
+PACKAGES_x86_64_linux_ubuntu_24
+PACKAGES_arm_64_linux_ubuntu_24
 
 PACKAGES_i386_mingw
 PACKAGES_x86_64_mingw

--- a/deps-packaging/rsync/cfbuild-rsync.spec
+++ b/deps-packaging/rsync/cfbuild-rsync.spec
@@ -5,6 +5,7 @@ Name: cfbuild-rsync
 Version: %{version}
 Release: 1
 Source0: rsync-%{rsync_version}.tar.gz
+Patch0: fix-buffer-overflow.patch
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -17,6 +18,8 @@ AutoReqProv: no
 %prep
 mkdir -p %{_builddir}
 %setup -q -n rsync-%{rsync_version}
+
+%patch0 -p1
 
 # liblz4, libxxhash, libzstd, and libssl give rsync extra compression
 # algorithms, extra checksum algorithms, and allow use of openssl's crypto lib

--- a/deps-packaging/rsync/debian/rules
+++ b/deps-packaging/rsync/debian/rules
@@ -12,6 +12,8 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
+	patch -p1 < $(CURDIR)/fix-buffer-overflow.patch
+
 	# liblz4, libxxhash, libzstd, and libssl give rsync extra compression
 	# algorithms, extra checksum algorithms, and allow use of openssl's crypto
 	# lib for (potentially) faster MD4/MD5 checksums.

--- a/deps-packaging/rsync/fix-buffer-overflow.patch
+++ b/deps-packaging/rsync/fix-buffer-overflow.patch
@@ -1,0 +1,14 @@
+diff --git a/popt/poptparse.c b/popt/poptparse.c
+index e003a04a..dbef88cb 100644
+--- a/popt/poptparse.c
++++ b/popt/poptparse.c
+@@ -38,7 +38,8 @@ int poptDupArgv(int argc, const char **argv,
+     /*@-branchstate@*/
+     for (i = 0; i < argc; i++) {
+ 	argv2[i] = dst;
+-	dst += strlcpy(dst, argv[i], nb) + 1;
++	dst = stpcpy(dst, argv[i]);
++	dst++;	/* trailing NUL */
+     }
+     /*@=branchstate@*/
+     argv2[argc] = NULL;

--- a/deps-packaging/rsync/fix-buffer-overflow.patch
+++ b/deps-packaging/rsync/fix-buffer-overflow.patch
@@ -1,3 +1,16 @@
+A buffer overflow in rsync 3.3.0 was detected after adding Ubuntu 24.04 to our
+build system. The command triggering the buffer overflow happened in the
+federated reporting script when pulling changes from a feeder hub onto the super
+hub. I modified this script to echo the exact command that was run so that I
+could reproduce it with the GNU debugger. The backtrace revealed that the line
+'poptparse.c:38' produced the buffer overflow. However, the buffer overflow did
+not happen in the rsync master branch. Thus, I hand-picked the relevant changes
+between the master branch and the 3.3.0 release tag.
+
+Neither rsync nor popt mentions anything about buffer overflow. However, popt
+seems to have fixed it, and rsync has updated popt in their master branch. Thus,
+we will not need this patch in the upcoming release of rsync.
+
 diff --git a/popt/poptparse.c b/popt/poptparse.c
 index e003a04a..dbef88cb 100644
 --- a/popt/poptparse.c


### PR DESCRIPTION
Ticket: ENT-11309
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Back ported to:
 - https://github.com/cfengine/buildscripts/pull/1420
 - https://github.com/cfengine/buildscripts/pull/1421
