### PR TITLE
ENT-11808: detect-environment: Fixed version detection for RHEL

### DIFF
--- a/build-scripts/detect-environment
+++ b/build-scripts/detect-environment
@@ -116,12 +116,11 @@ detect_distribution()
       "Red Hat Enterprise Linux Server release "*)
         VER=${REL#Red Hat Enterprise Linux Server release }
         VER=${VER% \(*};
-        case "$VER" in
-          [0-9].[0-9]);;
-          *)
+        if ! echo "$VER" | egrep '^[0-9]+.[0-9]+$' > /dev/null
+        then
           echo "Unknown RHEL Server version: $VER"
-          exit 42;;
-        esac
+          exit 42
+        fi
 
         OS=rhel
         OS_VERSION="$VER"
@@ -130,12 +129,11 @@ detect_distribution()
       "Red Hat Enterprise Linux release "*)
         VER=${REL#Red Hat Enterprise Linux release }
         VER=${VER% \(*};
-        case "$VER" in
-          [0-9].[0-9]);;
-          *)
+        if ! echo "$VER" | egrep '^[0-9]+.[0-9]+$' > /dev/null
+        then
           echo "Unknown RHEL Server version: $VER"
-          exit 42;;
-        esac
+          exit 42
+        fi
 
         OS=rhel
         OS_VERSION="$VER"


### PR DESCRIPTION
Jenkins failed with "Unknown RHEL Server version: 8.10" because the
`detect-environment` script did not take into account that the minor
version number can have more than one decimal.

Ticket: ENT-11808
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=10801)](https://ci.cfengine.com/job/pr-pipeline/10801/)
