### PR TITLE
ENT-11233: Aborted package installation if backup directory exists non-empty (3.21)

### DIFF
--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -24,13 +24,16 @@ fi
 
 test -z "$BACKUP_DIR" && BACKUP_DIR=$PREFIX/state/pg/backup
 
-if migrating_postgres; then
-    if [ -d "$BACKUP_DIR" ] && [ -n "$(ls -A "$BACKUP_DIR")" ]; then
-    cf_console echo "Backup directory $BACKUP_DIR already exists and is not empty."
+if [ -d "$BACKUP_DIR" ] && [ -n "$(ls -A "$BACKUP_DIR")" ]; then
+    # If the backup directory exists and is not empty we don't want to proceed,
+    # that stale data can cause database migration problems.
+    cf_console echo "Backup directory $BACKUP_DIR exists and is not empty."
     cf_console echo 'Please remove it, clean it, or set a different directory by setting a BACKUP_DIR env variable, like this:'
     cf_console echo 'export BACKUP_DIR=/mnt/plenty-of-free-space'
     exit 1
-  fi
+fi
+
+if migrating_postgres; then
   mkdir -p "$BACKUP_DIR"
   # Try to check if free space on $BACKUP_DIR drive is not less than $PREFIX/state/pg/data contains
   if command -v df >/dev/null && command -v du >/dev/null && command -v awk >/dev/null; then


### PR DESCRIPTION
We have observed the presence of an old backup directory causing issues during
upgrade. This change avoids proceeding with package installation if a backup
directory exists and is not empty.

Previously this was restricted to when we thought we would be doing a database
migration, but we have seen issues with failed migration when the backup
directory is non-empty and we are not doing any migration, so it is better to
simply avoid installing the package if the backup directory is not empty even if
we don't expect to use it for migration.

Ticket: ENT-11233
Changelog: Title
(cherry picked from commit b7364b8d32da914a4ec56fcfb66accc1fa390254)