### PR TITLE
ENT-11763: postinstall.sh: Removed call to inventory_variables_refresh

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1025,8 +1025,6 @@ true "Done updating password"
 
 su $MP_APACHE_USER -c "$PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/public/index.php cli_tasks migrate_ldap_settings https://localhost/ldap"
 
-$PREFIX/httpd/php/bin/php $PREFIX/httpd/htdocs/public/index.php cli_tasks inventory_variables_refresh
-
 # Shut down Apache and Postgres again, because we may need them to start through
 # systemd later.
 $PREFIX/httpd/bin/apachectl stop


### PR DESCRIPTION
Why is it even there? My guess is that the call to
inventory_variables_refresh was there because of something that was
rendered obsolete after moving this maintenance to cf-reactor.

Ticket: ENT-11763
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
