### PR TITLE
ENT-10646: Squashed common error logged by Apache related to IPv6 (3.21)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -6,7 +6,10 @@ ServerSignature Off
 ServerTokens ProductOnly
 ServerName INSERT_FQDN_HERE
 ServerRoot "/var/cfengine/httpd"
-Listen 80
+# ENT-10646 - Listen 80 often causes IPv6 related errors, specifying ipv4 squashes them.
+#   Unclear why the same is not an issue for 443
+#   To enable listening on ipv6 add Listen [::]:80
+Listen 0.0.0.0:80
 PidFile "/var/cfengine/httpd/httpd.pid"
 
 # Modules


### PR DESCRIPTION
Apache often logs errors related to IPv6, e.g.:

No route to host: AH00056: connect to listener on [::]:80

Specifying IPv4 when listening on port 80 prevents this excessive noise.

Ticket: ENT-10646
Changelog: Title
(cherry picked from commit a99ca365c5a45ac044b8c3629edcb54ae036c097)