### PR TITLE
Ignore gpg-agents lingering in chroot on Ubuntu 24 (3.21.x)

### DIFF
--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -53,6 +53,13 @@ case "$TEST_MACHINE" in
                 continue
             fi
 
+            # gpg-agent sometimes is spawned on Ubuntu 24 during our tests.
+            # This happens only in chroot. Ignore that.
+            if grep "Ubuntu 24" /etc/os-release && ps -o command --pid "$pid" | grep "gpg-agent --homedir /etc/apt/sources.list.d/.gnupg-temp --use-standard-socket --daemon"
+            then
+                continue
+            fi
+
             # Leaving processes behind is an error. It should never happen.
             return_code=1
             (


### PR DESCRIPTION
Issue was that on Ubuntu 24, they are sometimes spawned by apt and left
running in chroot. This fix has previously been used on SUSE platforms
(see ticket ENT-6139).

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
(cherry picked from commit 53e8f602d6345d13cccd0527388806d1215e8e6a)

Back ported from https://github.com/cfengine/buildscripts/pull/1452/commits