### PR TITLE
Only use 'hostname -I' to get local IPs for subjectAltName

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -339,7 +339,7 @@ if [ ! -f $CFENGINE_MP_CERT ]; then
   # Build configuration with reasonable default subjectAltName entries
   rm -f "$CFENGINE_MP_SSLCONF"
   test -f "$OPENSSL_CNF" && cat "$OPENSSL_CNF" > $CFENGINE_MP_SSLCONF
-  CFENGINE_LOCALIP=$(for i in $(hostname -i; hostname -I); do echo $i; done | sed '/::1/d' | sed '/127.0.0.1/d' | sort -u | xargs -n1 printf "IP:%s\n" | paste -sd "," -)
+  CFENGINE_LOCALIP=$(for i in $(hostname -I); do echo $i; done | sort -u | xargs -n1 printf "IP:%s\n" | paste -sd "," -)
   printf "[SAN]\nsubjectAltName=DNS:$CFENGINE_LOCALHOST,DNS:localhost,IP:127.0.0.1,$CFENGINE_LOCALIP" >> $CFENGINE_MP_SSLCONF
 
   # Generate CRT


### PR DESCRIPTION
The hostname(1) man page says for the '-i' option:

  Avoid using this option; use hostname --all-ip-addresses instead.

where '-I' is the short version of '--all-ip-addresses' for which:

  The loopback interface and IPv6 link-local addresses  are  omitted.

So we don't have to filter those out and worry about the link-local addresses reported like this:

  fe80::cf:85ff:fe1c:54d7%enX0

which is not a valid IP address and OpenSSL fails on it.

Ticket: ENT-7598
Changelog: None