### PR TITLE
Adjusted debug log message for build host setup script

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -54,7 +54,7 @@ trap cleanup SIGTERM
 
 
 echo "Using buildscripts commit:"
-git log -1
+git -C buildscripts log -1
 
 echo "Install any distribution upgrades"
 if [ -f /etc/os-release ]; then


### PR DESCRIPTION
Oops, wrong pwd for `git log -1` command, need to use `-C buildscripts`

Ticket: ENT-11898
Changelog: none
