### PR TITLE
ENT-11898: Revert to using 3.21.4 version for build host setup

### DIFF
--- a/ci/cfengine-masterfiles-3.21.4-1.pkg.tar.gz.sha256
+++ b/ci/cfengine-masterfiles-3.21.4-1.pkg.tar.gz.sha256
@@ -1,0 +1,1 @@
+a4b35ad85ec14dda49b93c1c91a93e09f4336d9ee88cd6a3b27d323c90a279ca  cfengine-masterfiles-3.21.4-1.pkg.tar.gz

--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -2,7 +2,7 @@
 shopt -s expand_aliases
 
 # TODO get latest LTS dynamically
-CFE_VERSION=3.21.5
+CFE_VERSION=3.21.4
 
 # install needed packages and software for a build host
 set -ex
@@ -107,6 +107,7 @@ else
 
   sha256sum --check ./buildscripts/ci/quick-install-cfengine-enterprise.sh.sha256
   chmod +x quick-install-cfengine-enterprise.sh
+  export CFEngine_Enterprise_Package_Version="$CFE_VERSION"
   bash ./quick-install-cfengine-enterprise.sh agent
 fi
 


### PR DESCRIPTION
3.21.5 introduced a behavior change for simple package promises without any attributes resulting in errors in the build host policy.

Ticket: ENT-11989
Changelog: none
