### PR TITLE
ENT-11898: Adjusted build host setup script for older git versions

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -54,7 +54,10 @@ trap cleanup SIGTERM
 
 
 echo "Using buildscripts commit:"
-git -C buildscripts rev-parse HEAD
+# we have very old platforms with old git that doesn't understand -C option so cd/cd .. it is
+cd buildscripts
+git rev-parse HEAD
+cd ..
 
 echo "Install any distribution upgrades"
 if [ -f /etc/os-release ]; then


### PR DESCRIPTION
-C <dir> wasn't supported on CentOS-6

Ticket: ENT-11898
Changelog: none
