### PR TITLE
ENT-11901: Removed /etc/init.d/cfengine3 from EL9+ packages

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -62,6 +62,11 @@ rm -f $RPM_BUILD_ROOT%{prefix}/bin/openssl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl
 rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 
+%if %{?rhel}%{!rhel:0} >= 9
+rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
+%endif
 
 %clean
 #rm -rf $RPM_BUILD_ROOT
@@ -127,9 +132,13 @@ rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 %endif
 
 # Globally installed configs, scripts
+%if %{?rhel}%{!?rhel:0} < 9
 %attr(644,root,root) /etc/sysconfig/cfengine3
 %attr(755,root,root) /etc/profile.d/cfengine3.sh
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
 %attr(755,root,root) /etc/init.d/cfengine3
+%endif
 
 # Systemd units
 %defattr(644,root,root,755)

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -73,6 +73,13 @@ mkdir -p $RPM_BUILD_ROOT%{prefix}
 cp -a %{prefix}/* $RPM_BUILD_ROOT%{prefix}
 cp -a %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
 
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} >= 9
+rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
+%endif
 # Remove useless stuff
 
 rm -f $RPM_BUILD_ROOT%{prefix}/lib/libpromises.la
@@ -318,9 +325,13 @@ exit 0
 
 # Initscript, other configuration
 %defattr(755,root,root,755)
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} < 9
 /etc/init.d/cfengine3
 /etc/profile.d/cfengine.sh
 %attr(644,root,root) /etc/sysconfig/cfengine3
+%endif
 
 # Systemd units
 %defattr(644,root,root,755)

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -53,6 +53,13 @@ mkdir -p $RPM_BUILD_ROOT%{prefix}
 cp -a %{prefix}/* $RPM_BUILD_ROOT%{prefix}
 cp -a %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
 
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} >= 9
+rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
+rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
+%endif
 
 # Remove useless stuff
 
@@ -145,9 +152,13 @@ exit 0
 %endif
 
 # Globally installed configs, scripts
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} < 9
 %attr(755,root,root) /etc/init.d/cfengine3
 %attr(644,root,root) /etc/sysconfig/cfengine3
 %attr(755,root,root) /etc/profile.d/cfengine.sh
+%endif
 
 # Systemd units
 %defattr(644,root,root,755)


### PR DESCRIPTION
We started getting reports of issues related to an upstream bug in
chkconfig, (it failed to install if /etc/init.d had been created already). While
not our issue, it highlighted that it's probably time to remove the old init
script from modern packages.

Ticket: ENT-11901