### PR TITLE
Only run 'chkconfig --del' on uninstall if we shipped /etc/init.d/cfe…

### DIFF
--- a/packaging/common/cfengine-hub/preremove.sh
+++ b/packaging/common/cfengine-hub/preremove.sh
@@ -9,7 +9,7 @@ fi
 
 case "`os_type`" in
   redhat)
-    test -x /sbin/chkconfig && chkconfig --del cfengine3
+    test -x /sbin/chkconfig && test -f /etc/init.d/cfengine3 && chkconfig --del cfengine3
     ;;
   debian)
     update-rc.d -f cfengine3 remove

--- a/packaging/common/cfengine-non-hub/preremove.sh
+++ b/packaging/common/cfengine-non-hub/preremove.sh
@@ -5,7 +5,7 @@ case `os_type` in
     #
     # Unregister CFEngine initscript on uninstallation.
     #
-    test -x /sbin/chkconfig && chkconfig --del cfengine3
+    test -x /sbin/chkconfig && test -f /etc/init.d/cfengine3 && chkconfig --del cfengine3
 
     #
     # systemd support


### PR DESCRIPTION
…ngine3

Otherwise it fails and the whole scriptlet fails like this:

  error: %preun(cfengine-nova-3.24.0a.c3a2325e3-33984.el9.x86_64) scriptlet failed, exit status 1
  error: cfengine-nova-3.24.0a.c3a2325e3-33984.el9.x86_64: erase failed

keeping the package installed.

Ticket: ENT-11901
Changelog: None