### PR TITLE
junit summary failure improvement/3.21

### DIFF
--- a/ci/Dockerfile-cfengine-build-package
+++ b/ci/Dockerfile-cfengine-build-package
@@ -1,5 +1,10 @@
 FROM ubuntu:20.04
+RUN cat /etc/resolv.conf
+RUN bash -c 'echo "test" >/dev/tcp/archive.ubuntu.com/80'
 RUN apt-get update -y && apt-get install -y systemd wget sudo
+# some ways of debugging update problems below, uncomment to try, see ENT-11871 for archive.ubuntu.com flakes
+#RUN apt-get update -y -o Debug::Acquire::http=true
+#RUN apt-get install -y -o Debug::Acquire::http=true systemd wget sudo
 ADD setup.sh /
 RUN /bin/bash -c '/setup.sh 2>&1 > setup.log'
 CMD [ "/lib/systemd/systemd" ]

--- a/ci/junit-text-summary.sh
+++ b/ci/junit-text-summary.sh
@@ -27,7 +27,7 @@ if test -z "$1"; then
 fi
 if ! test -f "$1"; then
   echo "File $1 not found"
-  exit 1
+  exit 0
 fi
 echo "## Test Summary for $1"
 xmlstarlet sel -T \


### PR DESCRIPTION
- When the junit xml file is not found, exit 0 to show a nicer result in GH actions summary
- Added a quick-fail if archive.ubuntu.com is unavailable
