### PR TITLE
latest lts for build hosts

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -2,7 +2,7 @@
 shopt -s expand_aliases
 
 # TODO get latest LTS dynamically
-CFE_VERSION=3.21.4
+CFE_VERSION=3.24.0
 
 # install needed packages and software for a build host
 set -ex


### PR DESCRIPTION
- **Update quick-install script sha for build host setup script**
- **Use latest LTS (3.24.0) for all build host setups**
