### PR TITLE
Added sha for 3.24.0 masterfiles tarball

### DIFF
--- a/ci/cfengine-masterfiles-3.24.0-1.pkg.tar.gz.sha256
+++ b/ci/cfengine-masterfiles-3.24.0-1.pkg.tar.gz.sha256
@@ -1,0 +1,1 @@
+8a23bbd1d84b3bd03e133cfd050b81c9ebfcdb6d44ab2a79789af2bb2c70e772  cfengine-masterfiles-3.24.0-1.pkg.tar.gz


### PR DESCRIPTION
Needed after version used for build host setup to 3.24.0

Ticket: none
Changelog: none
