### PR TITLE
ENT-4400: Added Content-Security-Policy header to the Apache httpd config (3.24.x)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -199,6 +199,23 @@ LogLevel warn
     Header always set X-Frame-Options DENY
     Header always set X-Content-Type-Options nosniff
 
+    Header always set Content-Security-Policy \
+        "frame-ancestors 'self'; \
+        default-src 'self'; \
+        script-src 'self' 'unsafe-inline'; \
+        style-src 'self' 'unsafe-inline' fonts.googleapis.com; \
+        object-src 'none'; \
+        frame-src 'self'; \
+        child-src 'self'; \
+        img-src 'self' data: blob: avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com; \
+        font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
+        connect-src 'self' fonts.gstatic.com fonts.googleapis.com; \
+        manifest-src 'self'; \
+        base-uri 'self'; \
+        form-action 'self'; \
+        media-src 'self'; \
+        worker-src 'self' blob:;"
+
     <FilesMatch "\.(cgi|shtml|phtml|php)$">
         SSLOptions +StdEnvVars
     </FilesMatch>


### PR DESCRIPTION
Ticket: ENT-4400
Signed-off-by: Ihor Aleksandrychiev <ihor.aleksandrychiev@northern.tech>
(cherry picked from commit eb2ffa3d6d476929fb02fa969ca3359131aa5bf9)