### PR TITLE
Fixed usage of pg_upgrade in hub package upgrades

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -525,7 +525,7 @@ check_disk_space() {
 #   and then importing it into new one
 
 migrate_db_using_pg_upgrade() {
-   su cfpostgres -c "LD_LIBRARY_PATH=$BACKUP_DIR/lib/ $PREFIX/bin/pg_upgrade --old-bindir=$BACKUP_DIR/bin --new-bindir=$PREFIX/bin --old-datadir=$BACKUP_DIR/data --new-datadir=$PREFIX/state/pg/data"
+   su cfpostgres -c "LD_LIBRARY_PATH=$BACKUP_DIR/lib:$PREFIX/lib $PREFIX/bin/pg_upgrade --old-bindir=$BACKUP_DIR/bin --new-bindir=$PREFIX/bin --old-datadir=$BACKUP_DIR/data --new-datadir=$PREFIX/state/pg/data"
 }
 
 migrate_db_using_pipe() {


### PR DESCRIPTION
In some cases library changes in libpq.so or other dependencies can change and since pg_upgrade
checks multiple binaries in both old and new bindirs we need to include both old and new lib dirs in LD_LIBRARY_PATH.

See check_bin_dir() in pg_upgrade code: https://github.com/postgres/postgres/blob/master/src/bin/pg_upgrade/exec.c#L383

Ticket: ENT-12383
Changelog: title
