### PR TITLE
Adjusted hub upgrade database migration to show only actionable logs

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -525,7 +525,7 @@ check_disk_space() {
 #   and then importing it into new one
 
 migrate_db_using_pg_upgrade() {
-   su cfpostgres -c "LD_LIBRARY_PATH=$BACKUP_DIR/lib/ $PREFIX/bin/pg_upgrade --old-bindir=$BACKUP_DIR/bin --new-bindir=$PREFIX/bin --old-datadir=$BACKUP_DIR/data --new-datadir=$PREFIX/state/pg/data"
+   su cfpostgres -c "$PREFIX/bin/pg_upgrade --old-bindir=$BACKUP_DIR/bin --new-bindir=$PREFIX/bin --old-datadir=$BACKUP_DIR/data --new-datadir=$PREFIX/state/pg/data"
 }
 
 migrate_db_using_pipe() {


### PR DESCRIPTION
If pg_upgrade fails it is OK because we have several other options which we try during hub package upgrade.

It is likely that pg_upgrade will fail when upgrading major versions of postgresql during the hub package upgrade.

Sadly, since we build postgresql to link to /var/cfengine/lib (WORKDIR/lib) the pg_upgrade utility can fail due to old-bin binaries trying to use the newer libraries and missing symbols.

If we followed the pattern of placing each set of postgresql binaries, libraries, etc in a major-versioned directory this would not be an issue.

However, making that change seems too large and doesn't handle previous versions of CFEngine hub package well.

To see the errors, run the upgrade with DEBUG=1 defined as an environment variable.

Ticket: ENT-12383
Changelog: title
