### PR TITLE
Adjusted hub upgrade database migration to show only actionable logs (3.21)

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -700,9 +700,7 @@ do_migration() {
     cf_console echo "Migrating database using pg_upgrade utility..."
     cf_console echo
     _pg_upgrade_log="/tmp/cfengine_pg_upgrade.log"
-    migrate_db_using_pg_upgrade >"${_pg_upgrade_log}" 2>&1
-    rc=$?
-    if [ $rc -eq 0 ] && [ $DEBUG -lt 1 ]; then
+    if migrate_db_using_pg_upgrade >"${_pg_upgrade_log}" 2>&1 && [ $DEBUG -lt 1 ]; then
       # Succeeded
       cat "${_pg_upgrade_log}" # might as well see the details of how it worked
       rm "${_pg_upgrade_log}" # clean up

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -699,16 +699,25 @@ do_migration() {
     cd /tmp
     cf_console echo "Migrating database using pg_upgrade utility..."
     cf_console echo
-    if migrate_db_using_pg_upgrade && [ $DEBUG -lt 1 ]; then
+    _pg_upgrade_log="/tmp/cfengine_pg_upgrade.log"
+    migrate_db_using_pg_upgrade >"${_pg_upgrade_log}" 2>&1
+    rc=$?
+    if [ $rc -eq 0 ] && [ $DEBUG -lt 1 ]; then
       # Succeeded
+      cat "${_pg_upgrade_log}" # might as well see the details of how it worked
+      rm "${_pg_upgrade_log}" # clean up
       exit 0 # exits only from (...)
     fi
     cf_console echo "Migration using pg_upgrade failed."
-    # here pg_upgrade probably said something like
-    # Consult the last few lines of "/var/cfengine/state/pg/data/pg_upgrade_output.d/20230913T150025.959/log/pg_upgrade_server.log" for the probable cause of the failure.
-    cf_console echo "Showing last lines of any related log files:"
-    _daysearch=$(date +%Y%m%d)
-    find "$PREFIX"/state/pg/data/pg_upgrade_output.d -name '*.log' | grep "$_daysearch" | cf_console xargs tail
+    if [ $DEBUG -gt 0 ]; then
+      cat "${_pg_upgrade_log}"
+      rm "${_pg_upgrade_log}"
+      # pg_upgrade probably said something like
+      # Consult the last few lines of "/var/cfengine/state/pg/data/pg_upgrade_output.d/20230913T150025.959/log/pg_upgrade_server.log" for the probable cause of the failure.
+      cf_console echo "Showing last lines of any related log files:"
+      _daysearch=$(date +%Y%m%d)
+      find "$PREFIX"/state/pg/data/pg_upgrade_output.d -name '*.log' | grep "$_daysearch" | cf_console xargs tail
+    fi
     cf_console echo
     check_disk_space # will abort if low on disk space
     init_postgres_dir "$new_pgconfig_file" "$pgconfig_type"

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -518,7 +518,7 @@ check_disk_space() {
 #   and then importing it into new one
 
 migrate_db_using_pg_upgrade() {
-   su cfpostgres -c "LD_LIBRARY_PATH=$BACKUP_DIR/lib/ $PREFIX/bin/pg_upgrade --old-bindir=$BACKUP_DIR/bin --new-bindir=$PREFIX/bin --old-datadir=$BACKUP_DIR/data --new-datadir=$PREFIX/state/pg/data"
+   su cfpostgres -c "$PREFIX/bin/pg_upgrade --old-bindir=$BACKUP_DIR/bin --new-bindir=$PREFIX/bin --old-datadir=$BACKUP_DIR/data --new-datadir=$PREFIX/state/pg/data"
 }
 
 migrate_db_using_pipe() {


### PR DESCRIPTION
- Adjusted hub upgrade database migration to show only actionable logs
- Revert "Adjusted calling pg_upgrade during upgrade to include LD_LIBRARY_PATH of previous installation"

- [ ] remember to re-do the changelogs in enterprise when this goes in, and remove

```
        Packaging changes:
	- Adjusted calling pg_upgrade during upgrade to include LD_LIBRARY_PATH of previous installation
	  (ENT-11853)
```