### PR TITLE
Added check for psycopg2 python module for nova/tests/reporting

### DIFF
--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -64,6 +64,14 @@ do
     fi
 done
 
+if [ "$PROJECT" = "nova" ]; then
+    . "$BASEDIR"/nova/tests/reporting/find-python.sh # to get PYTHON as the tests do
+    if ! $PYTHON -m pip list | grep psycopg2; then
+        echo "nova/tests/reporting needs psycopg2 module installed for python: $PYTHON"
+        RET=1
+    fi
+fi
+
 
 # Exit with the right exit code
 if [  $RET = 0  ]

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -83,8 +83,12 @@ bundle agent cfengine_build_host_setup
       "pkgconfig";
       "perl-IPC-Cmd";
       "perl-devel";
-      "python-psycopg2";
       "xfsprogs";
+
+    (redhat_6|centos_6).(yum_dnf_conf_ok)::
+      "python-psycopg2" comment => "centos-6 provides python2 and psycopg2 for python2 as a package";
+    (redhat_7|centos_7).(yum_dnf_conf_ok)::
+      "python3-psycopg2";
 
 # note that shellcheck, fakeroot and ccache require epel-release to be installed
     (redhat_7|centos_7).(yum_dnf_conf_ok)::


### PR DESCRIPTION
Want to check this as early as possible to save on resource usage and people waiting time.

Ticket: ENT-12432
Changelog: none

together:
https://github.com/cfengine/buildscripts/pull/1523
https://github.com/cfengine/nova/pull/2362