### PR TITLE
ENT-12432: Fixup python/pscopg2 for reporting tests (3.21)

### DIFF
--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -64,6 +64,14 @@ do
     fi
 done
 
+if [ "$PROJECT" = "nova" ]; then
+    . "$BASEDIR"/nova/tests/reporting/find-python.sh # to get PYTHON as the tests do
+    if ! $PYTHON -m pip list | grep psycopg2; then
+        echo "nova/tests/reporting needs psycopg2 module installed for python: $PYTHON"
+        RET=1
+    fi
+fi
+
 
 # Exit with the right exit code
 if [  $RET = 0  ]

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -11,7 +11,7 @@ bundle agent cfengine_build_host_setup
   packages:
     debian_9|debian_10|ubuntu_16::
       "python-psycopg2";
-    debian_11|debian_12::
+    debian_11|debian_12|ubuntu_20|ubuntu_22|ubuntu_24::
       "python3-psycopg2";
     ubuntu_16::
       "systemd-coredump" comment => "ubuntu_16 doesn't have systemd-coredump by default?";
@@ -191,12 +191,6 @@ bundle agent cfengine_build_host_setup
       "sed -i '/best=True/s/True/False/' /etc/yum.conf" contain => in_shell;
     (redhat_8|centos_8|redhat_9).!dnf_conf_ok::
       "sed -i '/best=True/s/True/False/' /etc/dnf/dnf.conf" contain => in_shell;
-    ubuntu_20.!have_python2_pip::
-      "sh $(this.promise_dirname)/install-python2-pip.sh" contain => in_shell,
-        comment => "pip(2) is required for psycopg2 for nova/tests/reporting.";
-    ubuntu_20.!have_python2_psycopg2::
-      "pip install psycopg2-binary" contain => in_shell,
-        comment => "Here we install psycopg2 as root because nova/tests/reporting runs as root.";
 
 
   classes:

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -83,8 +83,12 @@ bundle agent cfengine_build_host_setup
       "pkgconfig";
       "perl-IPC-Cmd";
       "perl-devel";
-      "python-psycopg2";
       "xfsprogs";
+
+    (redhat_6|centos_6).(yum_dnf_conf_ok)::
+      "python-psycopg2" comment => "centos-6 provides python2 and psycopg2 for python2 as a package";
+    (redhat_7|centos_7).(yum_dnf_conf_ok)::
+      "python3-psycopg2";
 
 # note that shellcheck, fakeroot and ccache require epel-release to be installed
     (redhat_7|centos_7).(yum_dnf_conf_ok)::


### PR DESCRIPTION
- Fixed up version of psycopg2 module to install on redhat/centos 6 and 7 platforms
- Added check for psycopg2 python module for nova/tests/reporting
- Install python3-psycopg2 on ubuntu >= 20
