### PR TITLE
Revert "Added check for psycopg2 python module for nova/tests/reporting" (3.24)

### DIFF
--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -64,14 +64,6 @@ do
     fi
 done
 
-if [ "$PROJECT" = "nova" ]; then
-    . "$BASEDIR"/nova/tests/reporting/find-python.sh # to get PYTHON as the tests do
-    if ! $PYTHON -m pip list | grep psycopg2; then
-        echo "nova/tests/reporting needs psycopg2 module installed for python: $PYTHON"
-        RET=1
-    fi
-fi
-
 
 # Exit with the right exit code
 if [  $RET = 0  ]


### PR DESCRIPTION
This reverts commit 82dd64c0ddf338d137cb9925eaa3d68bcd1c5061.

The check for psycopg2 was too early and is present in nova/tests/reporting 'make check' and early enough.

Ticket: ENT-12432
Changelog: none
(cherry picked from commit a483cf681b5d8e2d76a089e9362b3f654b07010e)
