### PR TITLE
Fixed up build host policy and build-environment-check for centos/redhat (3.21)

### DIFF
--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -17,7 +17,7 @@
 
 case "$OS" in
     rhel|centos)
-        DEP_LIST="gcc-c++ ncurses ncurses-devel pkgconfig rpm-build-libs pam-devel"
+        DEP_LIST="gcc-c++ ncurses ncurses-devel pkgconfig pam-devel"
         UNWANTED_DEPS="libtool-ltdl libtool-ltdl-devel"
         ;;
     debian|ubuntu)
@@ -32,10 +32,16 @@ case "$OS" in
         ;;
 esac
 
+
 # Fakeroot is here: http://dl.atrpms.net/el5-$1/atrpms/stable/fakeroot-1.6.4-15.1.el5.$1.rpm
 #          It is needed by the debian buildslaves for their packaging scripts
 case "$OS-$OS_VERSION" in
-    rhel-* | centos-* ) DEP_LIST="$DEP_LIST" ;;
+    rhel-6|centos-6)
+        DEP_LIST="$DEP_LIST rpm-build"
+        ;;
+    rhel-* | centos-* )
+        DEP_LIST="$DEP_LIST rpm-build-libs"
+        ;;
     *)                  DEP_LIST="$DEP_LIST fakeroot"    ;;
 esac
 

--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -17,7 +17,7 @@
 
 case "$OS" in
     rhel|centos)
-        DEP_LIST="gcc-c++ ncurses ncurses-devel pkgconfig rpm-build pam-devel"
+        DEP_LIST="gcc-c++ ncurses ncurses-devel pkgconfig rpm-build-libs pam-devel"
         UNWANTED_DEPS="libtool-ltdl libtool-ltdl-devel"
         ;;
     debian|ubuntu)

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -20,8 +20,8 @@ bundle agent cfengine_build_host_setup
       "shellcheck" comment => "not sure why only ubuntu-20 needed this.";
     debian.(!debian_12.!ubuntu_22)::
       "python" comment => "debian-12 has only python3";
-     !(debian_9|ubuntu_16).(debian|ubuntu)::
-       "default-jre" comment => "on debian10+ and ubuntu18+ this will be jdk11, good enough for jenkins 2.426.1 https://www.jenkins.io/doc/book/platform-information/support-policy-java/index.html";
+    !(debian_9|ubuntu_16).(debian|ubuntu)::
+      "default-jre" comment => "on debian10+ and ubuntu18+ this will be jdk11, good enough for jenkins 2.426.1 https://www.jenkins.io/doc/book/platform-information/support-policy-java/index.html";
 
     debian|ubuntu::
       "libltdl7" package_policy => "delete";

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -232,7 +232,7 @@ bundle agent cfengine_build_host_setup
         comment => "even though rhel8/9 come with /bin/perl perl >= 5.8.8 is needed by cfbuild-lcov-1.16-1.noarch. So the package must be installed.";
     redhat_9.!have_python3_pip_package_installed.(yum_dnf_conf_ok)::
       "yum install -y python3-pip" contain => in_shell;
-    redhat_8|centos_8|redhat_9::
+    redhat_8|centos_8|redhat_9|centos_9::
       "sudo sed -ri 's/^%_enable_debug_packages/#\0/' /usr/lib/rpm/redhat/macros" contain => in_shell;
 # todo, need 2.7pip psycopg2-binary for ubuntu-20 as well?
     debian_11.!have_pip2::

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -61,7 +61,8 @@ bundle agent cfengine_build_host_setup
       "pam-devel";
       "rsync";
       "make";
-      "rpm-build";
+      "rpm-build-libs" handle => "rpm_build_libs_installed";
+      "libtool-ltdl" package_policy => "delete";
 
     (redhat|centos).(yum_dnf_conf_ok)::
       "expat-devel";
@@ -233,11 +234,8 @@ bundle agent cfengine_build_host_setup
     redhat_9.!have_python3_pip_package_installed.(yum_dnf_conf_ok)::
       "yum install -y python3-pip" contain => in_shell;
     redhat_8|centos_8|redhat_9|centos_9::
-      "sudo sed -ri 's/^%_enable_debug_packages/#\0/' /usr/lib/rpm/redhat/macros" contain => in_shell;
-# todo, need 2.7pip psycopg2-binary for ubuntu-20 as well?
-    debian_11.!have_pip2::
-      "wget https://bootstrap.pypa.io/pip/2.7/get-pip.py -O get-pip.py && python2 get-pip.py && pip install psycopg2-binary"
-        contain => in_shell;
+      "sudo sed -ri 's/^%_enable_debug_packages/#\0/' /usr/lib/rpm/redhat/macros" contain => in_shell,
+        depends_on => { "rpm_build_libs_installed" };
 
     ubuntu_16.!have_i386_architecture:: # mingw build host
       "${paths.dpkg} --add-architecture i386";

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -61,7 +61,6 @@ bundle agent cfengine_build_host_setup
       "pam-devel";
       "rsync";
       "make";
-      "rpm-build-libs" handle => "rpm_build_libs_installed";
       "libtool-ltdl" package_policy => "delete";
 
     (redhat|centos).(yum_dnf_conf_ok)::
@@ -73,7 +72,13 @@ bundle agent cfengine_build_host_setup
       "perl-Module-Load-Conditional";
       "wget";
 
+    !(redhat_6|centos_6).(yum_dnf_conf_ok)::
+      "rpm-build-libs" handle => "rpm_build_installed";
+      "python3-psycopg2";
+
     (redhat_6|centos_6).(yum_dnf_conf_ok)::
+      "rpm-build" handle => "rpm_build_installed";
+      "python-psycopg2" comment => "centos-6 provides python2 and psycopg2 for python2 as a package";
       "perl-IO-Compress-Zlib" comment => "provides perl(IO::Uncompress::Gunzip) needed by lcov dependency package";
       "perl-JSON";
 # perl-Digest-MD5 and perl-Data-Dumper are included in perl for centos-6
@@ -88,7 +93,7 @@ bundle agent cfengine_build_host_setup
 
     (redhat_6|centos_6).(yum_dnf_conf_ok)::
       "python-psycopg2" comment => "centos-6 provides python2 and psycopg2 for python2 as a package";
-    (redhat_7|centos_7).(yum_dnf_conf_ok)::
+    !(redhat_6|centos_6).(yum_dnf_conf_ok)::
       "python3-psycopg2";
 
 # note that shellcheck, fakeroot and ccache require epel-release to be installed
@@ -235,7 +240,7 @@ bundle agent cfengine_build_host_setup
       "yum install -y python3-pip" contain => in_shell;
     redhat_8|centos_8|redhat_9|centos_9::
       "sudo sed -ri 's/^%_enable_debug_packages/#\0/' /usr/lib/rpm/redhat/macros" contain => in_shell,
-        depends_on => { "rpm_build_libs_installed" };
+        depends_on => { "rpm_build_installed" };
 
     ubuntu_16.!have_i386_architecture:: # mingw build host
       "${paths.dpkg} --add-architecture i386";

--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -111,9 +111,9 @@ policy="$(dirname "$0")"/cfengine-build-host-setup.cf
 chmod 600 "$policy"
 /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log
 grep -i error: promises.log && exit 1
-/var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log
+/var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee -a promises.log
 grep -i error: promises.log && exit 1
-/var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log
+/var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee -a promises.log
 grep -i error: promises.log && exit 1
 
 cleanup


### PR DESCRIPTION
- Adjusted build host policy script to append all three runs to one promises.log
- Adjusted build host policy a bit for centos_9
- Adjusted build-environment-check to align with centos-7, redhat-8 and redhat-9
- Adjusted build host policy to disable debug packages only after rpm-build-libs is installed (redhat)
