### PR TITLE
ENT-11901: Remove /etc/init.d/cfengine3 from EL8+ packages (3.21)

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -62,6 +62,11 @@ rm -f $RPM_BUILD_ROOT%{prefix}/bin/openssl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl
 rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 
+%if %{?rhel}%{!rhel:0} >= 9
+rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
+%endif
 
 %clean
 #rm -rf $RPM_BUILD_ROOT
@@ -123,9 +128,13 @@ rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 %endif
 
 # Globally installed configs, scripts
+%if %{?rhel}%{!?rhel:0} < 9
 %attr(644,root,root) /etc/sysconfig/cfengine3
 %attr(755,root,root) /etc/profile.d/cfengine3.sh
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
 %attr(755,root,root) /etc/init.d/cfengine3
+%endif
 
 # Systemd units
 %defattr(644,root,root,755)

--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -65,7 +65,7 @@ rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 %if %{?rhel}%{!?rhel:0} >= 9
 rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
-rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
+rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine3.sh
 %endif
 
 %clean

--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -62,7 +62,7 @@ rm -f $RPM_BUILD_ROOT%{prefix}/bin/openssl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl
 rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 
-%if %{?rhel}%{!rhel:0} >= 9
+%if %{?rhel}%{!?rhel:0} >= 9
 rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -69,6 +69,13 @@ mkdir -p $RPM_BUILD_ROOT%{prefix}
 cp -a %{prefix}/* $RPM_BUILD_ROOT%{prefix}
 cp -a %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
 
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} >= 9
+rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
+%endif
 # Remove useless stuff
 
 rm -f $RPM_BUILD_ROOT%{prefix}/lib/libpromises.la
@@ -314,9 +321,13 @@ exit 0
 
 # Initscript, other configuration
 %defattr(755,root,root,755)
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} < 9
 /etc/init.d/cfengine3
 /etc/profile.d/cfengine.sh
 %attr(644,root,root) /etc/sysconfig/cfengine3
+%endif
 
 # Systemd units
 %defattr(644,root,root,755)

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -49,6 +49,13 @@ mkdir -p $RPM_BUILD_ROOT%{prefix}
 cp -a %{prefix}/* $RPM_BUILD_ROOT%{prefix}
 cp -a %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
 
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} >= 9
+rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
+rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
+rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
+%endif
 
 # Remove useless stuff
 
@@ -137,9 +144,13 @@ exit 0
 %endif
 
 # Globally installed configs, scripts
+# ENT-11901
+# For el9+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} < 9
 %attr(755,root,root) /etc/init.d/cfengine3
 %attr(644,root,root) /etc/sysconfig/cfengine3
 %attr(755,root,root) /etc/profile.d/cfengine.sh
+%endif
 
 # Systemd units
 %defattr(644,root,root,755)

--- a/packaging/common/cfengine-hub/preremove.sh
+++ b/packaging/common/cfengine-hub/preremove.sh
@@ -9,7 +9,7 @@ fi
 
 case "`os_type`" in
   redhat)
-    test -x /sbin/chkconfig && chkconfig --del cfengine3
+    test -x /sbin/chkconfig && test -f /etc/init.d/cfengine3 && chkconfig --del cfengine3
     ;;
   debian)
     update-rc.d -f cfengine3 remove

--- a/packaging/common/cfengine-non-hub/preremove.sh
+++ b/packaging/common/cfengine-non-hub/preremove.sh
@@ -5,7 +5,7 @@ case `os_type` in
     #
     # Unregister CFEngine initscript on uninstallation.
     #
-    test -x /sbin/chkconfig && chkconfig --del cfengine3
+    test -x /sbin/chkconfig && test -f /etc/init.d/cfengine3 && chkconfig --del cfengine3
 
     #
     # systemd support


### PR DESCRIPTION
- Removed /etc/init.d/cfengine3 from EL9+ packages
- Only run 'chkconfig --del' on uninstall if we shipped /etc/init.d/cfengine3
- Fix RHEL version check in cfengine-community.spec.in
- Fix profile.d script name in cfengine-community.spec.in
