### PR TITLE
Restored rpm-build package installation for suse build hosts (3.24)

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -137,10 +137,11 @@ bundle agent cfengine_build_host_setup
 
     suse|opensuse|sles::
       "binutils";
-      "pam";
-      "pkg-config";
-      "patch";
       "gdb";
+      "pam";
+      "patch";
+      "pkg-config";
+      "rpm-build";
 
     suse_12|opensuse_12|sles_12::
       "java-11-openjdk";


### PR DESCRIPTION
And alphabetized the packages in that group.
It was a small portion so didn't want two commits: one for alpha, one for fix.

Ticket: ENT-12451
Changelog: none
(cherry picked from commit ad0ede982f7cb457090634f61c9844674652355d)
