### PR TITLE
Fixed perl version check for openssl building (master)

### DIFF
--- a/build-scripts/install-dependencies
+++ b/build-scripts/install-dependencies
@@ -48,7 +48,7 @@ check_and_install_perl()
              "too old"
         PERL_OK="no"
     fi
-    if ! perl -e 'use List::Util qw(pairs);'; then
+    if ! $PERL -e 'use List::Util qw(pairs);'; then
         echo "$PERL has List::Util that does not export pairs. Needs to be at least version 1.29 for OpenSSL version 3.3.2."
         PERL_OK="no"
     fi


### PR DESCRIPTION
Missed using $PERL for the List::Utils exporting pairs check from 3.24.x deps upgrade.

https://github.com/cfengine/buildscripts/pull/1498/commits/fd6d251b5d22a7dced1175cfec5cbd870a0c3e40

Ticket: ENT-12366
Changelog: none
