### PR TITLE
Bumped CI ubuntu from 20 to 22

### DIFF
--- a/.github/workflows/build-using-buildscripts.yml
+++ b/.github/workflows/build-using-buildscripts.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build_cfengine_hub_package:
     name: Build package and run selenium tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Together Action
         uses: actions/checkout@v3

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   deployment_tests:
     name: Run simple deployment tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Together Action
         uses: actions/checkout@v3

--- a/ci/Dockerfile-cfengine-build-package
+++ b/ci/Dockerfile-cfengine-build-package
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN cat /etc/resolv.conf
 RUN bash -c 'echo "test" >/dev/tcp/archive.ubuntu.com/80'
 RUN apt-get update -y && apt-get install -y systemd wget sudo

--- a/ci/Dockerfile-cfengine-deployment-tests
+++ b/ci/Dockerfile-cfengine-deployment-tests
@@ -1,3 +1,3 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update -y && apt-get install -y systemd sudo
 CMD [ "/lib/systemd/systemd" ]

--- a/ci/README
+++ b/ci/README
@@ -5,7 +5,7 @@ Currently a full build with no dependencies cached takes around 53 minutes with 
 
 Two options: containerize build or "normal" machine (such as virtual machine or actual hardware).
 
-The build is designed for ubuntu-20.04 but could be adjusted in various shell scripts for other platforms. (TODO: do this!)
+The build is designed for ubuntu-22.04 but could be adjusted in various shell scripts for other platforms. (TODO: do this!)
 
 # containerized build
 ./clean.sh # cleans any leftover docker bits
@@ -16,7 +16,7 @@ See /data/buildscripts/ci/build.sh for required environment variables and steps 
 
 # virtual or real machine
 
-For virtual machine such as with vagrant, at $NTECH_ROOT (aka top-level directory containing all CFEngine repositories), init an ubuntu-20.04 vagrant machine so it has access to all your repositories.
+For virtual machine such as with vagrant, at $NTECH_ROOT (aka top-level directory containing all CFEngine repositories), init an ubuntu-22.04 vagrant machine so it has access to all your repositories.
 
 vagrant init ubuntu/focal64
 vagrant ssh

--- a/ci/docker-build-package.sh
+++ b/ci/docker-build-package.sh
@@ -8,7 +8,7 @@ COMPUTED_ROOT="$(readlink -e "$(dirname "$0")/../../")"
 NTECH_ROOT=${NTECH_ROOT:-$COMPUTED_ROOT}
 
 name=cfengine-build-package
-label=PACKAGES_HUB_x86_64_linux_ubuntu_20
+label=PACKAGES_HUB_x86_64_linux_ubuntu_22
 export JOB_BASE_NAME=label=$label
 
 

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,10 +1,13 @@
-# setup build host on ubuntu 20
+# setup build host on ubuntu 22
 set -ex
 PREFIX=/var/cfengine
 
 # Github Actions provides machines with various packages installed,
 # what confuses our build system into thinking that it's an RPM distro.
 sudo rm -f /bin/rpm
+
+# silence noise from debconf about frontends, Dialog, Readline
+export DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 sudo apt-get update -qy
@@ -22,7 +25,7 @@ sudo apt-get install -qy python3 python3-pip
 apt-get -y install python3-psycopg2
 
 # install composer and friends
-sudo apt-get -qy install curl php7.4-cli php7.4-curl php7.4-zip php7.4-mbstring php7.4-xml php7.4-gd composer php7.4-ldap
+sudo --preserve-env apt-get -y install curl php-cli php-curl php-zip php-mbstring php-xml php-gd composer php-ldap
 # packages needed for autogen
 sudo apt-get -qy install git autoconf automake m4 make bison flex \
  binutils libtool gcc g++ libc-dev libpam0g-dev python3 psmisc


### PR DESCRIPTION
We were getting odd errors with ldap.so for php:

/usr/lib/php/20190902/ldap.so: undefined symbol: RETURN_THROWS

Ticket: ENT-12530
Changelog: none
