### PR TITLE
ENT-12531: Allowed images from raw.github.com

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -207,7 +207,7 @@ LogLevel warn
         object-src 'none'; \
         frame-src 'self'; \
         child-src 'self'; \
-        img-src 'self' data: blob: avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com; \
+        img-src 'self' data: blob: avatars.githubusercontent.com badges.gitter.im fonts.gstatic.com kiwiirc.com raw.githubusercontent.com raw.github.com; \
         font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
         connect-src 'self' fonts.gstatic.com fonts.googleapis.com; \
         manifest-src 'self'; \


### PR DESCRIPTION
README files in build module repos often contain images, sometimes those images
are served from raw.github.com. This change allows those images to be displayed
within the Build app in Mission Portal.

Ticket: ENT-12531
Changelog: Title

Merge together: https://github.com/cfengine/masterfiles/pull/2973