### PR TITLE
ENT-12565: Fixed bootstrap host after tcpdf 6.8.0 dependency upgrade

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -93,6 +93,13 @@ fi
 (
 if test -f "$BASEDIR/mission-portal/vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php"; then
   cd $BASEDIR/mission-portal
+  # The ability to use visibility modifiers on constants was added in PHP 7.1
+  # However, the default apt repository of the bootstrap host currently
+  # provides PHP 7.0. Thus, we need to remove the visibility modifiers from
+  # this file to avoid syntax errors. See ENT-12565. We can remove this line
+  # once the default apt repository provides a version >= 7.1
+  sed -i 's/protected const/const/g' ./vendor/tecnickcom/tcpdf/include/tcpdf_static.php
+
   # Add Red Hat Text font to TCPDF library that we use in Mission Portal for PDF generation
   php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Regular.ttf
   php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Bold.ttf

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -52,6 +52,7 @@ bundle agent cfengine_build_host_setup
     (debian_10|debian_11).systemssl_build_host::
       "libssl-dev";
     debian.bootstrap_pr_host::
+      "php-curl"; # Required by tecnickcom/tcpdf 6.8.0
       "librsync-dev"; # bootstrap_pr host needs this to run configure and make dist
 
 # I attempted to arrange these packages in order of: generic (all versions) and then as if we gradually added them through time: rhel-6, 7, 8, 9...


### PR DESCRIPTION
* [Added php-curl dependency to bootstrap-pr host](https://github.com/cfengine/buildscripts/pull/1565/commits/96a5930290de8a46468f19eaefd3529db99400ba)
* [Remove const visibility modifiers in tcpdf_static.php](https://github.com/cfengine/buildscripts/pull/1565/commits/6cb6ae8f0a9f0a704ddc0f6c5f7abf5c70b3ad67)

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=11577)](https://ci.cfengine.com/job/pr-pipeline/11577/)