### PR TITLE
Removed redhat-6 from supported platforms as of 3.25.0

### DIFF
--- a/build-scripts/labels.txt
+++ b/build-scripts/labels.txt
@@ -20,7 +20,6 @@ PACKAGES_arm_64_linux_debian_11
 PACKAGES_x86_64_linux_debian_12
 PACKAGES_arm_64_linux_debian_12
 
-PACKAGES_x86_64_linux_redhat_6
 PACKAGES_x86_64_linux_redhat_7
 PACKAGES_x86_64_linux_redhat_8
 PACKAGES_x86_64_linux_redhat_9


### PR DESCRIPTION
Ticket: ENT-12345
Changelog: title
