### PR TITLE
Fixed issue where rhel >8 packages would not have correct openssl dependency version

### DIFF
--- a/build-scripts/package
+++ b/build-scripts/package
@@ -142,11 +142,16 @@ case "$PACKAGING" in
         fi
     fi
 
-    # determine policy-version for rhel systems so we can require what we build with
+    # determine the system-provided versions of dependencies we build against so we can Require them later in our RPM spec files.
     if [ "$OS" = "rhel" ]; then
         SELINUX_POLICY_VERSION=$(rpm -q --qf '%{VERSION}\n' selinux-policy)
         if [ -z "$SELINUX_POLICY_VERSION" ]; then
             echo "error: unable to determine selinux-policy package version"
+            exit 1
+        fi
+        OPENSSL_VERSION=$(rpm -q --provides openssl-libs | grep OPENSSL_ | sed 's/^.*_\([0-9.]*\).*$/\1/' | sort -n | tail -1)
+        if [ -z "$OPENSSL_VERSION" ]; then
+            echo "error: unable to determine openssl package version"
             exit 1
         fi
     fi
@@ -155,6 +160,7 @@ case "$PACKAGING" in
         -e "s/@@VERSION@@/$RPM_VERSION/g" \
         -e "s/@@RELEASE@@/$safe_prefix$RPM_RELEASE/g" \
         -e "s/@@SELINUX_POLICY_VERSION@@/$SELINUX_POLICY_VERSION/g" \
+        -e "s/@@OPENSSL_VERSION@@/$OPENSSL_VERSION/g" \
         -e "/^%pre\$/r $PREINSTALL" \
         -e "/^%post\$/r $POSTINSTALL" \
         -e "/^%preun\$/r $PREREMOVE" \

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -33,9 +33,13 @@ Requires: libssl.so.1.1()(64bit) libssl.so.1.1(OPENSSL_1_1_0)(64bit) libssl.so.1
 Requires: libcrypto.so.1.1()(64bit) libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)
 %endif
 
+# We build against systems with the latest available dependencies such as OpenSSL.
+# We use rpm -q --provides to determine the highest API present in OpenSSL and then use that as a Requires.
+# OPENSSL_VERSION is determined in build-scripts/package script.
+# This should ensure that when packages are installed with yum/dnf any required OpenSSL package upgrades will be performed or the installation will fail.
 %if %{?rhel}%{!?rhel:0} > 8
-Requires: libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_3.0.0)(64bit) libcrypto.so.3(OPENSSL_3.0.1)(64bit)
-Requires: libssl.so.3()(64bit) libssl.so.3(OPENSSL_3.0.0)(64bit)
+Requires: libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_@@OPENSSL_VERSION@@)(64bit)
+Requires: libssl.so.3()(64bit) libssl.so.3(OPENSSL_@@OPENSSL_VERSION@@)(64bit)
 %endif
 
 # cfbs/Build requires Python 3.5+ (not available on RHEL 6)

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -29,9 +29,13 @@ Requires: libssl.so.1.1()(64bit) libssl.so.1.1(OPENSSL_1_1_0)(64bit) libssl.so.1
 Requires: libcrypto.so.1.1()(64bit) libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)
 %endif
 
+# We build against systems with the latest available dependencies such as OpenSSL.
+# We use rpm -q --provides to determine the highest API present in OpenSSL and then use that as a Requires.
+# OPENSSL_VERSION is determined in build-scripts/package script.
+# This should ensure that when packages are installed with yum/dnf any required OpenSSL package upgrades will be performed or the installation will fail.
 %if %{?rhel}%{!?rhel:0} > 8
-Requires: libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_3.0.0)(64bit) libcrypto.so.3(OPENSSL_3.0.1)(64bit)
-Requires: libssl.so.3()(64bit) libssl.so.3(OPENSSL_3.0.0)(64bit)
+Requires: libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_@@OPENSSL_VERSION@@)(64bit)
+Requires: libssl.so.3()(64bit) libssl.so.3(OPENSSL_@@OPENSSL_VERSION@@)(64bit)
 %endif
 
 AutoReqProv: no


### PR DESCRIPTION
We build against systems with the latest available dependencies such as OpenSSL.
libcurl builds against this OpenSSL version which can have API changes that will break functionality if used on a non-updated system.

Ticket: ENT-12587
Changelog: title
