### PR TITLE
Change unused rsync.log path to specific /tmp/rsync.log (3.24)

### DIFF
--- a/build-remote
+++ b/build-remote
@@ -183,7 +183,7 @@ prepare_workdir() {
 
 checkout() {
   mkdir -p build
-  rsync -avr --exclude='workdir-*' $(dirname $0)/ build/buildscripts  >>rsync.log
+  rsync -avr --exclude='workdir-*' $(dirname $0)/ build/buildscripts  >>/tmp/rsync.log
 
   REPOS="core masterfiles"
 
@@ -255,10 +255,10 @@ checkout() {
       ;;
 
     nova-cp)
-      rsync -avr --exclude='workdir-*' $AUTOBUILD_PATH/ build/buildscripts  >>rsync.log
+      rsync -avr --exclude='workdir-*' $AUTOBUILD_PATH/ build/buildscripts  >>/tmp/rsync.log
       for d in core nova enterprise masterfiles mission-portal
       do
-        rsync -avr $SOURCE/$d build  >>rsync.log
+        rsync -avr $SOURCE/$d build  >>/tmp/rsync.log
       done
       ;;
 

--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -86,18 +86,18 @@ INCLUDES='--include=test.* --include=summary.*'
 rsync -rv $INCLUDES --exclude="*" \
     $TESTMACHINE_URI$BASEDIR/core/tests/acceptance/ \
                     $BASEDIR/core/tests/acceptance/ \
-    >> rsync.log
+    >> /tmp/rsync.log
 
 if [ $PROJECT = nova ]
 then
     rsync -rv $INCLUDES --exclude="*" \
         $TESTMACHINE_URI$BASEDIR/enterprise/tests/acceptance/ \
                         $BASEDIR/enterprise/tests/acceptance/ \
-        >> rsync.log
+        >> /tmp/rsync.log
     rsync -rv $INCLUDES --exclude="*" \
         $TESTMACHINE_URI$BASEDIR/masterfiles/tests/acceptance/ \
                         $BASEDIR/masterfiles/tests/acceptance/ \
-        >> rsync.log
+        >> /tmp/rsync.log
 fi
 
 if [ $return_code -ne 0 ]

--- a/build-scripts/transfer-results
+++ b/build-scripts/transfer-results
@@ -10,6 +10,6 @@ BUILDMACHINE="$1"
 mkdir -p $BASEDIR/../../../output/${SCHEDULER}/${BUILD_NUMBER}
 rsync -avr --delete "$BUILDMACHINE:build/output/*" \
       $BASEDIR/../../../output/${SCHEDULER}/${BUILD_NUMBER} \
-      >rsync.log
+      >/tmp/rsync.log
 
 ssh "$BUILDMACHINE" "rm -rf build/output"

--- a/build-scripts/transfer-to-testmachine
+++ b/build-scripts/transfer-to-testmachine
@@ -28,6 +28,6 @@ esac
 BASEDIR_NO_DOT="$(echo $BASEDIR | sed -e 's,/\./,/,g;s,/\.$,,')"
 touch .keepalive-echo
 (while test -e .keepalive-echo; do sleep 60; echo Keep alive; done)&
-sudo rsync -avR $EXCLUDES --delete --delete-excluded "$BASEDIR_NO_DOT/" $TESTMACHINE_URI  >rsync.log
-sudo rsync -avR $EXCLUDES --delete --delete-excluded "$PREFIX/" $TESTMACHINE_URI    >>rsync.log
+sudo rsync -avR $EXCLUDES --delete --delete-excluded "$BASEDIR_NO_DOT/" $TESTMACHINE_URI  >/tmp/rsync.log
+sudo rsync -avR $EXCLUDES --delete --delete-excluded "$PREFIX/" $TESTMACHINE_URI    >>/tmp/rsync.log
 rm .keepalive-echo


### PR DESCRIPTION
An instance occurred where maybe the PWD was removed by another process and so an rsync command failed due to not being able to write the file in PWD.

Ticket: ENT-12633
Changelog: none
(cherry picked from commit 3e5e3885b63656244606118ca919b5af9218f02d)
