### PR TITLE
Adjusted cfengine build host policy to use http for debian-9

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -210,7 +210,7 @@ bundle agent cfengine_build_host_setup
       "/etc/apt/sources.list.d/*"
         delete => tidy;
       "/etc/apt/sources.list"
-        content => "deb https://archive.debian.org/debian/ stretch main contrib non-free";
+        content => "deb http://archive.debian.org/debian/ stretch main contrib non-free";
     suse_15|opensuse_15|sles_15::
       "/home/jenkins/.rpmmacros"
         content => "%dist .suse15",


### PR DESCRIPTION
apt-transport-https package is not easily installed so use http instead

Fix for jenkins-vms bootstrap vm.

Ticket: ENT-12659
Changelog: none
