### PR TITLE
Marked application/config/config.php as a configuration file in packages

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -385,6 +385,9 @@ exit 0
 
 # No-one should need access to anything under share/GUI
 %defattr(400,root,root,400)
+# We can change these configuration files as part of masterfiles policy so need to mark as configs
+%config(noreplace) %prefix/share/GUI/application/config/config.php
+%config(noreplace) %prefix/share/GUI/api/modules/inventory/config/config.php
 %prefix/share/GUI
 
 # Base policy

--- a/packaging/cfengine-nova-hub/debian/conffiles
+++ b/packaging/cfengine-nova-hub/debian/conffiles
@@ -1,0 +1,2 @@
+/var/cfengine/share/GUI/application/config/config.php
+/var/cfengine/share/GUI/api/modules/inventory/config/config.php


### PR DESCRIPTION
related to management of share/GUI and not-share/GUI of two php configuration files: https://github.com/cfengine/masterfiles/pull/2988

Ticket: ENT-12658
Changelog: none
