### PR TITLE
Added suse 15+ to agent packages which have init scripts removed

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -62,7 +62,8 @@ rm -f $RPM_BUILD_ROOT%{prefix}/bin/openssl
 rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl
 rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 
-%if %{?rhel}%{!?rhel:0} >= 9
+# For el9+ and suse-15+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} >= 9 || %{?suse_version}%{!?suse_version:0} >= 1500
 rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine3.sh
@@ -132,11 +133,11 @@ rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine3.sh
 %endif
 
 # Globally installed configs, scripts
-%if %{?rhel}%{!?rhel:0} < 9
+%if %{?rhel}%{!?rhel:0} < 9 && %{?suse_version}%{!?suse_version:0} < 1500
 %attr(644,root,root) /etc/sysconfig/cfengine3
 %attr(755,root,root) /etc/profile.d/cfengine3.sh
 # ENT-11901
-# For el9+ we started seeing issues from other packages not expecting init scripts
+# For el9+ and suse15+ we started seeing issues from other packages not expecting init scripts
 %attr(755,root,root) /etc/init.d/cfengine3
 %endif
 

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -54,8 +54,8 @@ cp -a %{prefix}/* $RPM_BUILD_ROOT%{prefix}
 cp -a %{_basedir}/cfengine/dist/* $RPM_BUILD_ROOT
 
 # ENT-11901
-# For el9+ we started seeing issues from other packages not expecting init scripts
-%if %{?rhel}%{!?rhel:0} >= 9
+# For el9+ and suse-15+ we started seeing issues from other packages not expecting init scripts
+%if %{?rhel}%{!?rhel:0} >= 9 || %{?suse_version}%{!?suse_version:0} >= 1500
 rm -f $RPM_BUILD_ROOT/etc/sysconfig/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine.sh
 rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
@@ -154,7 +154,7 @@ exit 0
 # Globally installed configs, scripts
 # ENT-11901
 # For el9+ we started seeing issues from other packages not expecting init scripts
-%if %{?rhel}%{!?rhel:0} < 9
+%if %{?rhel}%{!?rhel:0} < 9 && %{?suse_version}%{!?suse_version:0} < 1500
 %attr(755,root,root) /etc/init.d/cfengine3
 %attr(644,root,root) /etc/sysconfig/cfengine3
 %attr(755,root,root) /etc/profile.d/cfengine.sh


### PR DESCRIPTION
Otherwise, errors occur when removing the cfengine-nova package on suse-15+ systems.

Ticket: CFE-4077
Changelog: title
