### PR TITLE
ENT-12660: exclude npm dev dependencies from a package (3.24.x)

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -67,9 +67,11 @@ if test -f "$BASEDIR/mission-portal/public/scripts/package.json"; then
   npm --version
   node --version
   # install dependencies from npmjs
-  npm i --prefix $BASEDIR/mission-portal/public/scripts/
+  npm ci --prefix $BASEDIR/mission-portal/public/scripts/
   # build react components
   npm run build --prefix $BASEDIR/mission-portal/public/scripts/
+  # remove the packages specified in devDependencies
+  npm prune --omit=dev --prefix $BASEDIR/mission-portal/public/scripts/
 
 fi
 )

--- a/ci/setup-projects.sh
+++ b/ci/setup-projects.sh
@@ -13,9 +13,11 @@ set -ex
 if test -f "mission-portal/public/scripts/package.json"; then
 	cd mission-portal/public/scripts
 	# install dependencies from npmjs
-	npm i
+	npm ci
 	# build react components
 	npm run build
+	# remove the packages specified in devDependencies
+	npm prune --omit=dev
 fi
 )
 


### PR DESCRIPTION
Ticket: ENT-12660
Signed-off-by: Ihor Aleksandrychiev <ihor.aleksandrychiev@northern.tech>
(cherry picked from commit b743c80a93df2fe1eb14af47a032ec005293ab7c)