### PR TITLE
Remove enterprise hub systemd units from community and enterprise agent packages

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -68,6 +68,13 @@ rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine3.sh
 %endif
 
+# Remove enterprise systemd units
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-apache.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-php-fpm.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-hub.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-reactor.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
+
 %clean
 #rm -rf $RPM_BUILD_ROOT
 
@@ -143,12 +150,8 @@ rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine3.sh
 # Systemd units
 %defattr(644,root,root,755)
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
 /usr/lib/systemd/system/cf-serverd.service
 
 # Documentation

--- a/packaging/cfengine-community/debian/cfengine-community.install
+++ b/packaging/cfengine-community/debian/cfengine-community.install
@@ -1,11 +1,7 @@
 /etc/init.d/cfengine3
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
 /usr/lib/systemd/system/cf-serverd.service
 /etc/default/cfengine3
 /etc/profile.d/cfengine3.sh

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -73,6 +73,14 @@ rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl
 rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 
 
+# Remove enterprise systemd units
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-apache.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-php-fpm.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-hub.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-reactor.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
+
+
 %clean
 #rm -rf $RPM_BUILD_ROOT
 
@@ -163,13 +171,8 @@ exit 0
 # Systemd units
 %defattr(644,root,root,755)
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-php-fpm.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
 /usr/lib/systemd/system/cf-serverd.service
 
 # Documentation

--- a/packaging/cfengine-nova/debian/cfengine-nova.install
+++ b/packaging/cfengine-nova/debian/cfengine-nova.install
@@ -2,12 +2,8 @@
 /etc/default
 /etc/profile.d
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
 /usr/lib/systemd/system/cf-serverd.service
 /var/cfengine/bin/cf-agent
 /var/cfengine/bin/cf-check


### PR DESCRIPTION
These were added with CFE-2278, commit fdbe42f4b54e02230602a4d76b0a50aad4efe23c when split systemd units were introduced.

Ticket: ENT-12689
Changelog: none
