### PR TITLE
Don't set $MANPATH

### DIFF
--- a/packaging/cfengine-community/profile.sh
+++ b/packaging/cfengine-community/profile.sh
@@ -1,7 +1,3 @@
 if ! echo ${PATH} | /bin/grep /var/cfengine/bin > /dev/null ; then
     export PATH=$PATH:/var/cfengine/bin
 fi
-
-if ! echo ${MANPATH} | /bin/grep /var/cfengine/share/man > /dev/null ; then
-    export MANPATH=$MANPATH:/var/cfengine/share/man
-fi


### PR DESCRIPTION
The man pages aren't built anymore since https://github.com/cfengine/core/pull/715 . The directory /var/cfengine/share/man does not exist as part of the package so it does not make sense to refer to it.