### PR TITLE
Further standardized Url fields in spec files

### DIFF
--- a/deps-packaging/diffutils/cfbuild-diffutils-aix.spec
+++ b/deps-packaging/diffutils/cfbuild-diffutils-aix.spec
@@ -7,7 +7,7 @@ Release: 1
 Source0: diffutils-%{diffutils_version}.tar.xz
 License: GPL3
 Group: Other
-Url: https://www.gnu.org/software/diffutils/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
 AutoReqProv: no

--- a/deps-packaging/diffutils/cfbuild-diffutils.spec
+++ b/deps-packaging/diffutils/cfbuild-diffutils.spec
@@ -7,7 +7,7 @@ Release: 1
 Source0: diffutils-%{diffutils_version}.tar.xz
 License: GPL3
 Group: Other
-Url: https://www.gnu.org/software/diffutils/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
 AutoReqProv: no

--- a/deps-packaging/leech/cfbuild-leech.spec
+++ b/deps-packaging/leech/cfbuild-leech.spec
@@ -7,7 +7,7 @@ Release: 1
 Source0: leech-%{leech_version}.tar.gz
 License: LGPL
 Group: Other
-Url: https://github.com/larsewi/leech
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
 AutoReqProv: no

--- a/deps-packaging/libexpat/cfbuild-libexpat.spec
+++ b/deps-packaging/libexpat/cfbuild-libexpat.spec
@@ -7,7 +7,7 @@ Release: 1
 Source0: expat-%{expat_version}.tar.xz
 License: MIT
 Group: Other
-Url: https://libexpat.github.io
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
 AutoReqProv: no

--- a/deps-packaging/libgcc/cfbuild-libgcc.spec
+++ b/deps-packaging/libgcc/cfbuild-libgcc.spec
@@ -7,7 +7,7 @@ Release: 0
 Vendor: IBM
 License: Proprietary
 Group: Applications/System
-URL: https://ibm.com/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 
 

--- a/deps-packaging/libiconv/cfbuild-libiconv.spec
+++ b/deps-packaging/libiconv/cfbuild-libiconv.spec
@@ -5,7 +5,7 @@ Release: 1
 Source0: libiconv-1.17.tar.gz
 License: MIT
 Group: Other
-Url: https://www.gnu.org/software/libiconv/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
 AutoReqProv: no

--- a/deps-packaging/librsync/cfbuild-librsync.spec
+++ b/deps-packaging/librsync/cfbuild-librsync.spec
@@ -7,7 +7,7 @@ Release: 1
 Source0: librsync-%{librsync_version}.tar.gz
 License: LGPL
 Group: Other
-Url: https://librsync.sourcefrog.net
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
 AutoReqProv: no

--- a/deps-packaging/lmdb/cfbuild-lmdb.spec
+++ b/deps-packaging/lmdb/cfbuild-lmdb.spec
@@ -7,7 +7,7 @@ Release: 1
 Source0: openldap-LMDB_%{lmdb_version}.tar.gz
 License: OpenLDAP
 Group: Other
-Url: https://symas.com/mdb
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 
 AutoReqProv: no

--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -8,7 +8,7 @@ Release: @@RELEASE@@%{?dist}
 Vendor: Northern.tech AS
 License: COSL
 Group: Applications/System
-URL: https://cfengine.com/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3 < @@VERSION@@, cf-community < @@VERSION@@
 Requires: coreutils

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -10,7 +10,7 @@ Release: @@RELEASE@@%{?dist}
 Vendor: Northern.tech AS
 License: COSL
 Group: Applications/System
-URL: https://cfengine.com/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3 < @@VERSION@@, cf-community < @@VERSION@@
 Requires: coreutils

--- a/packaging/cfengine-nova/cfengine-nova.spec.aix.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.aix.in
@@ -7,7 +7,7 @@ Release: @@RELEASE@@%{?dist}
 Vendor: Northern.tech AS
 License: COSL
 Group: Applications/System
-URL: https://cfengine.com/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3, cfengine-community, cfengine-nova
 

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -8,7 +8,7 @@ Release: @@RELEASE@@%{?dist}
 Vendor: Northern.tech AS
 License: COSL
 Group: Applications/System
-URL: https://cfengine.com/
+Url: https://cfengine.com
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3 < @@VERSION@@, cf-community < @@VERSION@@
 Requires: coreutils


### PR DESCRIPTION
Discussed in Slack.

We build our own cfbuild- prefixed packages, nobody else should
really be installing these, but	if there is a problem with them
it's really more appropriate to	point to cfengine.com.
(To contact / blame us).