### PR TITLE
Remove enterprise hub systemd units from community and enterprise agent packages. (3.21)

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -69,6 +69,13 @@ rm -f $RPM_BUILD_ROOT/etc/init.d/cfengine3
 rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine3.sh
 %endif
 
+# Remove enterprise systemd units
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-apache.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-php-fpm.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-hub.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-reactor.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
+
 %clean
 #rm -rf $RPM_BUILD_ROOT
 
@@ -140,13 +147,8 @@ rm -f $RPM_BUILD_ROOT/etc/profile.d/cfengine3.sh
 # Systemd units
 %defattr(644,root,root,755)
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 
 # Documentation

--- a/packaging/cfengine-community/debian/cfengine-community.install
+++ b/packaging/cfengine-community/debian/cfengine-community.install
@@ -1,12 +1,7 @@
 /etc/init.d/cfengine3
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 /etc/default/cfengine3
 /etc/profile.d/cfengine3.sh

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -69,6 +69,14 @@ rm -f $RPM_BUILD_ROOT%{prefix}/bin/curl
 rm -rf $RPM_BUILD_ROOT%{prefix}/ssl
 
 
+# Remove enterprise systemd units
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-apache.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-php-fpm.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-hub.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-reactor.service
+rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
+
+
 %clean
 #rm -rf $RPM_BUILD_ROOT
 
@@ -155,13 +163,8 @@ exit 0
 # Systemd units
 %defattr(644,root,root,755)
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 
 # Documentation

--- a/packaging/cfengine-nova/debian/cfengine-nova.install
+++ b/packaging/cfengine-nova/debian/cfengine-nova.install
@@ -2,13 +2,8 @@
 /etc/default
 /etc/profile.d
 /usr/lib/systemd/system/cfengine3.service
-/usr/lib/systemd/system/cf-apache.service
 /usr/lib/systemd/system/cf-execd.service
-/usr/lib/systemd/system/cf-hub.service
-/usr/lib/systemd/system/cf-reactor.service
 /usr/lib/systemd/system/cf-monitord.service
-/usr/lib/systemd/system/cf-postgres.service
-/usr/lib/systemd/system/cf-runalerts.service
 /usr/lib/systemd/system/cf-serverd.service
 /var/cfengine/bin/cf-agent
 /var/cfengine/bin/cf-check


### PR DESCRIPTION
These were added with CFE-2278, commit fdbe42f4b54e02230602a4d76b0a50aad4efe23c when split systemd units were introduced.

Also explicitly remove the new cf-php-fpm service needed for http2 enablement in Mission Portal (ENT-11440).

Ticket: ENT-12689
Changelog: none
(cherry picked from commit 006d3dff46d5124262655490f803ecc1b1caa1ce)

 Conflicts:
	packaging/cfengine-community/cfengine-community.spec.in
	packaging/cfengine-community/debian/cfengine-community.install
	packaging/cfengine-nova/cfengine-nova.spec.in
	packaging/cfengine-nova/debian/cfengine-nova.install

3.21 does not include cf-php-fpm
