### PR TITLE
Automatic dependency updates for 3.24.x

### DIFF
--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -13,30 +13,23 @@ import subprocess
 DEPS_PACKAGING = "deps-packaging"
 
 
-def run_command(root: str, cmd: list):
-    curdir = os.getcwd()
-    os.chdir(root)
-
+def run_command(cmd: list):
     try:
-        log.debug(f"Running command '{" ".join(cmd)}' from directory '{root}'")
+        log.debug(f"Running command '{" ".join(cmd)}'")
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError:
         log.error(f"Command '{" ".join(cmd)}' failed")
         return False
-    finally:
-        os.chdir(curdir)
     return True
 
 
 def git_commit(root, msg):
-    return run_command(root, ["git", "add", "-u"]) and run_command(
-        root,
+    return run_command(["git", "-C", root, "add", "-u"]) and run_command(
         [
             "git",
             "-C",
             root,
             "commit",
-            "--author=GitHub <noreply@github.com>",
             f"--message={msg}",
         ],
     )

--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -29,7 +29,17 @@ def run_command(root: str, cmd: list):
 
 
 def git_commit(root, msg):
-    return run_command(root, [ "git", "add", "-u" ]) and run_command(root, [ "git", "-C", root, "commit", "--author=GitHub <noreply@github.com>", f"--message={msg}" ])
+    return run_command(root, ["git", "add", "-u"]) and run_command(
+        root,
+        [
+            "git",
+            "-C",
+            root,
+            "commit",
+            "--author=GitHub <noreply@github.com>",
+            f"--message={msg}",
+        ],
+    )
 
 
 def parse_args():
@@ -51,12 +61,10 @@ def parse_args():
         action="extend",
         default=[],
         metavar=("PACKAGE", "VERSION"),
-        help="skip updates for specific version of a package (e.g., --skip librsync 2.3.4)"
+        help="skip updates for specific version of a package (e.g., --skip librsync 2.3.4)",
     )
     parser.add_argument(
-        "--root",
-        default=".",
-        help="specify build scripts root directory"
+        "--root", default=".", help="specify build scripts root directory"
     )
 
     return parser.parse_args()
@@ -122,7 +130,7 @@ def select_new_version(
     old_version,
     available_versions,
 ):
-    assert len(skip_versions) % 2 == 0 # Is guaranteed by the argument parser
+    assert len(skip_versions) % 2 == 0  # Is guaranteed by the argument parser
 
     old_split = old_version.replace("-", ".").replace("_", ".").split(".")
     for new_version in available_versions:
@@ -210,7 +218,9 @@ def update_deps(root, bump, skip):
             exit(1)
 
         available_versions = get_available_versions(proj_id)
-        new_version = select_new_version(pkg_name, bump, skip, old_version, available_versions)
+        new_version = select_new_version(
+            pkg_name, bump, skip, old_version, available_versions
+        )
         if not new_version:
             log.error(f"Could not find a suitable new version for package {pkg_name}")
             exit(1)
@@ -231,7 +241,10 @@ def update_deps(root, bump, skip):
         update_version_numbers(root, pkg_name, old_version, new_version)
         update_distfiles_digest(root, pkg_name)
 
-        if not git_commit(root, f"Updated dependency '{pkg_name}' from version {old_version} to {new_version}"):
+        if not git_commit(
+            root,
+            f"Updated dependency '{pkg_name}' from version {old_version} to {new_version}",
+        ):
             log.error(f"Failed to commit changes after updating package '{pkg_name}'")
             exit(1)
 

--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -13,17 +13,23 @@ import subprocess
 DEPS_PACKAGING = "deps-packaging"
 
 
-def git_commit(root, msg):
-    cmd = [ "git", "add", "-u" ]
-    log.debug(f"Running command: {" ".join(cmd)}")
-    result = subprocess.run(cmd)
-    if result.returncode != 0:
-        return False
+def run_command(root: str, cmd: list):
+    curdir = os.getcwd()
+    os.chdir(root)
 
-    cmd = [ "git", "-C", root, "commit", "--author=GitHub <noreply@github.com>", f"--message={msg}" ]
-    log.debug(f"Running command: {" ".join(cmd)}")
-    result = subprocess.run(cmd)
-    return result.returncode == 0
+    try:
+        log.debug(f"Running command '{" ".join(cmd)}' from directory '{root}'")
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        log.error(f"Command '{" ".join(cmd)}' failed")
+        return False
+    finally:
+        os.chdir(curdir)
+    return True
+
+
+def git_commit(root, msg):
+    return run_command(root, [ "git", "add", "-u" ]) and run_command(root, [ "git", "-C", root, "commit", "--author=GitHub <noreply@github.com>", f"--message={msg}" ])
 
 
 def parse_args():

--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -231,10 +231,7 @@ def update_deps(root, bump, skip):
         update_version_numbers(root, pkg_name, old_version, new_version)
         update_distfiles_digest(root, pkg_name)
 
-        if git_commit(root, f"Updated dependency '{pkg_name}' from version {old_version} to {new_version}"):
-            with open("/tmp/create-pr", "w"):
-                pass
-        else:
+        if not git_commit(root, f"Updated dependency '{pkg_name}' from version {old_version} to {new_version}"):
             log.error(f"Failed to commit changes after updating package '{pkg_name}'")
             exit(1)
 

--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -20,10 +20,10 @@ def parse_args():
         help="enable debug log messages",
     )
     parser.add_argument(
-        "--update",
+        "--bump",
         default="minor",
         choices=["major", "minor", "patch"],
-        help="whether to do major, minor or patch updates",
+        help="whether to bump version major, minor or patch",
     )
     parser.add_argument(
         "--skip",
@@ -92,7 +92,7 @@ def get_available_versions(proj_id):
 
 def select_new_version(
     package_name,
-    update_type,
+    bump_version,
     skip_versions,
     old_version,
     available_versions,
@@ -112,11 +112,11 @@ def select_new_version(
             log.info(f"Skipping version {new_version} for package {package_name}")
             continue
 
-        if update_type == "major":
+        if bump_version == "major":
             return new_version
-        if update_type == "minor" and old_split[:1] == new_split[:1]:
+        if bump_version == "minor" and old_split[:1] == new_split[:1]:
             return new_version
-        if update_type == "patch" and old_split[:2] == new_split[:2]:
+        if bump_version == "patch" and old_split[:2] == new_split[:2]:
             return new_version
     return None  # Didn't find a suitable version
 
@@ -174,7 +174,7 @@ def update_distfiles_digest(pkg_name):
     replace_string_in_file(filename, old_digest, new_digest)
 
 
-def update_deps(update, skip):
+def update_deps(bump, skip):
     with open(os.path.join(DEPS_PACKAGING, "release-monitoring.json"), "r") as f:
         release_monitoring = json.load(f)
 
@@ -186,7 +186,7 @@ def update_deps(update, skip):
             exit(1)
 
         available_versions = get_available_versions(proj_id)
-        new_version = select_new_version(pkg_name, update, skip, old_version, available_versions)
+        new_version = select_new_version(pkg_name, bump, skip, old_version, available_versions)
         if not new_version:
             log.error(f"Could not find a suitable new version for package {pkg_name}")
             exit(1)
@@ -220,7 +220,7 @@ def main():
         format="[%(filename)s:%(lineno)d][%(levelname)s]: %(message)s", level=loglevel
     )
 
-    update_deps(args.update, args.skip)
+    update_deps(args.bump, args.skip)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -174,13 +174,7 @@ def update_distfiles_digest(pkg_name):
     replace_string_in_file(filename, old_digest, new_digest)
 
 
-def main():
-    args = parse_args()
-    loglevel = "DEBUG" if args.debug else "INFO"
-    log.basicConfig(
-        format="[%(filename)s:%(lineno)d][%(levelname)s]: %(message)s", level=loglevel
-    )
-
+def update_deps(update, skip):
     with open(os.path.join(DEPS_PACKAGING, "release-monitoring.json"), "r") as f:
         release_monitoring = json.load(f)
 
@@ -192,7 +186,7 @@ def main():
             exit(1)
 
         available_versions = get_available_versions(proj_id)
-        new_version = select_new_version(pkg_name, args.update, args.skip, old_version, available_versions)
+        new_version = select_new_version(pkg_name, update, skip, old_version, available_versions)
         if not new_version:
             log.error(f"Could not find a suitable new version for package {pkg_name}")
             exit(1)
@@ -217,6 +211,17 @@ def main():
 
     with open("/tmp/commit-message.txt", "w") as f:
         f.writelines(commit_message)
+
+
+def main():
+    args = parse_args()
+    loglevel = "DEBUG" if args.debug else "INFO"
+    log.basicConfig(
+        format="[%(filename)s:%(lineno)d][%(levelname)s]: %(message)s", level=loglevel
+    )
+
+    update_deps(args.update, args.skip)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -1,0 +1,198 @@
+import os
+import re
+import time
+import json
+import hashlib
+import argparse
+import requests
+import urllib.request
+import logging as log
+
+DEPS_PACKAGING = "deps-packaging"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="CFEngine dependency updater")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="enable debug log messages",
+    )
+    parser.add_argument(
+        "--update",
+        default="minor",
+        choices=["major", "minor", "patch"],
+        help="whether to do major, minor or patch updates",
+    )
+    return parser.parse_args()
+
+
+def determine_old_version(pkg_name):
+    distfile = os.path.join(DEPS_PACKAGING, pkg_name, "distfiles")
+    with open(distfile, "r") as f:
+        data = f.read().strip().split()
+    filename = data[-1]
+
+    match = re.search(
+        r"[\-_]([0-9]+[\.\-][0-9]+([\.\-][0-9]+)?)(\.tar|\.tgz|-rel|-src)", filename
+    )
+    if match:
+        version = match.group(1)
+        log.debug(f"Extracted version number '{version}' from '{filename}'")
+        return version
+
+    log.error(f"Failed to extract version number from '{filename}'")
+    return None
+
+
+def get_available_versions(proj_id):
+    url = f"https://release-monitoring.org/api/v2/versions/?project_id={proj_id}"
+
+    versions_cache = "/tmp/update-deps-cache.json"
+    if os.path.exists(versions_cache):
+        with open(versions_cache, "r") as f:
+            cache = json.load(f)
+    else:
+        cache = {}
+
+    now = time.time()
+    one_hour = 3600
+    if (url in cache) and (cache[url]["timestamp"] + one_hour) > now:
+        log.debug(f"Retrieving '{url}' from cache '{versions_cache}'")
+        return cache[url]["response"]
+
+    data = requests.get(url).json()
+    versions = list(
+        filter(
+            lambda x: re.fullmatch(r"[0-9]+[\.\-_][0-9]+([\.\-_][0-9]+)?", x),
+            data["stable_versions"],
+        )
+    )
+
+    cache[url] = {}
+    cache[url]["response"] = versions
+    cache[url]["timestamp"] = now
+
+    log.debug(f"Updating cache '{versions_cache}' with response from '{url}'")
+    with open(versions_cache, "w") as f:
+        json.dump(cache, f, indent=2)
+
+    return versions
+
+
+def select_new_version(
+    update_type,
+    old_version,
+    available_versions,
+):
+    old_split = old_version.replace("-", ".").replace("_", ".").split(".")
+    for new_version in available_versions:
+        new_split = new_version.replace("-", ".").replace("_", ".").split(".")
+        if update_type == "major":
+            return new_version
+        if update_type == "minor" and old_split[:1] == new_split[:1]:
+            return new_version
+        if update_type == "patch" and old_split[:2] == new_split[:2]:
+            return new_version
+    return None  # Didn't find a suitable version
+
+
+def replace_string_in_file(filename, old, new):
+    if not os.path.exists(filename):
+        return
+
+    with open(filename, "r") as f:
+        contents = f.read()
+
+    if old not in contents:
+        """This handles an exception for libexpat, where the version number is a
+        part of the contents of the source file, but the version number is
+        separated by underscores. We don't explicitly test that we are currently
+        working with the package libexpat and the source file, because this may
+        be the case for other packages as well in the future."""
+        old = old.replace(".", "_")
+        new = new.replace(".", "_")
+
+    with open(filename, "w") as f:
+        f.write(contents.replace(old, new))
+
+
+def update_version_numbers(pkg_name, old_version, new_version):
+    filenames = [
+        os.path.join(DEPS_PACKAGING, pkg_name, f"cfbuild-{pkg_name}.spec"),
+        os.path.join(DEPS_PACKAGING, pkg_name, f"cfbuild-{pkg_name}-aix.spec"),
+        os.path.join(DEPS_PACKAGING, pkg_name, "distfiles"),
+        os.path.join(DEPS_PACKAGING, pkg_name, "source"),
+    ]
+    for filename in filenames:
+        replace_string_in_file(filename, old_version, new_version)
+
+
+def update_distfiles_digest(pkg_name):
+    with open(os.path.join(DEPS_PACKAGING, pkg_name, "source"), "r") as f:
+        source = f.read().strip()
+
+    filename = os.path.join(DEPS_PACKAGING, pkg_name, "distfiles")
+    with open(filename, "r") as f:
+        content = f.read().strip().split()
+    old_digest = content[0]
+    tarball = content[-1]
+
+    if not os.path.exists(os.path.join("/tmp", tarball)):
+        url = f"{source}/{tarball}"
+        urllib.request.urlretrieve(url, os.path.join("/tmp", tarball))
+
+    sha = hashlib.sha256()
+    with open(os.path.join("/tmp", tarball), "rb") as f:
+        sha.update(f.read())
+    new_digest = sha.digest().hex()
+
+    replace_string_in_file(filename, old_digest, new_digest)
+
+
+def main():
+    args = parse_args()
+    loglevel = "DEBUG" if args.debug else "INFO"
+    log.basicConfig(
+        format="[%(filename)s:%(lineno)d][%(levelname)s]: %(message)s", level=loglevel
+    )
+
+    with open(os.path.join(DEPS_PACKAGING, "release-monitoring.json"), "r") as f:
+        release_monitoring = json.load(f)
+
+    commit_message = ["Updated dependencies\n\n"]
+    for pkg_name, proj_id in release_monitoring.items():
+        old_version = determine_old_version(pkg_name)
+        if not old_version:
+            log.error(f"Failed to determine old version of package {pkg_name}")
+            exit(1)
+
+        available_versions = get_available_versions(proj_id)
+        new_version = select_new_version(args.update, old_version, available_versions)
+        if not new_version:
+            log.error(f"Could not find a suitable new version for package {pkg_name}")
+            exit(1)
+
+        if pkg_name == "openldap":
+            """Special case for openldap: release-monitoring takes version
+            number from git repo, which uses underscores as separators, but
+            later we download a file with dots as separators."""
+            new_version = new_version.replace("_", ".")
+
+        if old_version == new_version:
+            log.debug(
+                f"Package {pkg_name} is already the newest version ({old_version} == {new_version})"
+            )
+            continue
+        log.info(f"Updating {pkg_name} from version {old_version} to {new_version}...")
+
+        update_version_numbers(pkg_name, old_version, new_version)
+        update_distfiles_digest(pkg_name)
+
+        commit_message.append(f"- Updated dependency '{pkg_name}' from version {old_version} to {new_version}\n")
+
+    with open("/tmp/commit-message.txt", "w") as f:
+        f.writelines(commit_message)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -32,8 +32,13 @@ jobs:
             git config user.email '<noreply@github.com>'
         - name: Run update script
           run: python3 .github/workflows/update-deps.py --debug --bump=major
+        - name: Check if commits were made
+          run: |
+            if [[ $(git log --oneline -1 --author="GitHub") ]]; then
+              echo "COMMIT_MADE=true" >> $GITHUB_ENV
+            fi
         - name: Create Pull Request
-          if: hashFiles('/tmp/create-pr') != ''
+          if: env.COMMIT_MADE == 'true'
           uses: cfengine/create-pull-request@v6
           with:
             title: Updated dependencies

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -28,30 +28,12 @@ jobs:
             python -m pip install requests
         - name: Run update script
           run: python3 .github/workflows/update-deps.py --debug --bump=major
-        - name: Check if there are changes
-          run: |
-            git diff --exit-code || touch git_diff_exists
-            if [ -f git_diff_exists ]; then echo "Changes need to be committed"; else echo "No changes to commit"; fi
-        - name: Commit changes
-          if: hashFiles('git_diff_exists') != ''
-          run: |
-            git config user.name 'GitHub'
-            git config user.email '<noreply@github.com>'
-            git add -u
-            git commit -F /tmp/commit-message.txt
-        - id: commit-message-from-file
-          name: Parse commit message from file into variable
-          if: hashFiles('git_diff_exists') != ''
-          run: |
-            body=$(cat /tmp/commit-message.txt)
-            body="${body//$'\n'/'%0A'}"
-            echo ::set-output name=body::$body
         - name: Create Pull Request
-          if: hashFiles('git_diff_exists') != ''
+          if: hashFiles('/tmp/create-pr') != ''
           uses: cfengine/create-pull-request@v6
           with:
             title: Updated dependencies
-            body: ${{ steps.commit-message-from-file.outputs.body }}
+            body: Automated dependency updates
             reviewers: |
               olehermanse
               larsewi

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -31,7 +31,7 @@ jobs:
             git config user.name 'GitHub'
             git config user.email '<noreply@github.com>'
         - name: Run update script
-          run: python3 .github/workflows/update-deps.py --debug --bump=major
+          run: python3 .github/workflows/update-deps.py --debug --bump=minor
         - name: Check if commits were made
           run: |
             if [[ $(git log --oneline -1 --author="GitHub") ]]; then

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -26,6 +26,10 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             python -m pip install requests
+        - name: Set Git user
+          run: |
+            git config user.name 'GitHub'
+            git config user.email '<noreply@github.com>'
         - name: Run update script
           run: python3 .github/workflows/update-deps.py --debug --bump=major
         - name: Create Pull Request

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,60 @@
+name: Update dependencies
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Run every Monday at 7am UTC
+    #        | | | | |
+    #        | | | | day of the week (0–6) (Sunday to Saturday)
+    #        | | | month (1–12)
+    #        | | day of the month (1–31)
+    #        | hour (0–23)
+    #        minute (0–59)
+  workflow_dispatch: # Enables manual trigger
+
+jobs:
+  update_dependencies:
+    name: Update dependencies
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checks-out repository
+          uses: actions/checkout@v4
+        - name: Set up Python 3.12
+          uses: actions/setup-python@v5
+          with:
+            python-version: "3.12"
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install requests
+        - name: Run update script
+          run: python3 .github/workflows/update-deps.py --debug --update=major
+        - name: Check if there are changes
+          run: |
+            git diff --exit-code || touch git_diff_exists
+            if [ -f git_diff_exists ]; then echo "Changes need to be committed"; else echo "No changes to commit"; fi
+        - name: Commit changes
+          if: hashFiles('git_diff_exists') != ''
+          run: |
+            git config user.name 'GitHub'
+            git config user.email '<noreply@github.com>'
+            shopt -s globstar
+            git add deps-packaging/.
+            git commit -F /tmp/commit-message.txt
+        - id: commit-message-from-file
+          name: Parse commit message from file into variable
+          if: hashFiles('git_diff_exists') != ''
+          run: |
+            body=$(cat /tmp/commit-message.txt)
+            body="${body//$'\n'/'%0A'}"
+            echo ::set-output name=body::$body
+        - name: Create Pull Request
+          if: hashFiles('git_diff_exists') != ''
+          uses: cfengine/create-pull-request@v6
+          with:
+            title: Updated dependencies
+            body: ${{ steps.commit-message-from-file.outputs.body }}
+            reviewers: |
+              olehermanse
+              larsewi
+              craigcomstock
+            branch: update-dependencies-action

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -37,8 +37,7 @@ jobs:
           run: |
             git config user.name 'GitHub'
             git config user.email '<noreply@github.com>'
-            shopt -s globstar
-            git add deps-packaging/.
+            git add -u
             git commit -F /tmp/commit-message.txt
         - id: commit-message-from-file
           name: Parse commit message from file into variable

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -27,7 +27,7 @@ jobs:
             python -m pip install --upgrade pip
             python -m pip install requests
         - name: Run update script
-          run: python3 .github/workflows/update-deps.py --debug --update=major
+          run: python3 .github/workflows/update-deps.py --debug --bump=major
         - name: Check if there are changes
           run: |
             git diff --exit-code || touch git_diff_exists


### PR DESCRIPTION
- **Added automatic dependency updates**
- **Added option to skip updating a specific version of a package**
- **Only add tracked files when updating dependencies**
- **Do only argument parsing and log config in main()**
- **Renamed --update option to --bump**
- **Added build scripts root path option**
- **One commit per dependency update**
- **Added utility function to run command**
- **Set git user in update-deps workflow**
- **Let's try another approach of determining if commit was created**
- **update-deps.py: Formatted with black**
- **update-deps.py: Do not change directory for git commands**
- **update-deps.yml: Bump minor instead of major**
