### PR TITLE
release-monitoring.json: Update project ID for psql

### DIFF
--- a/deps-packaging/release-monitoring.json
+++ b/deps-packaging/release-monitoring.json
@@ -18,7 +18,7 @@
         "openssl":"2566",
         "pcre2":"5832",
         "php":"3627",
-        "postgresql":"301832",
+        "postgresql":"5601",
         "pthreads-w32":"17517",
         "rsync":"4217",
         "sasl2":"13280",


### PR DESCRIPTION
The current project ID was for postgresql 15.x. But we are currently on
16.4, so the update dependencies workflow will not be able to find a
suitable version.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
