### PR TITLE
ENT-12596: Tuned workflow for automated dependency updates for 3.24.x

### DIFF
--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -138,6 +138,12 @@ def select_new_version(
             log.info(f"Skipping version {new_version} for package {package_name}")
             continue
 
+        if package_name == "php" and bump_version == "minor":
+            """For php, a bump in what is normally considered the minor version,
+            can contain breaking changes. So for minor package updates, we will
+            only bump the last number."""
+            bump_version = "patch"
+
         if bump_version == "major":
             return new_version
         if bump_version == "minor" and old_split[:1] == new_split[:1]:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -41,10 +41,10 @@ jobs:
           if: env.COMMIT_MADE == 'true'
           uses: cfengine/create-pull-request@v6
           with:
-            title: Updated dependencies
+            title: Updated dependencies (3.24)
             body: Automated dependency updates
             reviewers: |
               olehermanse
               larsewi
               craigcomstock
-            branch: update-dependencies-action
+            branch: update-dependencies-action-3.24.x


### PR DESCRIPTION
- Changed title of PR for automated dependency updates for 3.24.x
- Changed branch name for automated dependency updates for 3.24.x (otherwise, it will tamper with open master PR)
- Tweaked which number to bump for php