### PR TITLE
ENT-12597: update-deps.py: Tweaked which number to bump for php

### DIFF
--- a/.github/workflows/update-deps.py
+++ b/.github/workflows/update-deps.py
@@ -138,6 +138,12 @@ def select_new_version(
             log.info(f"Skipping version {new_version} for package {package_name}")
             continue
 
+        if package_name == "php" and bump_version == "minor":
+            """For php, a bump in what is normally considered the minor version,
+            can contain breaking changes. So for minor package updates, we will
+            only bump the last number."""
+            bump_version = "patch"
+
         if bump_version == "major":
             return new_version
         if bump_version == "minor" and old_split[:1] == new_split[:1]:


### PR DESCRIPTION
For php, a bump in what is normally considered the minor version, can
contain breaking changes. So for minor package updates, we will only
bump the last number.

Ticket: ENT-12597
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
