### PR TITLE
Fixed issue where master is checked out on 3.24.x PR

### DIFF
--- a/.github/workflows/build-using-buildscripts.yml
+++ b/.github/workflows/build-using-buildscripts.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: cfengine/core
           path: core
-          ref: ${{steps.together.outputs.core || github.base_ref || github.ref_name}}
+          ref: ${{github.base_ref}}
           submodules: recursive
 
       - name: Checkout Masterfiles
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: cfengine/masterfiles
           path: masterfiles
-          ref: ${{steps.together.outputs.masterfiles || github.base_ref || github.ref_name}}
+          ref: ${{github.base_ref}}
 
       - name: Checkout Buildscripts (current project)
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: cfengine/nova
           path: nova
-          ref: ${{steps.together.outputs.nova || github.base_ref || github.ref_name}}
+          ref: ${{github.base_ref}}
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_NOVA_REPO }}
           ssh-known-hosts: github.com
 
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: cfengine/enterprise
           path: enterprise
-          ref: ${{steps.together.outputs.enterprise || github.base_ref || github.ref_name}}
+          ref: ${{github.base_ref}}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_ENTERPRISE_REPO }}
           ssh-known-hosts: github.com
@@ -76,7 +76,7 @@ jobs:
         with:
           repository: cfengine/mission-portal
           path: mission-portal
-          ref: ${{steps.together.outputs.mission-portal || github.base_ref || github.ref_name}}
+          ref: ${{github.base_ref}}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_MISSION_PORTAL_REPO }}
           ssh-known-hosts: github.com

--- a/.github/workflows/build-using-buildscripts.yml
+++ b/.github/workflows/build-using-buildscripts.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: cfengine/core
           path: core
-          ref: ${{steps.together.outputs.core || github.base_ref || github.ref}}
+          ref: ${{steps.together.outputs.core || github.base_ref || github.ref_name}}
           submodules: recursive
 
       - name: Checkout Masterfiles
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: cfengine/masterfiles
           path: masterfiles
-          ref: ${{steps.together.outputs.masterfiles || github.base_ref || github.ref}}
+          ref: ${{steps.together.outputs.masterfiles || github.base_ref || github.ref_name}}
 
       - name: Checkout Buildscripts (current project)
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: cfengine/nova
           path: nova
-          ref: ${{steps.together.outputs.nova || github.base_ref || github.ref}}
+          ref: ${{steps.together.outputs.nova || github.base_ref || github.ref_name}}
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_NOVA_REPO }}
           ssh-known-hosts: github.com
 
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: cfengine/enterprise
           path: enterprise
-          ref: ${{steps.together.outputs.enterprise || github.base_ref || github.ref}}
+          ref: ${{steps.together.outputs.enterprise || github.base_ref || github.ref_name}}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_ENTERPRISE_REPO }}
           ssh-known-hosts: github.com
@@ -76,7 +76,7 @@ jobs:
         with:
           repository: cfengine/mission-portal
           path: mission-portal
-          ref: ${{steps.together.outputs.mission-portal || github.base_ref || github.ref}}
+          ref: ${{steps.together.outputs.mission-portal || github.base_ref || github.ref_name}}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_MISSION_PORTAL_REPO }}
           ssh-known-hosts: github.com

--- a/.github/workflows/build-using-buildscripts.yml
+++ b/.github/workflows/build-using-buildscripts.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: cfengine/core
           path: core
-          ref: ${{steps.together.outputs.core || github.base_ref}}
+          ref: ${{steps.together.outputs.core || github.base_ref || github.ref}}
           submodules: recursive
 
       - name: Checkout Masterfiles
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: cfengine/masterfiles
           path: masterfiles
-          ref: ${{steps.together.outputs.masterfiles || github.base_ref}}
+          ref: ${{steps.together.outputs.masterfiles || github.base_ref || github.ref}}
 
       - name: Checkout Buildscripts (current project)
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: cfengine/nova
           path: nova
-          ref: ${{steps.together.outputs.nova || github.base_ref}}
+          ref: ${{steps.together.outputs.nova || github.base_ref || github.ref}}
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_NOVA_REPO }}
           ssh-known-hosts: github.com
 
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: cfengine/enterprise
           path: enterprise
-          ref: ${{steps.together.outputs.enterprise || github.base_ref}}
+          ref: ${{steps.together.outputs.enterprise || github.base_ref || github.ref}}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_ENTERPRISE_REPO }}
           ssh-known-hosts: github.com
@@ -76,7 +76,7 @@ jobs:
         with:
           repository: cfengine/mission-portal
           path: mission-portal
-          ref: ${{steps.together.outputs.mission-portal || github.base_ref}}
+          ref: ${{steps.together.outputs.mission-portal || github.base_ref || github.ref}}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_MISSION_PORTAL_REPO }}
           ssh-known-hosts: github.com

--- a/.github/workflows/build-using-buildscripts.yml
+++ b/.github/workflows/build-using-buildscripts.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: cfengine/core
           path: core
-          ref: ${{ steps.together.outputs.core || github.base_ref }}
+          ref: ${{ steps.together.outputs.core || github.base_ref || github.event.base_ref }}
           submodules: recursive
 
       - name: Checkout Masterfiles

--- a/.github/workflows/build-using-buildscripts.yml
+++ b/.github/workflows/build-using-buildscripts.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: cfengine/core
           path: core
-          ref: ${{github.base_ref}}
+          ref: ${{ steps.together.outputs.core || github.base_ref }}
           submodules: recursive
 
       - name: Checkout Masterfiles
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: cfengine/masterfiles
           path: masterfiles
-          ref: ${{github.base_ref}}
+          ref: ${{ steps.together.outputs.core || github.base_ref }}
 
       - name: Checkout Buildscripts (current project)
         uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: cfengine/nova
           path: nova
-          ref: ${{github.base_ref}}
+          ref: ${{ steps.together.outputs.core || github.base_ref }}
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_NOVA_REPO }}
           ssh-known-hosts: github.com
 
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: cfengine/enterprise
           path: enterprise
-          ref: ${{github.base_ref}}
+          ref: ${{ steps.together.outputs.core || github.base_ref }}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_ENTERPRISE_REPO }}
           ssh-known-hosts: github.com
@@ -76,7 +76,7 @@ jobs:
         with:
           repository: cfengine/mission-portal
           path: mission-portal
-          ref: ${{github.base_ref}}
+          ref: ${{ steps.together.outputs.core || github.base_ref }}
           submodules: recursive
           ssh-key: ${{ secrets.GH_ACTIONS_SSH_DEPLOY_KEY_MISSION_PORTAL_REPO }}
           ssh-known-hosts: github.com


### PR DESCRIPTION
On PRs to buildscripts with 3.24.x as base I see:

```
Determining the default branch
  Retrieving the default branch name
  Default branch 'master'
```

in the output of build_cfengine_hub_package workflow. In the enterprise
repo I saw that there was an addition or condition. So I tried doing the
same here.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
