### PR TITLE
CFE-4509: Add timestamp as branch suffix to automatic dependency updates

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -48,3 +48,4 @@ jobs:
               larsewi
               craigcomstock
             branch: update-dependencies-action
+            branch-suffix: timestamp


### PR DESCRIPTION
There is often extra work required to get dependency updates to pass.
Like removing old or applying new patches. Without a branch suffix
strategy, the workflow will force push to the same branch, which can
cause loss of work.

Ticket: CFE-4509
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Back-ported to https://github.com/cfengine/buildscripts/pull/1626