### PR TITLE
CFE-4510: Updated dependency 'openssl' from version 3.4.0 to 3.4.1

### DIFF
--- a/deps-packaging/openssl/0001-Revert-rcu-Ensure-that-updates-to-the-ID-field-of-a-.patch
+++ b/deps-packaging/openssl/0001-Revert-rcu-Ensure-that-updates-to-the-ID-field-of-a-.patch
@@ -1,0 +1,83 @@
+From 911861e42ec764d801f82c343a53202d611f851f Mon Sep 17 00:00:00 2001
+From: Bernd Edlinger <bernd.edlinger@hotmail.de>
+Date: Sun, 9 Feb 2025 13:49:31 +0100
+Subject: [PATCH 1/2] Revert "rcu: Ensure that updates to the ID field of a qp
+ don't lose refs"
+
+This reverts commit fbd34c03e3ca94d3805e97a01defdf8b6037f61c.
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/26690)
+
+(cherry picked from commit 65787e2dc219685c30539c6f60eb6b64b890bf6f)
+---
+ crypto/threads_pthread.c | 31 ++++---------------------------
+ 1 file changed, 4 insertions(+), 27 deletions(-)
+
+diff --git a/crypto/threads_pthread.c b/crypto/threads_pthread.c
+index c98e775a77..497c8433c9 100644
+--- a/crypto/threads_pthread.c
++++ b/crypto/threads_pthread.c
+@@ -129,7 +129,6 @@ static inline void *apple_atomic_load_n_pvoid(void **p,
+ #  define ATOMIC_STORE_N(t, p, v, o) __atomic_store_n(p, v, o)
+ #  define ATOMIC_STORE(t, p, v, o) __atomic_store(p, v, o)
+ #  define ATOMIC_EXCHANGE_N(t, p, v, o) __atomic_exchange_n(p, v, o)
+-#  define ATOMIC_COMPARE_EXCHANGE_N(t, p, e, d, s, f) __atomic_compare_exchange_n(p, e, d, 0, s, f)
+ #  define ATOMIC_ADD_FETCH(p, v, o) __atomic_add_fetch(p, v, o)
+ #  define ATOMIC_FETCH_ADD(p, v, o) __atomic_fetch_add(p, v, o)
+ #  define ATOMIC_SUB_FETCH(p, v, o) __atomic_sub_fetch(p, v, o)
+@@ -198,23 +197,6 @@ IMPL_fallback_atomic_exchange_n(prcu_cb_item)
+ 
+ #  define ATOMIC_EXCHANGE_N(t, p, v, o) fallback_atomic_exchange_n_##t(p, v)
+ 
+-#  define IMPL_fallback_atomic_compare_exchange_n(t)                                  \
+-    static ossl_inline int fallback_atomic_compare_exchange_n_##t(t *p, t *e, t d, s, f) \
+-    {                                                                                 \
+-        int ret = 1;                                                                 \
+-        pthread_mutex_lock(&atomic_sim_lock);                                         \
+-        if (*p == *e)                                                                 \
+-            *p = d;                                                                    \
+-        else                                                                          \
+-            ret = 0;                                                                   \
+-        pthread_mutex_unlock(&atomic_sim_lock);                                       \
+-        return ret;                                                                   \
+-    }
+-
+-IMPL_fallback_atomic_exchange_n(uint64_t)
+-
+-#  define ATOMIC_COMPARE_EXCHANGE_N(t, p, e, d, s, f) fallback_atomic_compare_exchange_n_##t(p, e, d, s, f)
+-
+ /*
+  * The fallbacks that follow don't need any per type implementation, as
+  * they are designed for uint64_t only.  If there comes a time when multiple
+@@ -523,8 +505,6 @@ void ossl_rcu_read_unlock(CRYPTO_RCU_LOCK *lock)
+ static struct rcu_qp *update_qp(CRYPTO_RCU_LOCK *lock)
+ {
+     uint64_t new_id;
+-    uint64_t update;
+-    uint64_t ret;
+     uint32_t current_idx;
+ 
+     pthread_mutex_lock(&lock->alloc_lock);
+@@ -557,13 +537,10 @@ static struct rcu_qp *update_qp(CRYPTO_RCU_LOCK *lock)
+      * of this update are published to the read side prior to updating the
+      * reader idx below
+      */
+-try_again:
+-    ret = ATOMIC_LOAD_N(uint64_t, &lock->qp_group[current_idx].users, __ATOMIC_ACQUIRE);
+-    update = ret & ID_MASK;
+-    update |= new_id;
+-    if (!ATOMIC_COMPARE_EXCHANGE_N(uint64_t, &lock->qp_group[current_idx].users, &ret, update,
+-                                   __ATOMIC_ACQ_REL, __ATOMIC_RELAXED))
+-        goto try_again;
++    ATOMIC_AND_FETCH(&lock->qp_group[current_idx].users, ID_MASK,
++                     __ATOMIC_RELEASE);
++    ATOMIC_OR_FETCH(&lock->qp_group[current_idx].users, new_id,
++                    __ATOMIC_RELEASE);
+ 
+     /*
+      * Update the reader index to be the prior qp.
+-- 
+2.43.0
+

--- a/deps-packaging/openssl/0002-Don-t-use-__ATOMIC_ACQ_REL-on-older-compilers.patch
+++ b/deps-packaging/openssl/0002-Don-t-use-__ATOMIC_ACQ_REL-on-older-compilers.patch
@@ -1,0 +1,52 @@
+From edab719095b66c726022de25b5b10fdc15d0c845 Mon Sep 17 00:00:00 2001
+From: Lars Erik Wik <lars.erik.wik@northern.tech>
+Date: Mon, 24 Mar 2025 12:47:29 +0100
+Subject: [PATCH 2/2] Don't use __ATOMIC_ACQ_REL on older compilers
+
+Manually back-ported from https://github.com/openssl/openssl/commit/7d284560a0624206356d46a948ab3a0b6f670c0e
+
+Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
+---
+ crypto/threads_pthread.c | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/crypto/threads_pthread.c b/crypto/threads_pthread.c
+index 497c8433c9..b4eb24e0b8 100644
+--- a/crypto/threads_pthread.c
++++ b/crypto/threads_pthread.c
+@@ -90,7 +90,6 @@ __tsan_mutex_post_lock((x), 0, 0)
+  * fallback function names.
+  */
+ typedef void *pvoid;
+-typedef struct rcu_cb_item *prcu_cb_item;
+ 
+ # if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE) && !defined(BROKEN_CLANG_ATOMICS) \
+     && !defined(USE_ATOMIC_FALLBACKS)
+@@ -193,7 +192,6 @@ IMPL_fallback_atomic_store(pvoid)
+         return ret;                                                     \
+     }
+ IMPL_fallback_atomic_exchange_n(uint64_t)
+-IMPL_fallback_atomic_exchange_n(prcu_cb_item)
+ 
+ #  define ATOMIC_EXCHANGE_N(t, p, v, o) fallback_atomic_exchange_n_##t(p, v)
+ 
+@@ -641,13 +639,9 @@ int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
+ 
+     new->data = data;
+     new->fn = cb;
+-    /*
+-     * Use __ATOMIC_ACQ_REL here to indicate that any prior writes to this
+-     * list are visible to us prior to reading, and publish the new value
+-     * immediately
+-     */
+-    new->next = ATOMIC_EXCHANGE_N(prcu_cb_item, &lock->cb_items, new,
+-                                  __ATOMIC_ACQ_REL);
++
++    new->next = lock->cb_items;
++    lock->cb_items = new;
+ 
+     return 1;
+ }
+-- 
+2.43.0
+

--- a/deps-packaging/openssl/cfbuild-openssl.spec
+++ b/deps-packaging/openssl/cfbuild-openssl.spec
@@ -1,4 +1,4 @@
-%define openssl_version 3.4.0
+%define openssl_version 3.4.1
 
 Summary: CFEngine Build Automation -- openssl
 Name: cfbuild-openssl

--- a/deps-packaging/openssl/distfiles
+++ b/deps-packaging/openssl/distfiles
@@ -1,1 +1,1 @@
-e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf  openssl-3.4.0.tar.gz
+002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3  openssl-3.4.1.tar.gz

--- a/deps-packaging/openssl/hpux/build
+++ b/deps-packaging/openssl/hpux/build
@@ -13,6 +13,11 @@ export LD_LIBRARY_PATH=$PREFIX/lib
 
 # Configure
 
+# These two patches are taken from master branch as of 2025-Mar-26 and should
+# be removed with upgrade past 3.4.1
+${PATCH} -p1 < 0001-Revert-rcu-Ensure-that-updates-to-the-ID-field-of-a-.patch
+${PATCH} -p1 < 0002-Don-t-use-__ATOMIC_ACQ_REL-on-older-compilers.patch
+
 $PERL ./Configure hpux-ia64-gcc $(<config_flags_$ROLE.txt) \
     $LDFLAGS --prefix=$PREFIX --libdir=lib
 

--- a/deps-packaging/openssl/source
+++ b/deps-packaging/openssl/source
@@ -1,1 +1,1 @@
-https://github.com/openssl/openssl/releases/download/openssl-3.4.0/
+https://github.com/openssl/openssl/releases/download/openssl-3.4.1/


### PR DESCRIPTION
- **Updated dependency 'openssl' from version 3.4.0 to 3.4.1**
- **Fixed openssl on HP-UX**

Back-ported to https://github.com/cfengine/buildscripts/pull/1648