### PR TITLE
ENT-12711: Rename workflow for automatic dependency updates on 3.24.x

### DIFF
--- a/.github/workflows/update-deps-3.24.x.yml
+++ b/.github/workflows/update-deps-3.24.x.yml
@@ -1,4 +1,4 @@
-name: Update dependencies
+name: Update dependencies 3.24.x
 
 on:
   schedule:
@@ -12,8 +12,8 @@ on:
   workflow_dispatch: # Enables manual trigger
 
 jobs:
-  update_dependencies:
-    name: Update dependencies
+  update_dependencies_3_24_x:
+    name: Update dependencies 3.24.x
     runs-on: ubuntu-latest
     steps:
         - name: Checks-out repository


### PR DESCRIPTION
For some reason the workflow is only triggered on the `master` branch.
It could be a scheduled workflow is only triggered once, independent on
which branch it exists on. Hence I will try to rename the workflow, so
that it in theory becomes a different one.

Ticket: ENT-12711
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
