### PR TITLE
Smaller fixes to deptool, related GH Action, and READMEs

### DIFF
--- a/.github/workflows/update-dep-tables.yml
+++ b/.github/workflows/update-dep-tables.yml
@@ -1,14 +1,14 @@
-name: Update dependencies tables
+name: Update dependency tables
 
 on:
   push:
     branches:
       - master
-  workflow_dispatch:  # Enables manual trigger
+  workflow_dispatch: # Enables manual trigger
 
 jobs:
   update_dep_tables:
-    name: Update dependencies tables
+    name: Update dependency tables
     runs-on: ubuntu-24.04
     steps:
       - name: Checks-out repository
@@ -35,11 +35,11 @@ jobs:
         if: env.COMMIT_MADE == 'true'
         uses: cfengine/create-pull-request@v6
         with:
-          title: Update dependencies tables
-          body: Automated dependencies tables update using [the `update_dep_tables` workflow](https://github.com/cfengine/buildscripts/blob/master/.github/workflows/update-deps-tables.yml).
+          title: Update dependency tables
+          body: Automated dependency tables update using [the `update_dep_tables` workflow](https://github.com/cfengine/buildscripts/blob/master/.github/workflows/update-dep-tables.yml).
           reviewers: |
             olehermanse
             larsewi
             craigcomstock
-          branch: update-dependencies-tables
+          branch: update-dependency-tables
           branch-suffix: timestamp

--- a/README.md
+++ b/README.md
@@ -57,67 +57,74 @@ strict minimum amount of software (don't forget --no-install-recommends on
 dpkg-based systems):
 
 To access the build machine:
- * SSH server
-  * Bundled one on Unixes
-  * FreeSSHd on Windows
- * 'build' account with SSH key installed
+
+- SSH server
+- Bundled one on Unixes
+- FreeSSHd on Windows
+- 'build' account with SSH key installed
 
 To transfer files back and forth:
- * rsync on Unixes
- * 7z on Windows
+
+- rsync on Unixes
+- 7z on Windows
 
 To be able to install packages and run tests:
- * passwordless sudo access for 'build' account
- * sudo should not require TTY (remove 'Defaults requiretty' from /etc/sudoers)
+
+- passwordless sudo access for 'build' account
+- sudo should not require TTY (remove 'Defaults requiretty' from /etc/sudoers)
 
 To build everything:
- * GCC (gcc)
- * GNU make (make)
- * libc development package (libc-dev, glibc-devel)
- * bison (bison)
- * flex (flex)
- * fakeroot (but not fakeroot 1.12, it is horribly slow!)
+
+- GCC (gcc)
+- GNU make (make)
+- libc development package (libc-dev, glibc-devel)
+- bison (bison)
+- flex (flex)
+- fakeroot (but not fakeroot 1.12, it is horribly slow!)
 
 To create packages:
- * Native packaging manager
-  * rpm-build on RPM-based systems
-  * dpkg-dev, debhelper, fakeroot
-  * WiX on Windows
+
+- Native packaging manager
+- rpm-build on RPM-based systems
+- dpkg-dev, debhelper, fakeroot
+- WiX on Windows
 
 To build MySQL library (yeah!):
- * g++ (gcc-c++, g++)
- * ncurses (ncurses-devel, libncurses5-dev)
+
+- g++ (gcc-c++, g++)
+- ncurses (ncurses-devel, libncurses5-dev)
 
 To build libvirt:
- * pkg-config (pkg-config, pkgconfig)
+
+- pkg-config (pkg-config, pkgconfig)
 
 Anything else is either preprocessed on buildbot slave or built and installed
 during build.
 
 ## Documentation build pre-requisites
 
- * texinfo
- * texlive
- * cm-super
- * texlive-fonts-extra
+- texinfo
+- texlive
+- cm-super
+- texlive-fonts-extra
 
 ## Non-requisites
 
 Build machines should not contain the following items, which may interfere with
 build process:
 
- * CFEngine itself, either in source or binary form (build machines are
-   short-living, so this is not a problem)
- * Development packages for anything beside libc to avoid picking them up
-   instead of bundled ones accidentally.
- * MySQL and PostgreSQL servers, clients and libraries
+- CFEngine itself, either in source or binary form (build machines are
+  short-living, so this is not a problem)
+- Development packages for anything beside libc to avoid picking them up
+  instead of bundled ones accidentally.
+- MySQL and PostgreSQL servers, clients and libraries
 
 The following packages should not be installed on build machines as well, to
 avoid accidentally regenerating files transferred from buildslave:
 
- * automake
- * autoconf
- * libtool
+- automake
+- autoconf
+- libtool
 
 ## Dependencies
 
@@ -161,6 +168,6 @@ File `install-dependencies` and the relevant subdirectories in `deps-packaging` 
 | [nghttp2](https://nghttp2.opg/)                     | -      | -      | 1.64.0 |
 | [rsync](https://download.samba.org/pub/rsync/)      | 3.3.0  | 3.3.0  | 3.3.0  |
 
-* [MinGW-w64](https://sourceforge.net/projects/mingw-w64/) **OUTDATED** needed
+- [MinGW-w64](https://sourceforge.net/projects/mingw-w64/) **OUTDATED** needed
   for [redmine#2932](https://dev.cfengine.com/issues/2932)
-  * Requires change of buildslaves (autobuild)
+  - Requires change of buildslaves (autobuild)

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@ This repository contains the necessary tools to build and test cfengine packages
 
 ## Hardware requirements
 
-By experimentation I have found that building hub packages, which includes php dependency requires more than 1.6G of RAM/swap. 2.6G worked for me, less might work as well.
+By experimentation I have found that building hub packages, which includes php dependency requires more than 1.6G of RAM/swap.
+2.6G worked for me, less might work as well.
 
 ## Example build of Community Agent
 
 A minimal example would be to build packages for cfengine community agent.
 This should be done in an isolated environment such as a dedicated host, virtual machine or linux container.
 
-Install necessary distribution packages. For example on debian/ubuntu:
+Install necessary distribution packages.
+For example on debian/ubuntu:
 
 ```
 apt update -y
@@ -52,9 +54,7 @@ ls -l cfengine-community/*.deb
 
 ## General Build Machine Prerequisites
 
-Due to sheer diversity of the environments, build machine is expected to provide
-strict minimum amount of software (don't forget --no-install-recommends on
-dpkg-based systems):
+Due to sheer diversity of the environments, build machine is expected to provide strict minimum amount of software (don't forget `--no-install-recommends` on dpkg-based systems):
 
 To access the build machine:
 
@@ -98,8 +98,7 @@ To build libvirt:
 
 - pkg-config (pkg-config, pkgconfig)
 
-Anything else is either preprocessed on buildbot slave or built and installed
-during build.
+Anything else is either preprocessed on buildbot slave or built and installed during build.
 
 ## Documentation build pre-requisites
 
@@ -110,17 +109,13 @@ during build.
 
 ## Non-requisites
 
-Build machines should not contain the following items, which may interfere with
-build process:
+Build machines should not contain the following items, which may interfere with build process:
 
-- CFEngine itself, either in source or binary form (build machines are
-  short-living, so this is not a problem)
-- Development packages for anything beside libc to avoid picking them up
-  instead of bundled ones accidentally.
+- CFEngine itself, either in source or binary form (build machines are short-living, so this is not a problem)
+- Development packages for anything beside libc to avoid picking them up instead of bundled ones accidentally.
 - MySQL and PostgreSQL servers, clients and libraries
 
-The following packages should not be installed on build machines as well, to
-avoid accidentally regenerating files transferred from buildslave:
+The following packages should not be installed on build machines as well, to avoid accidentally regenerating files transferred from buildslave:
 
 - automake
 - autoconf

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ File `install-dependencies` and the relevant subdirectories in `deps-packaging` 
 | [leech](https://github.com/larsewi/leech/releases)                                |        |        | 0.1.21 |                          |
 | libgcc                                                                            |        |        |        | AIX and Solaris only     |
 
-### Enterprise Hub dependencies:
+### Enterprise Hub dependencies
 
 | CFEngine version                                    | 3.21.x | 3.24.x | master |
 | --------------------------------------------------- | ------ | ------ | ------ |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,5 @@
 # deptool
+
 `deptool.py` is a script which can be used to enumerate dependencies of CFEngine. It supports printing to stdout in the Markdown table format, and printing to file in the JSON format (see `--to-json`). It can be used as a replacement for the [cf-bottom](https://github.com/cfengine/cf-bottom/) `depstable` command.
 
 `deptool.py` works on a local buildscripts repository. By default, the repository is assumed to be located in the parent directory of the current working directory (as `deptool.py` lives in the `scripts` directory in the buildscript repository). A custom path for the local repository can be specified using the `--root` argument. Running the script will modify the git state of the repository by checking out branches (and with `--patch`, also overwriting and git-adding `README.md`), so it might be preferable to [use a copy of the buildscripts repository](https://github.com/cfengine/buildscripts/tree/master/scripts#using-a-copy-of-the-repository).
@@ -8,7 +9,9 @@ A custom list of versions to process can be specified ([given as space-separated
 See `python deptool.py -h` for more information on all available command-line arguments.
 
 ## Examples
+
 ### Suppressing logs
+
 ```
 $ cd scripts
 $ python deptool.py --no-info
@@ -53,11 +56,13 @@ WARNING:root:didn't find dep in line [| libgcc                                  
 ```
 
 ### Specifying custom versions list
+
 ```
 python deptool.py 3.21.6 3.24.x master
 ```
 
 ### Comparing versions
+
 ```
 $ python deptool.py 3.24.x master --compare --no-info
 | CFEngine version                                                                  | 3.24.x | **master** |
@@ -93,6 +98,7 @@ $ python deptool.py 3.24.x master --compare --no-info
 ```
 
 Rows which contain no dependency version changes can be omitted:
+
 ```
 $ python deptool.py --compare 3.21.5 3.21.6 3.24.0 3.24.1 --no-info --skip-unchanged
 | CFEngine version                                                                  | 3.21.5 | **3.21.6** | 3.24.0 | **3.24.1** |
@@ -114,6 +120,7 @@ $ python deptool.py --compare 3.21.5 3.21.6 3.24.0 3.24.1 --no-info --skip-uncha
 ```
 
 ## Using a copy of the repository
+
 ```
 python deptool.py --root ../../buildscripts-copy
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,12 @@
 # deptool
 
-`deptool.py` is a script which can be used to enumerate dependencies of CFEngine. It supports printing to stdout in the Markdown table format, and printing to file in the JSON format (see `--to-json`). It can be used as a replacement for the [cf-bottom](https://github.com/cfengine/cf-bottom/) `depstable` command.
+`deptool.py` is a script which can be used to enumerate dependencies of CFEngine.
+It supports printing to stdout in the Markdown table format, and printing to file in the JSON format (see `--to-json`).
+It can be used as a replacement for the [cf-bottom](https://github.com/cfengine/cf-bottom/) `depstable` command.
 
-`deptool.py` works on a local buildscripts repository. By default, the repository is assumed to be current working directory (i.e. `.`). A custom path for the local repository can be specified using the `--root` argument. Running the script will modify the git state of the repository by checking out branches (and with `--patch`, also overwriting and git-adding `README.md`), so it might be preferable to [use a copy of the buildscripts repository](https://github.com/cfengine/buildscripts/tree/master/scripts#using-a-copy-of-the-repository).
+`deptool.py` works on a local buildscripts repository. By default, the repository is assumed to be current working directory (i.e. `.`).
+A custom path for the local repository can be specified using the `--root` argument.
+Running the script will modify the git state of the repository by checking out branches (and with `--patch`, also overwriting and git-adding `README.md`), so it might be preferable to [use a copy of the buildscripts repository](https://github.com/cfengine/buildscripts/tree/master/scripts#using-a-copy-of-the-repository).
 
 A custom list of versions to process can be specified ([given as space-separated command-line arguments](https://github.com/cfengine/buildscripts/tree/master/scripts#specifying-custom-versions-list)).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 `deptool.py` is a script which can be used to enumerate dependencies of CFEngine. It supports printing to stdout in the Markdown table format, and printing to file in the JSON format (see `--to-json`). It can be used as a replacement for the [cf-bottom](https://github.com/cfengine/cf-bottom/) `depstable` command.
 
-`deptool.py` works on a local buildscripts repository. By default, the repository is assumed to be located in the parent directory of the current working directory (as `deptool.py` lives in the `scripts` directory in the buildscript repository). A custom path for the local repository can be specified using the `--root` argument. Running the script will modify the git state of the repository by checking out branches (and with `--patch`, also overwriting and git-adding `README.md`), so it might be preferable to [use a copy of the buildscripts repository](https://github.com/cfengine/buildscripts/tree/master/scripts#using-a-copy-of-the-repository).
+`deptool.py` works on a local buildscripts repository. By default, the repository is assumed to be current working directory (i.e. `.`). A custom path for the local repository can be specified using the `--root` argument. Running the script will modify the git state of the repository by checking out branches (and with `--patch`, also overwriting and git-adding `README.md`), so it might be preferable to [use a copy of the buildscripts repository](https://github.com/cfengine/buildscripts/tree/master/scripts#using-a-copy-of-the-repository).
 
 A custom list of versions to process can be specified ([given as space-separated command-line arguments](https://github.com/cfengine/buildscripts/tree/master/scripts#specifying-custom-versions-list)).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,7 @@ See `python deptool.py -h` for more information on all available command-line ar
 $ cd scripts
 $ python deptool.py --no-info
 WARNING:root:didn't find dep in line [| libgcc                                                                            |        |        |        | AIX and Solaris only     |]
-### Agent Dependencies:
+### Agent Dependencies
 
 | CFEngine version                                                                  | 3.21.x | 3.24.x | master | Notes                    |
 | --------------------------------------------------------------------------------- | ------ | ------ | ------ | ------------------------ |
@@ -43,7 +43,7 @@ WARNING:root:didn't find dep in line [| libgcc                                  
 | [librsync](https://github.com/librsync/librsync/releases)                         | -      | -      | 2.3.4  |                          |
 | [leech](https://github.com/larsewi/leech/releases)                                | -      | -      | 0.1.24 |                          |
 
-### Enterprise Hub dependencies:
+### Enterprise Hub dependencies
 
 | CFEngine version                                    | 3.21.x | 3.24.x | master |
 | --------------------------------------------------- | ------ | ------ | ------ |

--- a/scripts/deptool.py
+++ b/scripts/deptool.py
@@ -223,7 +223,7 @@ class DepsReader:
         REPO_OWNER = "cfengine"
         REPO_NAME = "buildscripts"
         if repo_path is None:
-            repo_path = ".."
+            repo_path = "."
         self.buildscripts_repo = GitRepo(
             repo_path,
             REPO_OWNER,

--- a/scripts/deptool.py
+++ b/scripts/deptool.py
@@ -661,9 +661,9 @@ def main():
         comparison_table = dr.comparison_md_table(args.refs, args.skip_unchanged)
         print(comparison_table)
     else:
-        print("### Agent Dependencies:\n")
+        print("### Agent Dependencies\n")
         print(updated_agent_table)
-        print("\n### Enterprise Hub dependencies:\n")
+        print("\n### Enterprise Hub dependencies\n")
         print(updated_hub_table)
 
     if args.patch:

--- a/scripts/deptool.py
+++ b/scripts/deptool.py
@@ -457,7 +457,7 @@ class DepsReader:
     def patch_readme(self, updated_readme):
         TARGET_README_PATH = "README.md"
         self.buildscripts_repo.put_file(TARGET_README_PATH, updated_readme)
-        self.buildscripts_repo.commit("Update dependencies tables")
+        self.buildscripts_repo.commit("Update dependency tables")
 
     def write_deps_json(self, json_path, refs):
         deps_data, _ = self.deps_dict(refs)


### PR DESCRIPTION
- **deptool / GH Action: Small grammar fix - dependencies tables vs dependency tables**
- **README.md: Reformatted with prettier**
- **scripts/README.md: Reformatted with prettier**
- **deptool: Changed default path to cwd (.)**
- **scripts/README.md: Switched to one sentence per line style**
- **README.md: Reformatted to use one sentence per line style**
- **deptool / READMEs: Removed colons from headings**
