### PR TITLE
README.md: Removed libgcc from dependency tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ To be able to install packages and run tests:
 To build everything:
 
 - GCC (gcc)
+  - Additionally, libgcc is used on AIX and Solaris only
 - GNU make (make)
 - libc development package (libc-dev, glibc-devel)
 - bison (bison)
@@ -147,7 +148,6 @@ File `install-dependencies` and the relevant subdirectories in `deps-packaging` 
 | [zlib](https://www.zlib.net/)                                                     | 1.3.1  | 1.3.1  | 1.3.1  |                          |
 | [librsync](https://github.com/librsync/librsync/releases)                         | -      | -      | 2.3.4  |                          |
 | [leech](https://github.com/larsewi/leech/releases)                                | -      | -      | 0.1.24 |                          |
-| libgcc                                                                            |        |        |        | AIX and Solaris only     |
 
 ### Enterprise Hub dependencies
 


### PR DESCRIPTION
Discussed with Lars and Jakub, probably makes more sense to not list
in dependency tables.