### PR TITLE
Added prefix ./ to policy file reference in build host setup script

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -133,7 +133,7 @@ tar xf cfengine-masterfiles-"$CFE_VERSION"-1.pkg.tar.gz
 cp -a masterfiles/* /var/cfengine/inputs/
 
 # run three times to ensure all is done
-policy="$(dirname "$0")"/cfengine-build-host-setup.cf
+policy="./$(dirname "$0")"/cfengine-build-host-setup.cf
 # just to be sure, make policy read/write for our user only to avoid errors when running
 chmod 600 "$policy"
 /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log


### PR DESCRIPTION
When I tried using setup-cfengine-build-host.sh on a rhel-8 machine I guess dirname $0 didn't include a ./ so cf-agent could not find the policy file in the relative location.

Ticket: none
Changelog: none
