### PR TITLE
Added 3.24.x branch to scheduled dependency updates workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -15,9 +15,14 @@ jobs:
   update_dependencies:
     name: Update dependencies
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [master, 3.24.x]
     steps:
       - name: Checks-out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -34,7 +39,7 @@ jobs:
         run: |
           echo "COMMIT_HASH_BEFORE=$(git log -1 --format=%H)">> $GITHUB_ENV
       - name: Run update script
-        run: python3 .github/workflows/update-deps.py --debug --bump=major
+        run: python3 .github/workflows/update-deps.py --debug --bump=${{ matrix.branch == 'master' && 'major' || 'minor' }}
       - name: Save commit hash after
         run: |
           echo "COMMIT_HASH_AFTER=$(git log -1 --format=%H)">> $GITHUB_ENV
@@ -42,11 +47,11 @@ jobs:
         if: env.COMMIT_HASH_BEFORE != env.COMMIT_HASH_AFTER
         uses: cfengine/create-pull-request@v6
         with:
-          title: Updated dependencies
-          body: Automated dependency updates
+          title: "Updated dependencies (${{ matrix.branch }})"
+          body: "Automated dependency updates for the ${{ matrix.branch }} branch"
           reviewers: |
             olehermanse
             larsewi
             craigcomstock
-          branch: update-dependencies-action
+          branch: update-dependencies-action-${{ matrix.branch }}
           branch-suffix: timestamp


### PR DESCRIPTION
GitHub docs say that scheduled workflows will only run on the default branch.

This commit:
- Adds branch matrix to run updates on both master and 3.24.x branches
- Configures branch-specific settings (major bumps for master, minor for 3.24.x)

Ticket: ENT-12711