### PR TITLE
Adjusted database stop code to give more time to smart shutdown

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1056,7 +1056,10 @@ if [ -n "$httpds" ]; then
   fi
 fi
 
-(cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart" || su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m fast")
+# wait 5 minutes for smart shutdown to happen, on slower machines it might take a while
+if ! (cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data --timeout=300 -m smart"); then
+  su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data --timeout=300 -m fast"
+fi
 
 # Have to be careful here because httpd/php/bin wants to be root:root
 chown root:$MP_APACHE_USER $PREFIX/httpd/php


### PR DESCRIPTION
On a slow raspberry pi 4 I found that the current smart and then immediate stop (immediate) did not work well.
The system needed more time.

Ticket: ENT-12750
Changelog: title

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12012)](https://ci.cfengine.com/job/pr-pipeline/12012/)