### PR TITLE
Fixed copying artifacts directory from container

### DIFF
--- a/ci/docker-build-package.sh
+++ b/ci/docker-build-package.sh
@@ -55,7 +55,8 @@ docker exec -i $name bash -c "cd /data; ./buildscripts/ci/build.sh ${additional_
 
 # save back cache and artifacts to host for handling by CI and such
 docker cp $name:/root/.cache/. "${NTECH_ROOT}/cache/"
-docker cp $name:/data/artifacts/. "${NTECH_ROOT}/artifacts/"
+docker exec $name find /data/artifacts
+docker exec $name tar Ccf $(dirname /data/artifacts) - $(basename /data/artifacts) | tar Cxf "${NTECH_ROOT}/artifacts/" -
 
 rc=1 # if we find no packages, fail
 for f in artifacts/*.deb; do


### PR DESCRIPTION
Was getting an "operation not permitted" for a chmod command on the core sub-directory for nova builds.

Ticket: ENT-10487
Changelog: none
