### PR TITLE
Reverting incorrect removal of patches for openssl dependency (3.24)

### DIFF
--- a/deps-packaging/openssl/cfbuild-openssl.spec
+++ b/deps-packaging/openssl/cfbuild-openssl.spec
@@ -5,6 +5,8 @@ Name: cfbuild-openssl
 Version: %{version}
 Release: 1
 Source0: openssl-%{openssl_version}.tar.gz
+Patch0: 0006-Add-latomic-on-AIX-7.patch
+Patch1: 0008-Define-_XOPEN_SOURCE_EXTENDED-as-1.patch
 License: MIT
 Group: Other
 Url: https://cfengine.com
@@ -17,6 +19,9 @@ AutoReqProv: no
 %prep
 mkdir -p %{_builddir}
 %setup -q -n openssl-%{openssl_version}
+
+%patch0 -p1
+%patch1 -p1
 
 %build
 


### PR DESCRIPTION
In cd0bc8206a0b4a60ad72b416825c316a2dcb794a I both removed the 0001 and 0002 patches for centos/rhel-6 but also incorrectly removed patches 0006 and 0008.

Restoring them here.

Ticket: ENT-12761
Changelog: none

aix only build: [![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12042)](https://ci.cfengine.com/job/pr-pipeline/12042/)