### PR TITLE
Revert "GH Actions: Removed contents write permission"

### DIFF
--- a/.github/workflows/update-dep-tables.yml
+++ b/.github/workflows/update-dep-tables.yml
@@ -11,6 +11,7 @@ jobs:
     name: Update dependency tables
     runs-on: ubuntu-24.04
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - name: Checks-out repository

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -16,6 +16,7 @@ jobs:
     name: Update dependencies
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     strategy:
       matrix:


### PR DESCRIPTION
Reverts cfengine/buildscripts#1687

We tested it and this permission is definitely needed to push commits, pull-requests is not enough.