### PR TITLE
Tidy up exotics platforms (3.21.x)

### DIFF
--- a/build-scripts/exotics.txt
+++ b/build-scripts/exotics.txt
@@ -1,12 +1,8 @@
 # exotic platforms that jobs should not run on by default
 
-PACKAGES_x86_64_linux_suse_11
 PACKAGES_x86_64_linux_suse_12
 PACKAGES_x86_64_linux_suse_15
 
 PACKAGES_ia64_hpux_11.23
-PACKAGES_ppc64_aix_53
 PACKAGES_ppc64_aix_71
-PACKAGES_sparc64_solaris_10
 PACKAGES_sparc64_solaris_11
-PACKAGES_x86_64_solaris_10


### PR DESCRIPTION
Removed suse-11, aix-5.3, solaris-10 (sparc and x86).
All of these were not being built because they are not in labels.txt but might as well remove them to keep things tidy.

Ticket: none
Changelog: none
