### PR TITLE
Moved tcpdf_add_font calls from bootstrap, to package step (3.24)

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -90,16 +90,6 @@ fi
 )
 
 (
-if test -f "$BASEDIR/mission-portal/vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php"; then
-  cd $BASEDIR/mission-portal
-  # Add Red Hat Text font to TCPDF library that we use in Mission Portal for PDF generation
-  php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Regular.ttf
-  php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Bold.ttf
-  php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Italic.ttf
-fi
-)
-
-(
 if test -f "$BASEDIR/mission-portal/public/themes/default/bootstrap/cfengine_theme.less"; then
   cd $BASEDIR/mission-portal/public/themes/default/bootstrap
   npx -p less lessc --compress ./cfengine_theme.less ./compiled/css/cfengine.less.css

--- a/build-scripts/package
+++ b/build-scripts/package
@@ -49,6 +49,19 @@ fi
 
 P="$BASEDIR/buildscripts/packaging/$PKG"
 
+(
+if [ "$PROJECT-$ROLE" = "nova-hub" ]; then
+  if test -f "$BASEDIR/mission-portal/vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php"; then
+    cd $BASEDIR/mission-portal
+    # Add Red Hat Text font to TCPDF library that we use in Mission Portal for PDF generation
+    $PREFIX/httpd/php/bin/php --version # diagnostic for ENT-12777, keep for future reference
+    $PREFIX/httpd/php/bin/php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Regular.ttf
+    $PREFIX/httpd/php/bin/php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Bold.ttf
+    $PREFIX/httpd/php/bin/php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Italic.ttf
+  fi
+fi
+)
+
 if [ "$BUILDPREFIX" != "/var/cfengine" ]
 then
     safe_prefix="$(echo "$BUILDPREFIX" | sed -e 's:/::g')"


### PR DESCRIPTION
tcpdf >= 6.8.0 requires php 7.1+ but we bootstrap for 3.21.x on debian-9 and sury.org has no stretch packages of newer php versions.

Use built php instead.
Ticket: ENT-12777
Changelog: none

(cherry picked from commit 177d48a645ddf6b1cd6cd3918bc3e877a443e540)
