### PR TITLE
Moved tcpdf_add_font calls from bootstrap, to package step (master)

### DIFF
--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -92,13 +92,6 @@ fi
 (
 if test -f "$BASEDIR/mission-portal/vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php"; then
   cd $BASEDIR/mission-portal
-  # The ability to use visibility modifiers on constants was added in PHP 7.1
-  # However, the default apt repository of the bootstrap host currently
-  # provides PHP 7.0. Thus, we need to remove the visibility modifiers from
-  # this file to avoid syntax errors. See ENT-12565. We can remove this line
-  # once the default apt repository provides a version >= 7.1
-  sed -i 's/protected const/const/g' ./vendor/tecnickcom/tcpdf/include/tcpdf_static.php
-
   # Add Red Hat Text font to TCPDF library that we use in Mission Portal for PDF generation
   php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Regular.ttf
   php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Bold.ttf

--- a/build-scripts/bootstrap-tarballs
+++ b/build-scripts/bootstrap-tarballs
@@ -90,16 +90,6 @@ fi
 )
 
 (
-if test -f "$BASEDIR/mission-portal/vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php"; then
-  cd $BASEDIR/mission-portal
-  # Add Red Hat Text font to TCPDF library that we use in Mission Portal for PDF generation
-  php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Regular.ttf
-  php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Bold.ttf
-  php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Italic.ttf
-fi
-)
-
-(
 if test -f "$BASEDIR/mission-portal/public/themes/default/bootstrap/cfengine_theme.less"; then
   cd $BASEDIR/mission-portal/public/themes/default/bootstrap
   npx -p less lessc --compress ./cfengine_theme.less ./compiled/css/cfengine.less.css

--- a/build-scripts/package
+++ b/build-scripts/package
@@ -49,6 +49,19 @@ fi
 
 P="$BASEDIR/buildscripts/packaging/$PKG"
 
+(
+if [ "$PROJECT-$ROLE" = "nova-hub" ]; then
+  if test -f "$BASEDIR/mission-portal/vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php"; then
+    cd $BASEDIR/mission-portal
+    # Add Red Hat Text font to TCPDF library that we use in Mission Portal for PDF generation
+    $PREFIX/httpd/php/bin/php --version # diagnostic for ENT-12777, keep for future reference
+    $PREFIX/httpd/php/bin/php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Regular.ttf
+    $PREFIX/httpd/php/bin/php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Bold.ttf
+    $PREFIX/httpd/php/bin/php ./vendor/tecnickcom/tcpdf/tools/tcpdf_addfont.php -i ./public/themes/default/bootstrap/cfengine/font/rht/RedHatText-Italic.ttf
+  fi
+fi
+)
+
 if [ "$BUILDPREFIX" != "/var/cfengine" ]
 then
     safe_prefix="$(echo "$BUILDPREFIX" | sed -e 's:/::g')"

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -52,7 +52,6 @@ bundle agent cfengine_build_host_setup
     (debian_10|debian_11).systemssl_build_host::
       "libssl-dev";
     debian.bootstrap_pr_host::
-      "php-curl"; # Required by tecnickcom/tcpdf 6.8.0
       "librsync-dev"; # bootstrap_pr host needs this to run configure and make dist
       "autoconf-archive" comment => "Required to resolve the AX_PTHREAD macro";
 


### PR DESCRIPTION
- Revert "Added php-curl dependency to bootstrap-pr host"
- Revert "Remove const visibility modifiers in tcpdf_static.php"
- Moved tcpdf_add_font calls from bootstrap, to package step

bootstrap-pr job is green! [![Build Status](https://ci.cfengine.com/buildStatus/icon?job=bootstrap-pr&build=955)](https://ci.cfengine.com/job/bootstrap-pr/955/) (I cancelled the rest of the job after, good enough for me)