### PR TITLE
Disabled avx512 feature when compiling php on Ubuntu 16 (3.21)

### DIFF
--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 PREFIX=$(BUILDPREFIX)
+CPPFLAGS="-I$(PREFIX)/include"
 
 clean:
 	dh_testdir
@@ -12,6 +13,8 @@ build: build-stamp
 build-stamp:
 	dh_testdir
 
+	[ $$OS = ubuntu ] && [ `echo $$OS_VERSION | cut -d. -f1` = 16 ] \
+	$(eval CPPFLAGS += "-mno-avx512f")
 	./configure --prefix=$(PREFIX)/httpd/php \
 --with-config-file-scan-dir=$(PREFIX)/httpd/php/lib \
 --with-apxs2=$(PREFIX)/httpd/bin/apxs \
@@ -84,7 +87,7 @@ build-stamp:
 --without-tsrm-pth \
 --without-tsrm-st \
 --without-tsrm-pthreads \
-CPPFLAGS="-I$(PREFIX)/include" LD_LIBRARY_PATH="$(PREFIX)/lib" LD_RUN_PATH="/$(PREFIX)/lib" PKG_CONFIG_PATH="/$(PREFIX)/lib/pkgconfig"
+CPPFLAGS="$(CPPFLAGS)" LD_LIBRARY_PATH="$(PREFIX)/lib" LD_RUN_PATH="/$(PREFIX)/lib" PKG_CONFIG_PATH="/$(PREFIX)/lib/pkgconfig"
 	make
 
 	touch build-stamp


### PR DESCRIPTION
Ubuntu 16 has an old compiler which improperly indicates support for avx512 (Advanced Vector Extensions) and so later fails during the build.

For this platform we force disabling this feature with -mno-avx512f.

Ticket: ENT-12945
Changelog: none

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12058)](https://ci.cfengine.com/job/pr-pipeline/12058/)
