### PR TITLE
Fixed avx512 ubuntu 16 php compile fix (3.21)

### DIFF
--- a/deps-packaging/php/debian/rules
+++ b/deps-packaging/php/debian/rules
@@ -14,7 +14,8 @@ build-stamp:
 	dh_testdir
 
 	[ $$OS = ubuntu ] && [ `echo $$OS_VERSION | cut -d. -f1` = 16 ] \
-	$(eval CPPFLAGS += "-mno-avx512f")
+	$(eval CPPFLAGS += "-mno-avx512f") \
+	|| true
 	./configure --prefix=$(PREFIX)/httpd/php \
 --with-config-file-scan-dir=$(PREFIX)/httpd/php/lib \
 --with-apxs2=$(PREFIX)/httpd/bin/apxs \


### PR DESCRIPTION
Accidentally made the php build ONLY work on ubuntu 16 by not providing an "else" case in debian/rules

Ticket: ENT-12945
Changelog: none
