### PR TITLE
Added hostname package dependency for rpm hub package

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -14,6 +14,10 @@ Url: https://cfengine.com
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3 < @@VERSION@@, cf-community < @@VERSION@@
 Requires: coreutils
+
+# installation scriptlets need hostname command, not present in UBI container images
+Requires: hostname
+
 # "Recommends" is only supported on RHEL 8+
 %if %{?rhel}%{!?rhel:0} >= 8
 Recommends: gzip


### PR DESCRIPTION
For UBI container images this package/command is not installed by default so require it as the installation scriptlets need it.

Ticket: ENT-12995
