### PR TITLE
Adjustments for running hub in non-priv/non-systemd container

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -14,6 +14,10 @@ Url: https://cfengine.com
 BuildRoot: %{_topdir}/%{name}-%{version}-%{release}-buildroot
 Obsoletes: cfengine3 < @@VERSION@@, cf-community < @@VERSION@@
 Requires: coreutils
+
+# installation scriptlets need hostname command, not present in UBI container images
+Requires: hostname
+
 # "Recommends" is only supported on RHEL 8+
 %if %{?rhel}%{!?rhel:0} >= 8
 Recommends: gzip

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -29,7 +29,7 @@ systemctl restart cfengine3"
   fi
 fi
 
-if [ -x /bin/systemctl ]; then
+if command -v systemctl 2>/dev/null && systemctl is-system-running; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
   if ! /bin/systemctl daemon-reload; then
@@ -1066,7 +1066,7 @@ chmod g+rX "$PREFIX/httpd/php"
 # Register CFEngine initscript, if not yet.
 #
 if ! is_upgrade; then
-  if [ -x /bin/systemctl ]; then
+  if command -v systemctl 2>/dev/null && systemctl is-system-running; then
     # Reload systemd config to pick up newly installed units
     /bin/systemctl daemon-reload > /dev/null 2>&1
     # Enable cfengine3 service (starts all the other services)

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -1,4 +1,4 @@
-if [ -x /bin/systemctl ]; then
+if command -v systemctl 2>/dev/null && systemctl is-system-running; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
   if ! /bin/systemctl daemon-reload; then
@@ -68,7 +68,7 @@ case `os_type` in
     #
     # Register CFEngine initscript, if not yet.
     #
-    if [ -x /bin/systemctl ]; then
+    if command -v systemctl 2>/dev/null && systemctl is-system-running; then
       # Reload systemd config to pick up newly installed units
       /bin/systemctl daemon-reload > /dev/null 2>&1
       # Enable cfengine3 service (starts all the other services)


### PR DESCRIPTION
- Added hostname package dependency for rpm hub package
- Added better check for systemd presence

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12143)](https://ci.cfengine.com/job/pr-pipeline/12143/)