### PR TITLE
CFE-4530: update-deps.yml: fetch update-deps.py from master

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install requests
+      - name: Download script to update dependencies from master
+        run: wget --directory-prefix /tmp https://raw.githubusercontent.com/cfengine/buildscripts/refs/heads/master/.github/workflows/update-deps.py
       - name: Set Git user
         run: |
           git config user.name 'github-actions[bot]'
@@ -42,7 +44,7 @@ jobs:
         run: |
           echo "COMMIT_HASH_BEFORE=$(git log -1 --format=%H)">> $GITHUB_ENV
       - name: Run update script
-        run: python3 .github/workflows/update-deps.py --debug --bump=${{ matrix.branch == 'master' && 'major' || 'minor' }}
+        run: python3 /tmp/update-deps.py --debug --bump=${{ matrix.branch == 'master' && 'major' || 'minor' }}
       - name: Save commit hash after
         run: |
           echo "COMMIT_HASH_AFTER=$(git log -1 --format=%H)">> $GITHUB_ENV


### PR DESCRIPTION
The workflow for updating dependencies keeps failing on the weekly
schedule because it checks out the `3.21.x` branch that does not have
the update-deps.py script. Instead of coping this script to the older
branch, I thought it would make more sense to fetch it from the master
branch. This way we only need to maintain one copy of it.

Ticket: CFE-4530
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
