### PR TITLE
ENT-13021: Refactor the update_dep_tables workflow across supported branches to correctly run on push (3.24.x)

### DIFF
--- a/.github/workflows/update-dep-tables.yml
+++ b/.github/workflows/update-dep-tables.yml
@@ -1,0 +1,13 @@
+name: Update dependency tables (3.24.x)
+
+on:
+  push:
+    branches:
+      - 3.24.x
+
+jobs:
+  update_dep_tables_3_24_x:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: cfengine/buildscripts/.github/workflows/update-dep-tables.yml@master


### PR DESCRIPTION
…correctly run on push (3.24.x)