### PR TITLE
ENT-12600: autogen: Documented and refactored

### DIFF
--- a/build-scripts/autogen
+++ b/build-scripts/autogen
@@ -1,70 +1,85 @@
-#!/bin/sh -ex
+#!/bin/sh -e
 
-. `dirname "$0"`/functions
+#
+# This script runs autogen.sh on each of the CFEngine repositories.
+# Please note that it does not run configure.
+#
+# The script expects the following repositories to exist side by side:
+# .
+# ├── buildscripts
+# ├── core
+# ├── enterprise
+# ├── nova
+# └── masterfiles
+#
+# The script can be run as follows:
+# ```
+# $ PROJECT=[nova|community] ./buildscripts/build-scripts/autogen
+# ```
+#
 
-GITSHAOF="core buildscripts buildscripts/deps-packaging"
+# Get the BASEDIR variable holding the path to where our repos are checked out
+. "$(dirname "$0")/functions"
 
+# Parse the required argument which should be set through the environment
+# variable PROJECT
 case "$PROJECT" in
   community)
     NOVA=no
     ;;
   nova)
     NOVA=yes
-    GITSHAOF="$GITSHAOF enterprise nova"
     ;;
   *)
-    echo "Unknown project: $PROJECT"
+    if [ -z "${PROJECT}" ]; then
+        echo "Error: Expected environment variable PROJECT=[community|nova]"
+    else
+        echo "Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
+    fi
+    echo "Usage: PROJECT=[community|nova] $0"
     exit 42;;
 esac
 
-if test "x$NOVA" = "xyes"
+# Determine which repositories should be included
+projects="core masterfiles"
+if test "$NOVA" = "yes"
 then
-    projects="core enterprise nova masterfiles"
-else
-    projects="core masterfiles"
+    projects="$projects enterprise nova"
 fi
 
-for p in $projects
+# Fail early by checking that the required repositories are present before
+# running the autogen.sh.
+for proj in $projects
 do
-    (cd $BASEDIR/$p && NO_CONFIGURE=1 ./autogen.sh) || false
-done
-# %h (abbreviated commit hash) is not deterministic for length on different systems
-# so far (up to Aug 2023) this didn't matter because one system (bootstrap-oslo-dc)
-# was responsible for doing this autogen work and all other systems used the result.
-# When we migrated from travis to github actions we needed things to be stable between
-# bootstrap-oslo-dc and other systems so will force a length of 7 and check that
-# the result is unique.
-export CORE_ABBREV=7 # adjust this up if need be
-git config --global --add core.abbrev $CORE_ABBREV
-
-for i in $GITSHAOF
-do
-    if [ -d $BASEDIR/$i ] && [ ! -f $BASEDIR/$i/revision ]
-    then
-        R=$(cd $BASEDIR/$i && git log --pretty='format:%h' -1 -- .) || false
-        (
-            cd $BASEDIR/$i
-            if ! git show $R --oneline >/dev/null; then
-                echo "abbreviated commit hash of $CORE_ABBREV is not unique. Consider increasing the value in the script $0."
-                exit 1
-            fi
-        )
-        echo $R | tr -d '\n' > $BASEDIR/$i/revision
+    if [ ! -d "$BASEDIR/$proj" ]; then
+        echo "Error: Expected to find the '$proj' repository in '$BASEDIR', but it's not there"
+        exit 1
     fi
 done
 
+# Run autogen.sh on each repository
+for proj in $projects
+do
+    # autogen.sh is quite verbose, so only print the output in case of failure
+    echo "Running autogen.sh for project $proj..."
+    temp_output_file=$(mktemp)
+    if (cd "$BASEDIR/$proj" && NO_CONFIGURE=1 ./autogen.sh) > "$temp_output_file" 2>&1; then
+        rm -f "$temp_output_file"
+    else
+        exit_code=$? # Store exit code for later
+        echo "Error: failed to run autogen.sh ---"
+        echo "--- Start of Output ---"
+        cat "$temp_output_file"
+        rm -f "$temp_output_file"
+        echo "--- End of Output (Exit code: $exit_code) ---"
+        exit $exit_code
+    fi
+done
 
-detected_versions=`echo $projects  \
-    | xargs -n1  \
-    | sed "s|.*|$BASEDIR/&/CFVERSION|"  \
-    | xargs cat`
-number_of_different_versions=`echo $detected_versions  \
-    | tr ' ' '\n'  \
-    | sed -e 's/\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/'  \
-    | uniq  |  wc -l`
+# Create revision files (containing the N first hex decimals from the last
+# commit of the current branch)
+./"$(dirname "$0")/revision-file"
 
-if [ x"$number_of_different_versions" != x1 ]
-then
-    echo "Detected versions mismatch:" "$detected_versions"  1>&2
-    exit 33
-fi
+# Compare versions between the CFEngine repositories to make sure they
+# match
+./"$(dirname "$0")/compare-versions"

--- a/build-scripts/compare-versions
+++ b/build-scripts/compare-versions
@@ -1,0 +1,66 @@
+#!/bin/sh -e
+
+#
+# This script is called by the autogen scrip and compares the versions between
+# the CFEngine repositories. The script exits with code 33 in case of version
+# mismatch.
+#
+# The script expects the following repositories to exist side by side:
+# .
+# ├── core
+# ├── enterprise
+# ├── nova
+# └── masterfiles
+#
+# The script can be run as follows:
+# ```
+# $ PROJECT=[nova|community] ./buildscripts/build-scripts/compare-versions
+# ```
+#
+
+# Get the BASEDIR variable holding the path to where our repos are checked out
+. "$(dirname "$0")/functions"
+
+# Parse the required argument which should be set through the environment
+# variable PROJECT
+case "$PROJECT" in
+  community)
+    NOVA=no
+    ;;
+  nova)
+    NOVA=yes
+    ;;
+  *)
+    if [ -z "${PROJECT}" ]; then
+        echo "Error: Expected environment variable PROJECT=[community|nova]"
+    else
+        echo "Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
+    fi
+    echo "Usage: PROJECT=[community|nova] $0"
+    exit 42;;
+esac
+
+# Determine which repositories to compare versions between
+projects="core masterfiles"
+if test "$NOVA" = "yes"
+then
+    projects="$projects enterprise nova"
+fi
+
+# Compare versions between projects (yes this code also compares each project to
+# themselves, however, in my opinion it reads better this way)
+for proj_i in $projects; do
+    for proj_j in $projects; do
+        # The CFVERSION file is read into the tr command which removes
+        # whitespace and the sed command extracts the major, minor & patch
+        # version number from the string.
+        version_i=$(< "$BASEDIR/$proj_i/CFVERSION" tr ' ' '\n'  \
+            | sed -e 's/\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+        version_j=$(< "$BASEDIR/$proj_j/CFVERSION" tr ' ' '\n'  \
+            | sed -e 's/\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+        if [ "$version_i" != "$version_j" ]; then
+            echo "Detected version mismatch: $proj_i $version_i != $proj_j $version_j"
+            exit 33
+        fi
+    done
+done

--- a/build-scripts/revision-file
+++ b/build-scripts/revision-file
@@ -1,0 +1,79 @@
+#!/bin/sh -e
+
+#
+# This script called by the autogen script and generates a revision file for
+# each of the following directories:
+# ├── buildscripts
+# │   └── deps_packaging
+# ├── core
+# ├── enterprise
+# └── nova
+#
+# The revision contains the N first hexadecimals from the last commit on the
+# current branch.
+#
+# TODO: Explain what the revision files are used for. Why are there five?
+#
+# The script can be run as follows:
+# ```
+# $ PROJECT=[nova|community] ./buildscripts/build-scripts/autogen
+# ```
+#
+
+# Get the BASEDIR variable holding the path to where our repos are checked out
+. "$(dirname "$0")/functions"
+
+# Adjust this up in case of hash collisions
+CORE_ABBREV=7
+
+# Parse the required argument which should be set through the environment
+# variable PROJECT
+case "$PROJECT" in
+  community)
+    NOVA=no
+    ;;
+  nova)
+    NOVA=yes
+    ;;
+  *)
+    if [ -z "${PROJECT}" ]; then
+        echo "Error: Expected environment variable PROJECT=[community|nova]"
+    else
+        echo "Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
+    fi
+    echo "Usage: PROJECT=[community|nova] $0"
+    exit 42;;
+esac
+
+# Determine which repositories should be included
+_dirs="core buildscripts buildscripts/deps-packaging"
+if test "$NOVA" = "yes"
+then
+    _dirs="$_dirs enterprise nova"
+fi
+
+for _dir in $_dirs
+do
+    if [ -d "$BASEDIR/$_dir" ]; then
+        if [ ! -f "$BASEDIR/$_dir/revision" ]; then
+            echo "Creating revision file in $_dir"
+
+            # Get the revision hash
+            R=$(git -C "$BASEDIR/$_dir" log --abbrev=$CORE_ABBREV --pretty='format:%h' -1 -- .) || false
+
+            # Make sure there are no hash collisions
+            if ! git -C "$BASEDIR/$_dir" show "$R" --oneline >/dev/null; then
+                echo "abbreviated commit hash of $CORE_ABBREV is not unique. Consider increasing the value in the script $0."
+                exit 1
+            fi
+
+            # Create the revision file
+            echo "$R" | tr -d '\n' > "$BASEDIR/$_dir/revision"
+        else
+            echo "Revision file already exists in $_dir"
+        fi
+    else
+        echo "Error: Expected to find the '$_dir' directory in '$BASEDIR', but it's not there"
+        exit 1
+    fi
+done


### PR DESCRIPTION
What has changed:
- autogen is split into three files (autogen, revision-file, and compare-versions). This makes it easier to debug each of these things by executing stand-alone files.
- autogen fails early in case of any missing repositories
- the autogen.sh is quite verbose. Now, the output of autogen is silenced unless an error occurs.
- the revision file generation no longer edits your git config
- output tells you if a revision file was created or if it already existed
- the repository version checking now reads easier by not piping a bunch of commands together
- the repository version checking now tells you which two repositories did not match
- all of the scripts no longer issue warnings and errors with shellcheck
- changing directories is avoided to the extent possible and only done in subshells when required

Example output:
```
$ PROJECT=community ./buildscripts/build-scripts/autogen
Running autogen.sh for project core...
Running autogen.sh for project masterfiles...
Creating revision file in core
Revision file already exists in buildscripts
Creating revision file in buildscripts/deps-packaging
Detected version mismatch: core 3.24.3 != masterfiles 3.27.0
```

```
$ shellcheck build-scripts/autogen

In build-scripts/autogen line 22:
. "$(dirname "$0")/functions"
  ^-------------------------^ SC1091 (info): Not following: ./functions was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./functions was no...
$ shellcheck build-scripts/revision-file

In build-scripts/revision-file line 24:
. "$(dirname "$0")/functions"
  ^-------------------------^ SC1091 (info): Not following: ./functions was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./functions was no...
$ shellcheck build-scripts/compare-versions

In build-scripts/compare-versions line 22:
. "$(dirname "$0")/functions"
  ^-------------------------^ SC1091 (info): Not following: ./functions was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./functions was no...
```

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12203)](https://ci.cfengine.com/job/pr-pipeline/12203/)