### PR TITLE
setup-projects.sh: Don't pass NO_CONFIGURE=1 to the autogen script

### DIFF
--- a/ci/setup-projects.sh
+++ b/ci/setup-projects.sh
@@ -54,7 +54,7 @@ fi
 )
 
 # packages needed for autogen are installed in setup.sh
-NO_CONFIGURE=1 PROJECT=nova ./buildscripts/build-scripts/autogen
+PROJECT=nova ./buildscripts/build-scripts/autogen
 
 # remove unwanted dependencies
 sudo apt-get -qy purge libltdl-dev libltdl7 #libtool


### PR DESCRIPTION
`NO_CONFIGURE=1` is explicitly set in the `autogen` script. Hence, there is no point in passing it to the script.

In the `autogen` script there is:
```
for p in $projects
do
    (cd $BASEDIR/$p && NO_CONFIGURE=1 ./autogen.sh) || false
done
```

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12215)](https://ci.cfengine.com/job/pr-pipeline/12215/)
