### PR TITLE
Restrict workflow runs to cfengine organization pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continuous Integration
 
 on: pull_request
+permissions: read-all
 
 jobs:
   build_cfengine_hub_package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: Continuous Integration
 
-# Run this CI on all pushes to upstream
-# (including PRs from upstream to upstream)
-on: push
+on: pull_request
 
 jobs:
   build_cfengine_hub_package:
+    # this job only works when submitted from the cfengine organization aka upstream to upstream pull requests: ENT-13038
+    if: github.event.organization.login == 'cfengine'
     uses: ./.github/workflows/build-using-buildscripts.yml
     secrets: inherit
 


### PR DESCRIPTION
The workflow event must be pull_request in order for the scripts to know what baseref (branch) to use for dependent repos.

Before this change master branch worked fine but branch dependency PRs from github-actions(bot) would fail due to always checking out master.

Ticket: ENT-13038
Changelog: none
(cherry picked from commit 0621c0637394cdef37993a05a50eb27986c0ade9)

 Conflicts:
	.github/workflows/build-using-buildscripts.yml

We don't want to bring build-using-buildscripts.yml changes from 3.24.x, only the fix for when to run.
