### PR TITLE
Force all jenkins build hosts to use jdk 21

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -52,6 +52,13 @@ bundle agent cfengine_build_host_setup
       "librsync-dev"; # bootstrap_pr host needs this to run configure and make dist
       "autoconf-archive" comment => "Required to resolve the AX_PTHREAD macro";
 
+    debian.containers_host:: # in jenkins, CONTAINER labeled nodes are capable of running container builds like valgrind-check and static-check
+      "buildah";
+      "podman";
+      "jq";
+      "make";
+
+
 # I attempted to arrange these packages in order of: generic (all versions) and then as if we gradually added them through time: rhel-6, 7, 8, 9...
     suse|opensuse|sles|redhat|centos::
       "gcc";
@@ -140,6 +147,7 @@ bundle agent cfengine_build_host_setup
       "mingw_build_host" expression => fileexists("/etc/cfengine-mingw-build-host.flag");
       "systemssl_build_host" expression => fileexists("/etc/cfengine-systemssl-build-host.flag");
       "bootstrap_pr_host" expression => fileexists("/etc/cfengine-bootstrap-pr-host.flag");
+      "containers_host" expression => fileexists("/etc/cfengine-containers-host.flag");
     linux::
       "have_coredumpctl" expression => returnszero("command -v coredumpctl", "useshell");
       "missing_opt_jdk21" expression => not(fileexists("/opt/jdk-21.0.1"));
@@ -235,6 +243,20 @@ root - core unlimited
       "/home/jenkins/.rpmmacros"
         content => "%dist .suse11",
         comment => "ensure %dist works in RPM .spec files - needed to add OS name/version to rpm filename";
+
+    debian.containers_host::
+      "/etc/sudoers.d/999-local"
+        comment => "NOPASSWD is needed for various tools related to container jobs",
+        content => "%wheel ALL=NOPASSWD: /usr/bin/lvm-cache-stats
+%wheel ALL=NOPASSWD: /usr/bin/podman
+%sudo ALL=NOPASSWD: /usr/bin/lvm-cache-stats
+%sudo ALL=NOPASSWD: /usr/bin/podman
+%sudo ALL=NOPASSWD: /usr/sbin/lvs
+%sudo ALL=NOPASSWD: /usr/bin/journalctl
+jenkins_builds ALL=NOPASSWD: /usr/bin/podman
+",
+        create => "true",
+        perms => mog("400", "root", "root");
 
   commands:
     (redhat_8|centos_8|redhat_9).(!have_perl_package_installed).(yum_dnf_conf_ok)::

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -16,13 +16,10 @@ bundle agent cfengine_build_host_setup
       "shellcheck" comment => "not sure why only ubuntu-20 needed this.";
     debian.(!debian_12.!ubuntu_22)::
       "python" comment => "debian-12 has only python3";
-    !(debian_9|ubuntu_16).(debian|ubuntu)::
-      "default-jre" comment => "on debian10+ and ubuntu18+ this will be jdk11, good enough for jenkins 2.426.1 https://www.jenkins.io/doc/book/platform-information/support-policy-java/index.html";
 
     debian|ubuntu::
       "libltdl7" package_policy => "delete";
       "libltdl-dev" package_policy => "delete";
-
       "binutils";
       "bison";
       "build-essential";
@@ -96,7 +93,6 @@ bundle agent cfengine_build_host_setup
       "epel-release";
       "ccache";
       "fakeroot";
-      "java-11-openjdk" comment => "ok for jenkins 2.426.1 https://www.jenkins.io/doc/book/platform-information/support-policy-java/index.html";
       "perl-JSON-PP";
       "perl-Data-Dumper";
       "perl-Digest-MD5";
@@ -119,7 +115,6 @@ bundle agent cfengine_build_host_setup
     (redhat_8|centos_8|redhat_9).(yum_dnf_conf_ok)::
       "java-1.8.0-openjdk-headless" package_policy => "delete",
         comment => "Installing Development Tools includes this jdk1.8 which we do not want.";
-      "java-17-openjdk";
       "pkgconf" comment => "pkgconfig renamed to pkgconf in rhel8";
       "selinux-policy-devel" comment => "maybe add to _7 and _6?";
       "openssl-devel";
@@ -135,10 +130,6 @@ bundle agent cfengine_build_host_setup
       "pkg-config";
       "rpm-build";
 
-    suse_12|opensuse_12|sles_12::
-      "java-11-openjdk";
-    suse_15|opensuse_15|sles_15::
-      "java-17-openjdk";
 
 
   vars:
@@ -151,8 +142,7 @@ bundle agent cfengine_build_host_setup
       "bootstrap_pr_host" expression => fileexists("/etc/cfengine-bootstrap-pr-host.flag");
     linux::
       "have_coredumpctl" expression => returnszero("command -v coredumpctl", "useshell");
-    debian_9|ubuntu_16|redhat_6|centos_6::
-      "have_opt_jdk21" expression => fileexists("/opt/jdk-21.0.1");
+      "missing_opt_jdk21" expression => not(fileexists("/opt/jdk-21.0.1"));
     (redhat|centos).!(redhat_6|centos_6|redhat_7|centos_7)::
       "yum_conf_ok" expression => returnszero("grep best=False /etc/yum.conf", "useshell");
     redhat_6|centos_6|redhat_7|centos_7::
@@ -179,7 +169,7 @@ bundle agent cfengine_build_host_setup
       "sysctl kernel.core_pattern='|/lib/systemd/systemd-coredump %p %u %g %s %t %e'" -> { "ENT-12669" }
         comment => "Ensure that core_pattern is proper for systemd-coredump if coredumpctl is present.",
         contain => in_shell;
-    !have_opt_jdk21.(debian_9|ubuntu_16|redhat_6|centos_6)::
+    missing_opt_jdk21::
       "sh $(this.promise_dirname)/linux-install-jdk21.sh" contain => in_shell;
     (redhat_7|centos_7|redhat_8|centos_8|redhat_9).(!have_development_tools).(yum_dnf_conf_ok)::
       "yum groups install -y 'Development Tools'" contain => in_shell;

--- a/ci/linux-install-jdk21.sh
+++ b/ci/linux-install-jdk21.sh
@@ -3,18 +3,27 @@ set -e
 # install jdk "manually"
 # depending on os, might want to do something like `apt remove default-jre openjdk-*-jre-*`
 cd /opt
-wget https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz
-echo "7e80146b2c3f719bf7f56992eb268ad466f8854d5d6ae11805784608e458343f  openjdk-21.0.1_linux-x64_bin.tar.gz"  | sha256sum --check -
-sudo tar xf openjdk-21.0.1_linux-x64_bin.tar.gz
+baseurl=https://download.oracle.com/java/21/latest/
+version=21.0.7
+if uname -m | grep aarch64; then
+  tarball=jdk-21_linux-aarch64_bin.tar.gz
+  sha=47372cfa9244dc74ec783a1b287381502419b564fbd0b18abc8f2d6b19ac865e
+else
+  tarball=jdk-21_linux-x64_bin.tar.gz
+  sha=267b10b14b4e5fada19aca3be3b961ce4f81f1bd3ffcd070e90a5586106125eb
+fi
+wget --quiet "$baseurl$tarball"
+echo "$sha" "$tarball" | sha256sum --check -
+sudo tar xf "$tarball"
 sudo tee /etc/profile.d/jdk.sh << EOF
-export JAVA_HOME=/opt/jdk-21.0.1
+export JAVA_HOME="/opt/jdk-$version"
 export PATH=\$PATH:\$JAVA_HOME/bin
 EOF
-sudo chown -R root:jenkins /opt/jdk-21.0.1
-sudo chmod -R g+rx /opt/jdk-21.0.1
+sudo chown -R root:jenkins "/opt/jdk-$version"
+sudo chmod -R g+rx "/opt/jdk-$version"
 if command -v update-alternatives; then
-  sudo update-alternatives --install /usr/bin/java java /opt/jdk-21.0.1/bin/java 9999
+  sudo update-alternatives --install /usr/bin/java java "/opt/jdk-$version/bin/java" 9999
 else
-  sudo ln -s /opt/jdk-21.0.1/bin/java /usr/bin/java
+  sudo ln -s "/opt/jdk-$version/bin/java" /usr/bin/java
 fi
 cd -


### PR DESCRIPTION
On older hosts we were getting away with jdk 11 but that isn't sufficient for impending jenkins upgrade.

This needs to hold-off while jenkins-dev is still in testing.

Ticket: ENT-13033
Changelog: none
