### PR TITLE
Fixed ubuntu.24 build host policy, python is not a package, python3 will be installed as a dependency.

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -14,8 +14,8 @@ bundle agent cfengine_build_host_setup
     ubuntu_20::
       "autoconf" comment => "because on arm ubuntu-20 we need to reconfigure the debian-9 bootstrapped configure scripts.";
       "shellcheck" comment => "not sure why only ubuntu-20 needed this.";
-    debian.(!debian_12.!ubuntu_22)::
-      "python" comment => "debian-12 has only python3";
+    debian.(!debian_12.!ubuntu_22.!ubuntu_24)::
+      "python" comment => "debian>=12 and ubuntu>=22 only has python3";
 
     debian|ubuntu::
       "libltdl7" package_policy => "delete";


### PR DESCRIPTION
Ticket: ENT-13030
Changelog: none
