### PR TITLE
Bump cfengine build host cfengine bootstrapping version

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -2,7 +2,7 @@
 shopt -s expand_aliases
 
 # TODO get latest LTS dynamically
-CFE_VERSION=3.24.0
+CFE_VERSION=3.24.2
 
 # install needed packages and software for a build host
 set -ex


### PR DESCRIPTION
3.24.0 didn't have packages for ubu24 and we should upgrade anyway.

Ticket: ENT-13030
Changelog: none
