### PR TITLE
autogen: use run_and_print_on_failure function

### DIFF
--- a/build-scripts/autogen
+++ b/build-scripts/autogen
@@ -62,18 +62,10 @@ for proj in $projects
 do
     # autogen.sh is quite verbose, so only print the output in case of failure
     echo "Running autogen.sh for project $proj..."
-    temp_output_file=$(mktemp)
-    if (cd "$BASEDIR/$proj" && NO_CONFIGURE=1 ./autogen.sh) > "$temp_output_file" 2>&1; then
-        rm -f "$temp_output_file"
-    else
-        exit_code=$? # Store exit code for later
-        echo "Error: failed to run autogen.sh ---"
-        echo "--- Start of Output ---"
-        cat "$temp_output_file"
-        rm -f "$temp_output_file"
-        echo "--- End of Output (Exit code: $exit_code) ---"
-        exit $exit_code
-    fi
+    (
+        cd "$BASEDIR/$proj"
+        NO_CONFIGURE=1 run_and_print_on_failure ./autogen.sh
+    )
 done
 
 # Create revision files (containing the N first hex decimals from the last

--- a/build-scripts/autogen
+++ b/build-scripts/autogen
@@ -32,9 +32,9 @@ case "$PROJECT" in
     ;;
   *)
     if [ -z "${PROJECT}" ]; then
-        echo "Error: Expected environment variable PROJECT=[community|nova]"
+        echo "$(basename "$0"): Error: Expected environment variable PROJECT=[community|nova]"
     else
-        echo "Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
+        echo "$(basename "$0"): Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
     fi
     echo "Usage: PROJECT=[community|nova] $0"
     exit 42;;
@@ -52,7 +52,7 @@ fi
 for proj in $projects
 do
     if [ ! -d "$BASEDIR/$proj" ]; then
-        echo "Error: Expected to find the '$proj' repository in '$BASEDIR', but it's not there"
+        echo "$(basename "$0"): Error: Expected to find the '$proj' repository in '$BASEDIR', but it's not there"
         exit 1
     fi
 done
@@ -61,7 +61,7 @@ done
 for proj in $projects
 do
     # autogen.sh is quite verbose, so only print the output in case of failure
-    echo "Running autogen.sh for project $proj..."
+    echo "$(basename "$0"): Debug: Running autogen.sh for project $proj..."
     (
         cd "$BASEDIR/$proj"
         NO_CONFIGURE=1 run_and_print_on_failure ./autogen.sh

--- a/build-scripts/compare-versions
+++ b/build-scripts/compare-versions
@@ -32,9 +32,9 @@ case "$PROJECT" in
     ;;
   *)
     if [ -z "${PROJECT}" ]; then
-        echo "Error: Expected environment variable PROJECT=[community|nova]"
+        echo "$(basename "$0"): Error: Expected environment variable PROJECT=[community|nova]"
     else
-        echo "Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
+        echo "$(basename "$0"): Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
     fi
     echo "Usage: PROJECT=[community|nova] $0"
     exit 42;;
@@ -59,7 +59,7 @@ for proj_i in $projects; do
         version_j=$(< "$BASEDIR/$proj_j/CFVERSION" tr ' ' '\n'  \
             | sed -e 's/\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
         if [ "$version_i" != "$version_j" ]; then
-            echo "Detected version mismatch: $proj_i $version_i != $proj_j $version_j"
+            echo "$(basename "$0"): Error: Detected version mismatch: $proj_i $version_i != $proj_j $version_j"
             exit 33
         fi
     done

--- a/build-scripts/revision-file
+++ b/build-scripts/revision-file
@@ -37,9 +37,9 @@ case "$PROJECT" in
     ;;
   *)
     if [ -z "${PROJECT}" ]; then
-        echo "Error: Expected environment variable PROJECT=[community|nova]"
+        echo "$(basename "$0"): Error: Expected environment variable PROJECT=[community|nova]"
     else
-        echo "Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
+        echo "$(basename "$0"): Error: Unknown project '$PROJECT', expected 'community' or 'nova'"
     fi
     echo "Usage: PROJECT=[community|nova] $0"
     exit 42;;
@@ -56,24 +56,24 @@ for _dir in $_dirs
 do
     if [ -d "$BASEDIR/$_dir" ]; then
         if [ ! -f "$BASEDIR/$_dir/revision" ]; then
-            echo "Creating revision file in $_dir"
+            echo "$(basename "$0"): Debug: Creating revision file in $_dir"
 
             # Get the revision hash
             R=$(git -C "$BASEDIR/$_dir" log --abbrev=$CORE_ABBREV --pretty='format:%h' -1 -- .) || false
 
             # Make sure there are no hash collisions
             if ! git -C "$BASEDIR/$_dir" show "$R" --oneline >/dev/null; then
-                echo "abbreviated commit hash of $CORE_ABBREV is not unique. Consider increasing the value in the script $0."
+                echo "$(basename "$0"): Error: abbreviated commit hash of $CORE_ABBREV is not unique. Consider increasing the value in the script $0."
                 exit 1
             fi
 
             # Create the revision file
             echo "$R" | tr -d '\n' > "$BASEDIR/$_dir/revision"
         else
-            echo "Revision file already exists in $_dir"
+            echo "$(basename "$0"): Debug: Revision file already exists in $_dir"
         fi
     else
-        echo "Error: Expected to find the '$_dir' directory in '$BASEDIR', but it's not there"
+        echo "$(basename "$0"): Error: Expected to find the '$_dir' directory in '$BASEDIR', but it's not there"
         exit 1
     fi
 done


### PR DESCRIPTION
- **autogen: Use run_and_print_on_failure function**
- **autogen: Add filename to log messages**
- **compare-versions: add filename to log messages**
- **revision-file: add filename to log messages**

Example output:
```
$ PROJECT=nova ./buildscripts/build-scripts/autogen
autogen: Debug: Running autogen.sh for project core...
autogen: Debug: Running autogen.sh for project masterfiles...
autogen: Debug: Running autogen.sh for project enterprise...
autogen: Debug: Running autogen.sh for project nova...
revision-file: Debug: Revision file already exists in core
revision-file: Debug: Revision file already exists in buildscripts
revision-file: Debug: Revision file already exists in buildscripts/deps-packaging
revision-file: Debug: Revision file already exists in enterprise
revision-file: Debug: Revision file already exists in nova
compare-versions: Error: Detected version mismatch: core 3.27.0 != nova 3.24.0
```

With exotics (no tests)
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12273)](https://ci.cfengine.com/job/pr-pipeline/12273/)
^ Solaris 11 failure is unrelated `14:50:08 ssh: connect to host cloud.siteox.com port 16322: No route to host`