### PR TITLE
Adjusted packaging scripts to check systemctl is-system-running

### DIFF
--- a/packaging/common/script-templates/deb-script-common.sh
+++ b/packaging/common/script-templates/deb-script-common.sh
@@ -19,7 +19,7 @@ rc_d_path()
 
 platform_service()
 {
-  if [ -x /bin/systemctl ]; then
+  if [ -x /bin/systemctl ] && systemctl is-system-running; then
     /bin/systemctl "$2" "$1".service
   else
     /etc/init.d/"$1" "$2"

--- a/packaging/common/script-templates/rpm-script-common.sh
+++ b/packaging/common/script-templates/rpm-script-common.sh
@@ -27,7 +27,7 @@ rc_d_path()
 
 platform_service()
 {
-  if [ -x /bin/systemctl ]; then
+  if [ -x /bin/systemctl ] && systemctl is-system-running; then
     /bin/systemctl "$2" "$1".service
   else
     `rc_d_path`/init.d/"$1" "$2"

--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -29,7 +29,7 @@ case "$PKG_TYPE" in
 esac
 
 get_cfengine_state() {
-    if type systemctl >/dev/null 2>&1; then
+    if [ -x /bin/systemctl ] && systemctl is-system-running; then
         systemctl list-units -l | sed -r -e '/^\s*(cf-[-a-z]+|cfengine3)\.service/!d' -e 's/\s*(cf-[-a-z]+|cfengine3)\.service.*/\1/'
     else
         platform_service cfengine3 status | awk '/is running/ { print $1 }'
@@ -39,7 +39,7 @@ get_cfengine_state() {
 restore_cfengine_state() {
     # $1 -- file where the state to restore is saved (see get_cfengine_state())
 
-    if type systemctl >/dev/null 2>&1; then
+    if [ -x /bin/systemctl ] && systemctl is-system-running; then
         for service in `cat "$1"`; do
             definition=`systemctl cat "$service"` || continue
             # only try to start service that are defined/exist (some may be gone


### PR DESCRIPTION
In the case of containers running debian 11 and such, systemctl command is available but the system may not be running.

systemctl is-system-running is a better check as to whether we should execute systemd related commands.

Ticket: CFE-4544
Changelog: title
