### PR TITLE
ENT-12600: compile: Documented/refactored script

### DIFF
--- a/build-scripts/compile
+++ b/build-scripts/compile
@@ -1,5 +1,21 @@
 #!/bin/sh
 
+# Usage: PROJECT=[nova|community] ROLE=[hub|agent] ./buildscripts/build-scripts/compile
+#
+# This script compiles and installs the CFEngine repositories into
+# '$BASEDIR/cfengine/dist'. You should first run the 'autogen' script, then
+# 'configure' script before running this script.
+#
+# The script expects the following repositories to exist side by side:
+# .
+# ├── buildscripts
+# ├── core
+# ├── enterprise
+# ├── nova
+# └── masterfiles
+#
+# ^ When building community you won't need enterprise and nova
+
 . "$(dirname "$0")"/functions
 . detect-environment
 . compile-options

--- a/build-scripts/compile
+++ b/build-scripts/compile
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . "$(dirname "$0")"/functions
 . detect-environment
@@ -12,21 +12,29 @@ case "$PROJECT" in
     NOVA=yes
     ;;
   *)
-    echo "Unknown project: $PROJECT"
+    echo "$(basename "$0"): Error: Unknown project '$PROJECT'"
     exit 42;;
 esac
 
-$MAKE -C "$BASEDIR"/core -k
-$MAKE -C "$BASEDIR"/core install DESTDIR="$BASEDIR"/cfengine/dist
+echo "$(basename "$0"): Debug: Running make in core repo..."
+run_and_print_on_failure $MAKE -C "$BASEDIR"/core -k
+echo "$(basename "$0"): Debug: Running make install in core repo..."
+run_and_print_on_failure $MAKE -C "$BASEDIR"/core install DESTDIR="$BASEDIR"/cfengine/dist
 
 if [ "$NOVA" = yes ]; then
-    $MAKE -C "$BASEDIR"/enterprise -k
-    $MAKE -C "$BASEDIR"/enterprise install DESTDIR="$BASEDIR"/cfengine/dist
+    echo "$(basename "$0"): Debug: Running make in enterprise repo..."
+    run_and_print_on_failure $MAKE -C "$BASEDIR"/enterprise -k
+    echo "$(basename "$0"): Debug: Running make install in enterprise repo..."
+    run_and_print_on_failure $MAKE -C "$BASEDIR"/enterprise install DESTDIR="$BASEDIR"/cfengine/dist
     if [ "$ROLE" = hub ]; then
-        $MAKE -C "$BASEDIR"/nova -k
-        $MAKE -C "$BASEDIR"/nova install DESTDIR="$BASEDIR"/cfengine/dist
-        $MAKE -C "$BASEDIR"/masterfiles install DESTDIR="$BASEDIR"/cfengine/dist
+        echo "$(basename "$0"): Debug: Running make in nova repo..."
+        run_and_print_on_failure $MAKE -C "$BASEDIR"/nova -k
+        echo "$(basename "$0"): Debug: Running make install in nova repo..."
+        run_and_print_on_failure $MAKE -C "$BASEDIR"/nova install DESTDIR="$BASEDIR"/cfengine/dist
+        echo "$(basename "$0"): Debug: Running make install in masterfiles repo..."
+        run_and_print_on_failure $MAKE -C "$BASEDIR"/masterfiles install DESTDIR="$BASEDIR"/cfengine/dist
     fi
 else
-    $MAKE -C "$BASEDIR"/masterfiles install DESTDIR="$BASEDIR"/cfengine/dist
+    echo "$(basename "$0"): Debug: Running make install in masterfiles repo..."
+    run_and_print_on_failure $MAKE -C "$BASEDIR"/masterfiles install DESTDIR="$BASEDIR"/cfengine/dist
 fi

--- a/build-scripts/compile
+++ b/build-scripts/compile
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-. `dirname "$0"`/functions
+. "$(dirname "$0")"/functions
 . detect-environment
 . compile-options
 
@@ -16,19 +16,17 @@ case "$PROJECT" in
     exit 42;;
 esac
 
-$MAKE -C $BASEDIR/core -k
-$MAKE -C $BASEDIR/core install DESTDIR=$BASEDIR/cfengine/dist
+$MAKE -C "$BASEDIR"/core -k
+$MAKE -C "$BASEDIR"/core install DESTDIR="$BASEDIR"/cfengine/dist
 
-if test "x$NOVA" = "xyes"; then
-    $MAKE -C $BASEDIR/enterprise -k
-    $MAKE -C $BASEDIR/enterprise install DESTDIR=$BASEDIR/cfengine/dist
-    if test "x$ROLE" = "xhub"; then
-        $MAKE -C $BASEDIR/nova -k
-        $MAKE -C $BASEDIR/nova install DESTDIR=$BASEDIR/cfengine/dist
-        $MAKE -C $BASEDIR/masterfiles install DESTDIR=$BASEDIR/cfengine/dist
+if [ "$NOVA" = yes ]; then
+    $MAKE -C "$BASEDIR"/enterprise -k
+    $MAKE -C "$BASEDIR"/enterprise install DESTDIR="$BASEDIR"/cfengine/dist
+    if [ "$ROLE" = hub ]; then
+        $MAKE -C "$BASEDIR"/nova -k
+        $MAKE -C "$BASEDIR"/nova install DESTDIR="$BASEDIR"/cfengine/dist
+        $MAKE -C "$BASEDIR"/masterfiles install DESTDIR="$BASEDIR"/cfengine/dist
     fi
 else
-    $MAKE -C $BASEDIR/masterfiles install DESTDIR=$BASEDIR/cfengine/dist
+    $MAKE -C "$BASEDIR"/masterfiles install DESTDIR="$BASEDIR"/cfengine/dist
 fi
-
-

--- a/build-scripts/compile
+++ b/build-scripts/compile
@@ -5,15 +5,15 @@
 . compile-options
 
 case "$PROJECT" in
-  community)
-    NOVA=no
-    ;;
-  nova)
-    NOVA=yes
-    ;;
-  *)
-    echo "$(basename "$0"): Error: Unknown project '$PROJECT'"
-    exit 42;;
+    community)
+        NOVA=no
+        ;;
+    nova)
+        NOVA=yes
+        ;;
+    *)
+        echo "$(basename "$0"): Error: Unknown project '$PROJECT'"
+        exit 42;;
 esac
 
 echo "$(basename "$0"): Debug: Running make in core repo..."

--- a/build-scripts/compile
+++ b/build-scripts/compile
@@ -13,7 +13,8 @@ case "$PROJECT" in
         ;;
     *)
         echo "$(basename "$0"): Error: Unknown project '$PROJECT'"
-        exit 42;;
+        exit 42
+        ;;
 esac
 
 echo "$(basename "$0"): Debug: Running make in core repo..."


### PR DESCRIPTION
- **compile: fixed shellcheck issues**
- **compile: Reduced verbosity of script**
- **compile: Fixed inconsistent indents**
- **compile: Placed block terminator on a new line for consistency**
- **compile: Documented script**

Build with no tests
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12277)](https://ci.cfengine.com/job/pr-pipeline/12277/)

Example output:
```
$ PROJECT=nova ROLE=hub ./buildscripts/build-scripts/compile
 ---snip---
compile: Debug: Running make in core repo...
compile: Debug: Running make install in core repo...
compile: Debug: Running make in enterprise repo...
compile: Debug: Running make install in enterprise repo...
compile: Debug: Running make in nova repo...
compile: Debug: Running make install in nova repo...
compile: Debug: Running make install in masterfiles repo...
```
^ Snipped noise from sourced scripts