### PR TITLE
ENT-13084: Fixed implicit declaration of GNU extension gettid

### DIFF
--- a/deps-packaging/apache/debian/rules
+++ b/deps-packaging/apache/debian/rules
@@ -14,6 +14,10 @@ build-stamp:
 	dh_testdir
 
 	patch -p0 < $(CURDIR)/apachectl.patch
+
+	# Fixed implicit declaration of GNU extension gettid() (See ENT-13084)
+	patch -p1 < $(CURDIR)/fixed-implicit-decl-gettid.patch
+
 	./configure \
 --prefix=$(PREFIX)/httpd \
 --enable-so \

--- a/deps-packaging/apache/fixed-implicit-decl-gettid.patch
+++ b/deps-packaging/apache/fixed-implicit-decl-gettid.patch
@@ -1,0 +1,19 @@
+diff -ruN httpd-2.4.63/server/log.c httpd-2.4.63-modified/server/log.c
+--- httpd-2.4.63/server/log.c	2024-06-21 16:31:54.000000000 +0200
++++ httpd-2.4.63-modified/server/log.c	2025-06-26 15:58:03.168415807 +0200
+@@ -633,11 +633,11 @@
+ #endif
+ #if defined(HAVE_GETTID) || defined(HAVE_SYS_GETTID)
+     if (arg && *arg == 'g') {
+-#ifdef HAVE_GETTID
+-        pid_t tid = gettid();
+-#else
++// #ifdef HAVE_GETTID
++//         pid_t tid = gettid();
++// #else
+         pid_t tid = syscall(SYS_gettid);
+-#endif
++// #endif
+         if (tid == -1)
+             return 0;
+         return apr_snprintf(buf, buflen, "%"APR_PID_T_FMT, tid);


### PR DESCRIPTION
Fixes current compilation error (found on Ubuntu 24):

```
23:16:48 log.c:637:21: error: implicit declaration of function 'gettid'; did you mean 'getgid'? [-Wimplicit-function-declaration]
23:16:48   637 |         pid_t tid = gettid();
23:16:48       |                     ^~~~~~
23:16:48       |                     getgid
```

Ticket: ENT-13084
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Back-ported to:
* https://github.com/cfengine/buildscripts/pull/1780
* https://github.com/cfengine/buildscripts/pull/1781 