### PR TITLE
linux-install-jdk21.sh: Use curly brackets to expand variable

### DIFF
--- a/ci/linux-install-jdk21.sh
+++ b/ci/linux-install-jdk21.sh
@@ -8,11 +8,11 @@ install_jdk() {
   baseurl=https://download.oracle.com/java/21/archive/
   version=21.0.8
   if uname -m | grep aarch64; then
-    tarball=jdk-$(version)_linux-aarch64_bin.tar.gz
+    tarball=jdk-${version}_linux-aarch64_bin.tar.gz
     # checksum from https://download.oracle.com/java/21/latest/jdk-21_linux-aarch64_bin.tar.gz.sha256
     sha=708064ee3a1844245d83be483ff42cc9ca0c482886a98be7f889dff69ac77850
   else
-    tarball=jdk-$(version)_linux-x64_bin.tar.gz
+    tarball=jdk-${version}_linux-x64_bin.tar.gz
     # checksum from https://download.oracle.com/java/24/latest/jdk-24_linux-x64_bin.tar.gz.sha256
     sha=5f9f7c4ca2a6cef0f18a27465e1be81bddd8653218f450a329a2afc9bf2a1dd8
   fi


### PR DESCRIPTION
- **linux-install-jdk21.sh: Use curly brackets to expand variable**
