### PR TITLE
Removed unrecognized options when configuring libcurl

### DIFF
--- a/deps-packaging/libcurl-hub/debian/rules
+++ b/deps-packaging/libcurl-hub/debian/rules
@@ -2,12 +2,6 @@
 
 PREFIX=$(BUILDPREFIX)
 
-ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
-  PTHREAD=
-else
-  PTHREAD=--with-pthread=$(PREFIX)
-endif
-
 clean:
 	dh_testdir
 	dh_testroot
@@ -20,27 +14,19 @@ build-stamp:
 
 	./configure --with-sysroot=$(PREFIX) \
 				--host=$(DEB_HOST_GNU_TYPE) \
-				$(PTHREAD) \
 				--with-ssl=$(PREFIX) \
 				--with-zlib=$(PREFIX) \
 				--prefix=$(PREFIX) \
 				--disable-ldap \
 				--disable-ldaps \
 				--disable-ntlm \
-				--without-axtls \
-				--without-cyassl \
-				--without-egd-socket \
 				--without-gnutls \
 				--without-gssapi \
-				--without-libidn \
 				--without-libpsl \
 				--without-librtmp \
 				--without-libssh2 \
 				--without-nghttp2 \
-				--without-nss \
-				--without-polarssl \
 				--without-winidn \
-				--without-winssl \
 				CPPFLAGS="-I$(PREFIX)/include" \
 
 	make

--- a/deps-packaging/libcurl/debian/rules
+++ b/deps-packaging/libcurl/debian/rules
@@ -3,10 +3,8 @@
 PREFIX=$(BUILDPREFIX)
 
 ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
-  PTHREAD=
   CC_OVERRIDE=
 else
-  PTHREAD=--with-pthread=$(PREFIX)
   CC_OVERRIDE="CC=$(DEB_HOST_GNU_TYPE)-gcc -static-libgcc"
 endif
 
@@ -28,33 +26,25 @@ build-stamp:
 
 	./configure --with-sysroot=$(PREFIX) \
 				--host=$(DEB_HOST_GNU_TYPE) \
-				$(PTHREAD) \
 				--with-ssl=$(SSL_PREFIX) \
 				--with-zlib=$(PREFIX) \
 				--prefix=$(PREFIX) \
 				--disable-ldap \
 				--disable-ldaps \
 				--disable-ntlm \
-				--without-axtls \
-				--without-cyassl \
-				--without-egd-socket \
 				--without-gnutls \
 				--without-gssapi \
-				--without-libidn \
 				--without-libpsl \
 				--without-librtmp \
 				--without-libssh2 \
 				--without-nghttp2 \
-				--without-nss \
-				--without-polarssl \
 				--without-winidn \
-				--without-winssl \
 				LDFLAGS="$(LDFLAGS)" \
 				$(CC_OVERRIDE) \
 				CPPFLAGS="-I$(PREFIX)/include" \
 
 	make
-	
+
 	touch build-stamp
 
 install: build

--- a/deps-packaging/libcurl/hpux/build
+++ b/deps-packaging/libcurl/hpux/build
@@ -18,20 +18,13 @@ TTD=${BUILD_ROOT}/cfbuild-libcurl-devel${PREFIX}
     --with-zlib=$PREFIX \
     --disable-ldap \
     --disable-ldaps \
-    --without-axtls \
-    --without-cyassl \
-    --without-egd-socket \
     --without-gnutls \
     --without-gssapi \
-    --without-libidn \
     --without-libpsl \
     --without-librtmp \
     --without-libssh2 \
     --without-nghttp2 \
-    --without-nss \
-    --without-polarssl \
     --without-winidn \
-    --without-winssl \
     CPPFLAGS="-DAF_LOCAL=AF_UNIX -D_LARGEFILE_SOURCE"
 gmake
 

--- a/deps-packaging/libcurl/solaris/build
+++ b/deps-packaging/libcurl/solaris/build
@@ -15,20 +15,13 @@ TTD=${BUILD_ROOT}/cfbuild-libcurl-devel${PREFIX}
     --with-zlib=$PREFIX \
     --disable-ldap \
     --disable-ldaps \
-    --without-axtls \
-    --without-cyassl \
-    --without-egd-socket \
     --without-gnutls \
     --without-gssapi \
-    --without-libidn \
     --without-libpsl \
     --without-librtmp \
     --without-libssh2 \
     --without-nghttp2 \
-    --without-nss \
-    --without-polarssl \
     --without-winidn \
-    --without-winssl \
     CPPFLAGS="-DAF_LOCAL=AF_UNIX"
 $MAKE
 


### PR DESCRIPTION
```
configure: WARNING: unrecognized options: --with-pthread, --without-axtls, --without-cyassl, --without-egd-socket, --without-libidn, --without-nss, --without-polarssl, --without-winssl
```

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
