### PR TITLE
build-scripts/functions: added logging functions

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -617,4 +617,14 @@ run_and_print_on_failure()
     return $exit_code
 }
 
+log_debug()
+{
+    echo "$(basename "$0"): Debug:" "$@"
+}
+
+log_error()
+{
+    echo "$(basename "$0"): Error:" "$@" >&2
+}
+
 _IS_FUNCTIONS_SOURCED=yes


### PR DESCRIPTION
The main motivation for these functions is for them to include the
filename in the output. Hence, when things stop working, you'll know
exactly where to look.

Example file:
```sh
#!/bin/sh
. "$(dirname "$0")/functions"
log_debug foo bar baz
log_error bogus
```

Example output:
```
$ ./test.sh
test.sh: Debug: foo bar baz
test.sh: Error: bogus
```

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
