### PR TITLE
Script comment cleanups regarding unspecific/old "autobuild policy"

### DIFF
--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -75,6 +75,6 @@ then
     exit 0
 else
     echo "$0: FAILURE buildslave is NOT correctly setup"
-    echo "You should edit the policy in autobuild to fix the issues"
+    echo "You should edit the policy at buildscripts/ci/cfengine-build-host-setup.cf to fix the issues"
     exit 1
 fi

--- a/build-scripts/build-environment-check
+++ b/build-scripts/build-environment-check
@@ -12,7 +12,6 @@
 # The rest are wanted only on the machine doing "autogen.sh",
 #     aka buildmaster, which is *different* from the buildslaves
 ### TODO add to the unwanted list:    bison byacc flex
-### TODO unfortunately autoconf is installed by autobuild policy
 
 
 case "$OS" in


### PR DESCRIPTION
- **Remove TODO about autoconf installed by autobuild policy. No longer useful or applicable.**
- **Adjusted reference to policy which configures build hosts**
