### PR TITLE
update-deps.yml: Failure when running workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "COMMIT_HASH_BEFORE=$(git log -1 --format=%H)">> $GITHUB_ENV
       - name: Run update script
-        run: python3 /tmp/update-deps.py --debug --bump=${{ matrix.branch == 'master' && 'major' || 'minor' }} {{ matrix.branch == 'master' && '--jdk21' }}
+        run: python3 /tmp/update-deps.py --debug --bump=${{ matrix.branch == 'master' && 'major' || 'minor' }} ${{ matrix.branch == 'master' && '--jdk21' }}
       - name: Save commit hash after
         run: |
           echo "COMMIT_HASH_AFTER=$(git log -1 --format=%H)">> $GITHUB_ENV


### PR DESCRIPTION
It appears that I missed a dollar sign when adding a new conditional
argument to the update dependencies automation.

```
Run python3 /tmp/update-deps.py --debug --bump=major {{ matrix.branch == 'master' && '--jdk21' }}
usage: update-deps.py [-h] [--debug] [--bump {major,minor,patch}]
                      [--skip PACKAGE VERSION] [--root ROOT] [--jdk21]
update-deps.py: error: unrecognized arguments: {{ matrix.branch == master
```

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
