### PR TITLE
ENT-12600: generate-source-tarballs: Documented and refactored script

### DIFF
--- a/build-scripts/generate-source-tarballs
+++ b/build-scripts/generate-source-tarballs
@@ -22,19 +22,15 @@
 # ```
 #
 
-. `dirname "$0"`/functions
+. "$(dirname "$0")"/functions
 . detect-environment
 . compile-options
-set -x
 
 
-cd core
-$MAKE V=1 dist
-cd ..
-
-cd masterfiles
-$MAKE V=1 dist
-cd ..
+for repo in core masterfiles; do
+    log_debug "Running target make dist in $repo repository..."
+    (cd $repo && run_and_print_on_failure "$MAKE" V=1 dist)
+done
 
 
 # Copy to the directory that's being uploaded to buildcache

--- a/build-scripts/generate-source-tarballs
+++ b/build-scripts/generate-source-tarballs
@@ -1,5 +1,27 @@
 #!/bin/sh
 
+#
+# This script tests that the "make dist" target works on the core and masterfiles repositories on different platforms.
+# THESE TARBALLS ARE NOT MEANT TO BE RELEASED!
+#
+# The tarballs that we release are built on a dedicated build host in the bootstrap-tarballs script.
+# This script, on the other hand, is meant to be run on all hosts to make sure that make dist works everywhere.
+# However, it's currently only used in our GitHub workflows and is not a part of the Jenkins PR pipeline (I think).
+#
+# The source tarballs a built into $OUTDIR (defined in the functions script).
+#
+# The script expects the following repositories to exist side by side:
+# .
+# ├── buildscripts
+# ├── core
+# └── masterfiles
+#
+# The script can be run as follows:
+# ```
+# $ ./buildscripts/build-scripts/generate-source-tarballs
+# ```
+#
+
 . `dirname "$0"`/functions
 . detect-environment
 . compile-options


### PR DESCRIPTION
- **generate-source-tarballs: Documented script**
- **generate-source-tarballs: fixed shellcheck issues**

Example output:
```
generate-source-tarballs: debug: Running target make dist in core repository...
generate-source-tarballs: debug: Running target make dist in masterfiles repository...
```

Build with no tests:
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12420)](https://ci.cfengine.com/job/pr-pipeline/12420/)