### PR TITLE
create-empty-test: removed escape sequence from double quotes

### DIFF
--- a/build-scripts/create-empty-test
+++ b/build-scripts/create-empty-test
@@ -5,10 +5,10 @@
 # test report saying that there were no tests to report.
 
 for repo in core nova; do
-    cat << EOF > "$BASEDIR"/"$repo"/tests/unit/no_tests.xml
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<testsuite name=\"no_tests_to_report\">
-<testcase name=\"no_tests\" />
+    cat << EOF > "$BASEDIR/$repo/tests/unit/no_tests.xml"
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="no_tests_to_report">
+<testcase name="no_tests" />
 </testsuite>
 EOF
 done


### PR DESCRIPTION
After simplifying the create-empty-test script in
https://github.com/cfengine/buildscripts/pull/1815/files we no longer
need to escape the double quotes. Doing so causes the literal backslash
to be included causing the following error:

```
org.dom4j.DocumentException: Error on line 1 of document  : The value following "version" in the XML declaration must be a quoted string.
```

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Build on MinGW
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12427)](https://ci.cfengine.com/job/pr-pipeline/12427/)