### PR TITLE
run_and_print_on_failure(): fixed mktemp not found on AIX

### DIFF
--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -601,7 +601,22 @@ rm_if_empty()
 run_and_print_on_failure()
 {
     local temp_output_file
-    temp_output_file=$(mktemp)
+    if command -v mktemp >/dev/null; then
+        temp_output_file=$(mktemp)
+    else
+        # AIX 7.1 does not have mktemp
+        while true; do
+          # shellcheck disable=SC2021
+          # ^^ legacy/POSIX requires square brackets
+          temp_output_file="$(LC_CTYPE=C tr -dc "[A-Z][a-z][0-9]" </dev/urandom | dd count=1 bs=8 2>/dev/null)"
+          if [ -f "$temp_output_file" ]; then
+            continue
+          fi
+          break;
+        done
+        touch "$temp_output_file"
+    fi
+
     local exit_code=0
     if "$@" > "$temp_output_file" 2>&1; then
         : # NOOP

--- a/build-scripts/functions
+++ b/build-scripts/functions
@@ -415,7 +415,7 @@ mount_procfs()
 #     fatal "exiting with default error code"
 fatal()
 {
-    echo "FATAL ERROR: $1" >&2
+    echo "$(basename "$0"): FATAL ERROR: $1" >&2
     exit ${2-1}
 }
 


### PR DESCRIPTION
Ticket: ENT-13158
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>

Build on AIX & Ubuntu with no tests
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12464)](https://ci.cfengine.com/job/pr-pipeline/12464/)