### PR TITLE
ENT-13161: Aligned Hub package perms for share/GUI on EL and Debian platforms with the MPF (3.24)

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -373,11 +373,11 @@ exit 0
 
 # ENT-2708, ENT-2846
 %defattr(600,root,root,700)
-%prefix/share/GUI/application/config/*.php
-%prefix/share/GUI/phpcfenginenova/*.sql
-%prefix/share/GUI/phpcfenginenova/migrations
-%prefix/share/GUI/phpcfenginenova/migrations/*.sql
 %prefix/share/db/*.sql
+
+# No-one should need access to anything under share/GUI
+%defattr(400,root,root,400)
+%prefix/share/GUI
 
 # Base policy
 %defattr(644,root,root,755)

--- a/packaging/cfengine-nova-hub/debian/rules
+++ b/packaging/cfengine-nova-hub/debian/rules
@@ -95,6 +95,13 @@ install: build
 # cf-enterprise-support
 	cp $(BASEDIR)/nova/misc/cf-support-nova-hub.sh $(CURDIR)/debian/tmp$(PREFIX)/share/
 
+execute_after_dh_fixperms:
+# No-one should need access to anything under share/GUI
+	chmod 400 -R $(CURDIR)/debian/tmp$(PREFIX)/share/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/ppkeys/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/outputs/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/inputs/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/state/
 
 binary-indep: build install
 


### PR DESCRIPTION
The MPF enforces permissions of 400 and group and user ownership of root. While
the mis-alignment stabilizes, it does cause verification errors for RPM packages
that persists. This change brings the packaged permissions of share/GUI in
alignment with the MPF.

Ticket: ENT-13161