### PR TITLE
Two fixes about share/gui in packaging ENT-12658, ENT-13161 (3.21)

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -372,6 +372,9 @@ exit 0
 
 # No-one should need access to anything under share/GUI
 %defattr(400,root,root,400)
+# We can change these configuration files as part of masterfiles policy so need to mark as configs
+%config(noreplace) %prefix/share/GUI/application/config/config.php
+%config(noreplace) %prefix/share/GUI/api/modules/inventory/config/config.php
 %prefix/share/GUI
 
 # Base policy

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -368,11 +368,11 @@ exit 0
 
 # ENT-2708, ENT-2846
 %defattr(600,root,root,700)
-%prefix/share/GUI/application/config/*.php
-%prefix/share/GUI/phpcfenginenova/*.sql
-%prefix/share/GUI/phpcfenginenova/migrations
-%prefix/share/GUI/phpcfenginenova/migrations/*.sql
 %prefix/share/db/*.sql
+
+# No-one should need access to anything under share/GUI
+%defattr(400,root,root,400)
+%prefix/share/GUI
 
 # Base policy
 %defattr(644,root,root,755)

--- a/packaging/cfengine-nova-hub/debian/conffiles
+++ b/packaging/cfengine-nova-hub/debian/conffiles
@@ -1,0 +1,2 @@
+/var/cfengine/share/GUI/application/config/config.php
+/var/cfengine/share/GUI/api/modules/inventory/config/config.php

--- a/packaging/cfengine-nova-hub/debian/rules
+++ b/packaging/cfengine-nova-hub/debian/rules
@@ -98,6 +98,13 @@ install: build
 # cf-enterprise-support
 	cp $(BASEDIR)/nova/misc/cf-support-nova-hub.sh $(CURDIR)/debian/tmp$(PREFIX)/share/
 
+execute_after_dh_fixperms:
+# No-one should need access to anything under share/GUI
+	chmod 400 -R $(CURDIR)/debian/tmp$(PREFIX)/share/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/ppkeys/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/outputs/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/inputs/
+	chmod 700 $(CURDIR)/debian/tmp$(PREFIX)/state/
 
 binary-indep: build install
 


### PR DESCRIPTION
- **Aligned Hub package perms for share/GUI on EL and Debian platforms with the MPF**
- **Marked config.php files in share/GUI folder as configuration files in packages**
