### PR TITLE
Adjusted compile-options to not bundle OpenSSL on newer SuSE systems due to libpam/openssl incompatability

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -36,10 +36,18 @@ export PROJECT
 # Otherwise, we build it.
 if [ x"$SYSTEM_SSL" = x ]
 then
-    # We don't bundle OpenSSL on RHEL 8 (and newer in the future)
-    if [ "$OS" = "rhel" ] && expr "$OS_VERSION" ">=" "8" >/dev/null
+    # We don't bundle OpenSSL on some redhat-derived systems due to incompatability with libpam and our openssl.
+    _OS_MAJOR_VERSION="$(echo "$OS_VERSION" | cut -d. -f1)"
+    if [ "$OS" = "rhel" ] && expr "$_OS_MAJOR_VERSION" ">=" "8" >/dev/null
     then
         SYSTEM_SSL=1
+    fi
+    if [ "$OS" = "opensuse" ] || [ "$OS" = "sles" ]
+    then
+        if expr "$_OS_MAJOR_VERSION" ">=" "15"
+        then
+            SYSTEM_SSL=1
+        fi
     fi
     # Detect using system ssl when running a Jenkins job
     if expr x"$label" ":" ".*systemssl" >/dev/null

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -130,8 +130,8 @@ bundle agent cfengine_build_host_setup
         comment => "py3_shebang_fix macro needs /usr/bin/pathfix.py from platform-python-devel package";
 
     suse_15::
-        "openssl-devel" -> { "ENT-12528" }
-          comment => "like redhat, suse 15+ needs to build with system openssl.";
+      "libopenssl-devel" -> { "ENT-12528" }
+        comment => "like redhat, suse 15+ needs to build with system openssl.";
 
     (redhat_8|centos_8|redhat_9).(yum_dnf_conf_ok)::
       "java-1.8.0-openjdk-headless" package_policy => "delete",

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -129,6 +129,10 @@ bundle agent cfengine_build_host_setup
       "platform-python-devel" -> { "cfbs shebang", "ENT-11338" }
         comment => "py3_shebang_fix macro needs /usr/bin/pathfix.py from platform-python-devel package";
 
+    suse_15::
+        "openssl-devel" -> { "ENT-12528" }
+          comment => "like redhat, suse 15+ needs to build with system openssl.";
+
     (redhat_8|centos_8|redhat_9).(yum_dnf_conf_ok)::
       "java-1.8.0-openjdk-headless" package_policy => "delete",
         comment => "Installing Development Tools includes this jdk1.8 which we do not want.";


### PR DESCRIPTION
- **some random suse related requirements for non-aws instances**
- **Adjusted compile-options to not bundle OpenSSL on newer SuSE systems due to libpam/openssl incompatability**
