### PR TITLE
Added bullseye to list of hosts to use archive.debian.org

### DIFF
--- a/ci/distribution-patched.sh
+++ b/ci/distribution-patched.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ex
-for debian_release in stretch buster; do
+for debian_release in stretch buster bullseye; do
   if grep "CODENAME=$debian_release" /etc/os-release; then
     echo "deb http://archive.debian.org/debian-archive/debian ${debian_release} main" >/etc/apt/sources.list
     echo "deb http://archive.debian.org/debian-archive/debian ${debian_release}-backports main" >>/etc/apt/sources.list


### PR DESCRIPTION
bullseye-backports is only at archive.debian.org so use that instead of the standard locations.

Ticket: ENT-13140
Changelog: none
