### PR TITLE
Revert "Updated Java Development Kit to 21.0.8"

### DIFF
--- a/ci/linux-install-jdk21.sh
+++ b/ci/linux-install-jdk21.sh
@@ -9,15 +9,15 @@ install_jdk() {
   baseurl=https://download.oracle.com/java/21/archive/
   major_version=21
   baseurl="https://download.oracle.com/java/${major_version}/archive/"
-  version=21.0.8
+  version=21.0.7
   if uname -m | grep aarch64; then
     tarball=jdk-${version}_linux-aarch64_bin.tar.gz
     # checksum from https://download.oracle.com/java/${major_version}/archive/jdk-${version}_linux-aarch64_bin.tar.gz.sha256
-    sha=708064ee3a1844245d83be483ff42cc9ca0c482886a98be7f889dff69ac77850
+    sha=47372cfa9244dc74ec783a1b287381502419b564fbd0b18abc8f2d6b19ac865e
   else
     tarball=jdk-${version}_linux-x64_bin.tar.gz
     # checksum from https://download.oracle.com/java/${major_version}/latest/jdk-${version}_linux-x64_bin.tar.gz.sha256
-    sha=d87272944278713fc7a120cf024d2818d136b5debc750aa17045e3c6f045b867
+    sha=267b10b14b4e5fada19aca3be3b961ce4f81f1bd3ffcd070e90a5586106125eb
   fi
   wget --quiet "$baseurl$tarball"
   echo "$sha  $tarball" | sha256sum --check -


### PR DESCRIPTION
This reverts commit 5d24969295d5c9c3b4976b3d0e05968d28ac7dd9.

We need latest minor -1, so 21.0.8 is latest but not in /archive/ so we need to stick with 21.0.7 for now.
