### PR TITLE
 ENT-11481: Removed web server redirect from http to https 

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -259,10 +259,6 @@ SetHandler "proxy:fcgi://127.0.0.1:9000"
   <IfModule rewrite_module>
     RewriteEngine On
 
-    # Force https with redirection
-    RewriteCond %{HTTPS} off
-    RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-
     # redirect from `index.php/path` to `/path`
     RewriteCond %{REQUEST_URI} !(.*)/api/(.*) [NC]  #do not apply redirect to internal APIs for backward compatibility
     RewriteCond %{THE_REQUEST} /index\.php/(.+)\sHTTP [NC]


### PR DESCRIPTION
HTTP_HOST can be manipulated via Host header and for this reason http to https redirect will be handled on the UI.

Ticket: ENT-11481
Signed-off-by: Ihor Aleksandrychiev <ihor.aleksandrychiev@northern.tech>

together: https://github.com/cfengine/mission-portal/pull/2906