### PR TITLE
ENT-13008: Added symlinks to CFEngine binaries in `/usr/sbin` for RHEL packages

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -77,6 +77,14 @@ rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-hub.service
 rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-reactor.service
 rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
 
+# Create symlinks to /usr/local/sbin and /usr/sbin
+mkdir -p $RPM_BUILD_ROOT/usr/local/sbin
+mkdir -p $RPM_BUILD_ROOT/usr/sbin
+for binary in cf-agent cf-check cf-execd cf-key cf-monitord cf-net cf-promises cf-runagent cf-secret cf-serverd cf-support; do
+  ln -sf %{prefix}/bin/$binary $RPM_BUILD_ROOT/usr/local/sbin/$binary
+  ln -sf %{prefix}/bin/$binary $RPM_BUILD_ROOT/usr/sbin/$binary
+done
+
 %clean
 #rm -rf $RPM_BUILD_ROOT
 
@@ -155,6 +163,33 @@ rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-serverd.service
+
+# Symlinks to /usr/local/sbin (backward compatibility)
+%defattr(755,root,root,755)
+/usr/local/sbin/cf-agent
+/usr/local/sbin/cf-check
+/usr/local/sbin/cf-execd
+/usr/local/sbin/cf-key
+/usr/local/sbin/cf-monitord
+/usr/local/sbin/cf-net
+/usr/local/sbin/cf-promises
+/usr/local/sbin/cf-runagent
+/usr/local/sbin/cf-secret
+/usr/local/sbin/cf-serverd
+/usr/local/sbin/cf-support
+
+# Symlinks to /usr/sbin (included in secure_path)
+/usr/sbin/cf-agent
+/usr/sbin/cf-check
+/usr/sbin/cf-execd
+/usr/sbin/cf-key
+/usr/sbin/cf-monitord
+/usr/sbin/cf-net
+/usr/sbin/cf-promises
+/usr/sbin/cf-runagent
+/usr/sbin/cf-secret
+/usr/sbin/cf-serverd
+/usr/sbin/cf-support
 
 # Documentation
 %defattr(644,root,root,755)

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -186,6 +186,16 @@ rm -rf $RPM_BUILD_ROOT/tmp/cfbs_root
 # Add cf-enterprise-support to share
 cp %{_basedir}/nova/misc/cf-support-nova-hub.sh $RPM_BUILD_ROOT%prefix/share/
 chmod 755 $RPM_BUILD_ROOT%prefix/share/cf-support-nova-hub.sh
+
+# Create symlinks to /usr/local/sbin and /usr/sbin
+mkdir -p $RPM_BUILD_ROOT/usr/local/sbin
+mkdir -p $RPM_BUILD_ROOT/usr/sbin
+for binary in cf-agent cf-check cf-execd cf-hub cf-key cf-monitord cf-net cf-promises cf-reactor cf-runagent cf-secret cf-serverd cf-support cfbs; do
+  if [ -f $RPM_BUILD_ROOT%{prefix}/bin/$binary ]; then
+    ln -sf %{prefix}/bin/$binary $RPM_BUILD_ROOT/usr/local/sbin/$binary
+    ln -sf %{prefix}/bin/$binary $RPM_BUILD_ROOT/usr/sbin/$binary
+  fi
+done
 %clean
 #rm -rf $RPM_BUILD_ROOT
 
@@ -355,6 +365,43 @@ exit 0
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-postgres.service
 /usr/lib/systemd/system/cf-serverd.service
+
+# Symlinks to /usr/local/sbin (backward compatibility)
+%defattr(755,root,root,755)
+/usr/local/sbin/cf-agent
+/usr/local/sbin/cf-check
+/usr/local/sbin/cf-execd
+/usr/local/sbin/cf-hub
+/usr/local/sbin/cf-key
+/usr/local/sbin/cf-monitord
+/usr/local/sbin/cf-net
+/usr/local/sbin/cf-promises
+/usr/local/sbin/cf-reactor
+/usr/local/sbin/cf-runagent
+/usr/local/sbin/cf-secret
+/usr/local/sbin/cf-serverd
+/usr/local/sbin/cf-support
+%if %{?rhel}%{!?rhel:0} >= 7
+/usr/local/sbin/cfbs
+%endif
+
+# Symlinks to /usr/sbin (included in secure_path)
+/usr/sbin/cf-agent
+/usr/sbin/cf-check
+/usr/sbin/cf-execd
+/usr/sbin/cf-hub
+/usr/sbin/cf-key
+/usr/sbin/cf-monitord
+/usr/sbin/cf-net
+/usr/sbin/cf-promises
+/usr/sbin/cf-reactor
+/usr/sbin/cf-runagent
+/usr/sbin/cf-secret
+/usr/sbin/cf-serverd
+/usr/sbin/cf-support
+%if %{?rhel}%{!?rhel:0} >= 7
+/usr/sbin/cfbs
+%endif
 
 %if %{?rhel}%{!?rhel:0} > 7
 # SELinux policy

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -85,6 +85,14 @@ rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-hub.service
 rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-reactor.service
 rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
 
+# Create symlinks to /usr/local/sbin and /usr/sbin
+mkdir -p $RPM_BUILD_ROOT/usr/local/sbin
+mkdir -p $RPM_BUILD_ROOT/usr/sbin
+for binary in cf-agent cf-check cf-execd cf-key cf-monitord cf-net cf-promises cf-runagent cf-secret cf-serverd cf-support; do
+  ln -sf %{prefix}/bin/$binary $RPM_BUILD_ROOT/usr/local/sbin/$binary
+  ln -sf %{prefix}/bin/$binary $RPM_BUILD_ROOT/usr/sbin/$binary
+done
+
 
 %clean
 #rm -rf $RPM_BUILD_ROOT
@@ -179,6 +187,33 @@ exit 0
 /usr/lib/systemd/system/cf-execd.service
 /usr/lib/systemd/system/cf-monitord.service
 /usr/lib/systemd/system/cf-serverd.service
+
+# Symlinks to /usr/local/sbin (backward compatibility)
+%defattr(755,root,root,755)
+/usr/local/sbin/cf-agent
+/usr/local/sbin/cf-check
+/usr/local/sbin/cf-execd
+/usr/local/sbin/cf-key
+/usr/local/sbin/cf-monitord
+/usr/local/sbin/cf-net
+/usr/local/sbin/cf-promises
+/usr/local/sbin/cf-runagent
+/usr/local/sbin/cf-secret
+/usr/local/sbin/cf-serverd
+/usr/local/sbin/cf-support
+
+# Symlinks to /usr/sbin (included in secure_path)
+/usr/sbin/cf-agent
+/usr/sbin/cf-check
+/usr/sbin/cf-execd
+/usr/sbin/cf-key
+/usr/sbin/cf-monitord
+/usr/sbin/cf-net
+/usr/sbin/cf-promises
+/usr/sbin/cf-runagent
+/usr/sbin/cf-secret
+/usr/sbin/cf-serverd
+/usr/sbin/cf-support
 
 # Documentation
 %defattr(644,root,root,755)

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -276,7 +276,8 @@ for i in cf-agent cf-promises cf-key cf-secret cf-execd cf-serverd cf-monitord c
          cf-net cf-check cf-support \
          cfbs;
 do
-  if [ -f $PREFIX/bin/$i -a -d /usr/local/sbin ]; then
+  if [ `os_type` != redhat ] && [ -x $PREFIX/bin/$i ] && [ -d /usr/local/sbin ]; then
+    # These links are handled in .spec file for RedHat
     ln -sf $PREFIX/bin/$i /usr/local/sbin/$i || true
   fi
   if [ -f /usr/share/man/man8/$i.8.gz ]; then

--- a/packaging/common/cfengine-hub/postremove.sh
+++ b/packaging/common/cfengine-hub/postremove.sh
@@ -26,10 +26,12 @@ if [ -f /usr/lib64/php5/extensions/cfmod.so ]; then
     rm -f /usr/lib64/php5/extensions/cfengine-enterprise-api.so
 fi
 
-for i in cf-agent cf-key cf-secret cf-promises cf-execd cf-serverd cf-monitord cf-net cf-check cf-support;
-do
+if [ `os_type` != redhat ]; then
+  # These links are handled in .spec file for RedHat
+  for i in cf-agent cf-key cf-secret cf-promises cf-execd cf-serverd cf-monitord cf-net cf-check cf-support; do
     rm -f /usr/local/sbin/$i || true
-done
+  done
+fi
 
 # unload SELinux policy if not upgrading
 if ! is_upgrade; then

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -47,7 +47,8 @@ fi
 mkdir -p /usr/local/sbin
 for i in cf-agent cf-promises cf-key cf-secret cf-execd cf-serverd cf-monitord cf-runagent cf-net cf-check cf-support;
 do
-  if [ -f $PREFIX/bin/$i ]; then
+  if [ `os_type` != redhat ] && [ -x $PREFIX/bin/$i ]; then
+    # These links are handled in .spec file for RedHat
     ln -sf $PREFIX/bin/$i /usr/local/sbin/$i || true
   fi
 

--- a/packaging/common/cfengine-non-hub/postremove.sh
+++ b/packaging/common/cfengine-non-hub/postremove.sh
@@ -7,12 +7,11 @@ case `os_type` in
     ;;
 esac
 
-if [ -d /usr/local/sbin ]; then
-  rm -f /usr/local/sbin/cf-agent /usr/local/sbin/cf-check /usr/local/sbin/cf-execd \
-    /usr/local/sbin/cf-key /usr/local/sbin/cf-secret /usr/local/sbin/cf-know /usr/local/sbin/cf-monitord \
-    /usr/local/sbin/cf-net /usr/local/sbin/cf-support \
-    /usr/local/sbin/cf-promises /usr/local/sbin/cf-report /usr/local/sbin/cf-runagent \
-    /usr/local/sbin/cf-serverd /usr/local/sbin/cf-twin /usr/local/sbin/cf-hub /usr/local/sbin/cf-reactor > /dev/null 2>&1
+if [ `os_type` != redhat ]; then
+  # These links are handled in .spec file for RedHat
+  for i in cf-agent cf-promises cf-key cf-secret cf-execd cf-serverd cf-monitord cf-runagent cf-net cf-check cf-support; do
+    rm -f /usr/local/sbin/$i || true
+  done
 fi
 
 # unload SELinux policy if not upgrading


### PR DESCRIPTION
- Moved creation of CFEngine binary symlinks in `/usr/local/bin` to RPM spec files
- Added new to CFEngine binary symlinks in `/usr/sbin` which is part of secure path

**Motivation:** RHEL uses a secure path when running sudo commands, which does not include `/usr/local/sbin`. This means cf-* binaries are not found when invoked via sudo. By adding symlinks to `/usr/sbin` (which is in the secure path), the binaries become accessible via sudo.  We maintain backward compatibility by keeping the `/usr/local/sbin` symlinks as well.

Build (redhat only):
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=12785)](https://ci.cfengine.com/job/pr-pipeline/12785/)