### PR TITLE
ENT-11481: Removed web server redirect from http to https (3.24.x)

### DIFF
--- a/deps-packaging/apache/httpd.conf
+++ b/deps-packaging/apache/httpd.conf
@@ -251,10 +251,6 @@ AddType    application/x-httpd-php-source php
   <IfModule rewrite_module>
     RewriteEngine On
 
-    # Force https with redirection
-    RewriteCond %{HTTPS} off
-    RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-
     # redirect from `index.php/path` to `/path`
     RewriteCond %{REQUEST_URI} !(.*)/api/(.*) [NC]  #do not apply redirect to internal APIs for backward compatibility
     RewriteCond %{THE_REQUEST} /index\.php/(.+)\sHTTP [NC]


### PR DESCRIPTION
HTTP_HOST can be manipulated via Host header and for this reason http to https redirect will be handled on the UI.

Ticket: ENT-11481

(cherry picked from commit ac7b17c51e713063b7d3bec1d5a368ffa84b0bae)