### PR TITLE
ENT-13277: Adjusted detection of systemd in package scriptlets to handle more valid states

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -29,7 +29,7 @@ systemctl restart cfengine3"
   fi
 fi
 
-if command -v systemctl 2>/dev/null && systemctl is-system-running; then
+if use_systemd; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
   if ! /bin/systemctl daemon-reload; then
@@ -1073,7 +1073,7 @@ chmod g+rX "$PREFIX/httpd/php"
 # Register CFEngine initscript, if not yet.
 #
 if ! is_upgrade; then
-  if command -v systemctl 2>/dev/null && systemctl is-system-running; then
+  if use_systemd; then
     # Reload systemd config to pick up newly installed units
     /bin/systemctl daemon-reload > /dev/null 2>&1
     # Enable cfengine3 service (starts all the other services)

--- a/packaging/common/cfengine-hub/preinstall.sh
+++ b/packaging/common/cfengine-hub/preinstall.sh
@@ -136,7 +136,7 @@ fi
 if is_upgrade; then
   cf_console platform_service cfengine3 stop
   # CFE-2278: Migrate to split units
-  if [ -x /bin/systemctl ] && [ -e /usr/lib/systemd/system/cfengine3-web.service ]; then
+  if use_systemd && [ -e /usr/lib/systemd/system/cfengine3-web.service ]; then
     # When using systemd, the services are split in two, and although both will
     # stop due to the command above, the web part may only do so after some
     # delay, which may cause problems in an upgrade situation, since this script

--- a/packaging/common/cfengine-hub/preremove.sh
+++ b/packaging/common/cfengine-hub/preremove.sh
@@ -1,5 +1,5 @@
 cf_console platform_service cfengine3 stop
-if [ -x /bin/systemctl ] && [ -e /usr/lib/systemd/system/cfengine3-web.service ]; then
+if use_systemd && [ -e /usr/lib/systemd/system/cfengine3-web.service ]; then
   # When using systemd, the services are split in two, and although both will
   # stop due to the command above, the web part may only do so after some
   # delay, which may cause problems later if the binaries are gone by the time

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -1,4 +1,4 @@
-if command -v systemctl 2>/dev/null && systemctl is-system-running; then
+if use_systemd; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
   if ! /bin/systemctl daemon-reload; then
@@ -69,7 +69,7 @@ case `os_type` in
     #
     # Register CFEngine initscript, if not yet.
     #
-    if command -v systemctl 2>/dev/null && systemctl is-system-running; then
+    if use_systemd; then
       # Reload systemd config to pick up newly installed units
       /bin/systemctl daemon-reload > /dev/null 2>&1
       # Enable cfengine3 service (starts all the other services)

--- a/packaging/common/cfengine-non-hub/preremove.sh
+++ b/packaging/common/cfengine-non-hub/preremove.sh
@@ -10,7 +10,7 @@ case `os_type` in
     #
     # systemd support
     #
-    test -x /bin/systemctl && systemctl disable cfengine3.service > /dev/null 2>&1
+    use_systemd && systemctl disable cfengine3.service > /dev/null 2>&1
 
     #
     # Clean lock files created by initscript, if any

--- a/packaging/common/produce-script
+++ b/packaging/common/produce-script
@@ -6,6 +6,7 @@
 # type = <deb|rpm|depot|bff|pkg>
 # action = <install|remove>
 #
+# script-header.sh
 # <type>-script-common.sh
 # <type>-script-common-<action>.sh
 # script-common.sh
@@ -33,6 +34,7 @@ include_script()
   fi
 }
 
+include_script "$TEMPLATEDIR/script-header.sh"
 include_script "$TEMPLATEDIR/$PKG_TYPE-script-common.sh"
 
 case "$PKG_TYPE" in

--- a/packaging/common/script-templates/deb-script-common.sh
+++ b/packaging/common/script-templates/deb-script-common.sh
@@ -19,7 +19,7 @@ rc_d_path()
 
 platform_service()
 {
-  if [ -x /bin/systemctl ]; then
+  if use_systemd; then
     /bin/systemctl "$2" "$1".service
   else
     /etc/init.d/"$1" "$2"

--- a/packaging/common/script-templates/rpm-script-common.sh
+++ b/packaging/common/script-templates/rpm-script-common.sh
@@ -27,7 +27,7 @@ rc_d_path()
 
 platform_service()
 {
-  if [ -x /bin/systemctl ]; then
+  if use_systemd; then
     /bin/systemctl "$2" "$1".service
   else
     `rc_d_path`/init.d/"$1" "$2"

--- a/packaging/common/script-templates/script-common.sh
+++ b/packaging/common/script-templates/script-common.sh
@@ -29,7 +29,7 @@ case "$PKG_TYPE" in
 esac
 
 get_cfengine_state() {
-    if type systemctl >/dev/null 2>&1; then
+    if use_systemd; then
         systemctl list-units -l | sed -r -e '/^\s*(cf-[-a-z]+|cfengine3)\.service/!d' -e 's/\s*(cf-[-a-z]+|cfengine3)\.service.*/\1/'
     else
         platform_service cfengine3 status | awk '/is running/ { print $1 }'
@@ -39,7 +39,7 @@ get_cfengine_state() {
 restore_cfengine_state() {
     # $1 -- file where the state to restore is saved (see get_cfengine_state())
 
-    if type systemctl >/dev/null 2>&1; then
+    if use_systemd; then
         for service in `cat "$1"`; do
             definition=`systemctl cat "$service"` || continue
             # only try to start service that are defined/exist (some may be gone

--- a/packaging/common/script-templates/script-header.sh
+++ b/packaging/common/script-templates/script-header.sh
@@ -1,0 +1,19 @@
+USE_SYSTEMD=0
+_use_systemd=$(command -v systemctl 2>&1 >/dev/null && systemctl is-system-running)
+case "$_use_systemd" in
+  offline|unknown)
+    USE_SYSTEMD=0
+    ;;
+  "")
+    USE_SYSTEMD=0
+    ;;
+  *)
+    USE_SYSTEMD=1
+    ;;
+esac
+
+use_systemd()
+{
+  test $USE_SYSTEMD = 1
+}
+


### PR DESCRIPTION
In the case where a package is installed but not bootstrapped several of the components: cf-execd, cf-monitord, cf-serverd will not be able to start due to lack of ${sys.inputs}/promises.cf.
This will cause the `systemctl is-system-running` command to return `degraded` and a non-zero exit code.

Previously this would cause the cfengine3 service to not be enabled as part of the package install and so on reboots services would not be running.

Ticket: ENT-13277
Changelog: title
