### PR TITLE
ENT-12603: autogen: removed ./ prefix when executing other scripts

### DIFF
--- a/build-scripts/autogen
+++ b/build-scripts/autogen
@@ -67,8 +67,8 @@ done
 
 # Create revision files (containing the N first hex decimals from the last
 # commit of the current branch)
-./"$(dirname "$0")/revision-file"
+"$(dirname "$0")/revision-file"
 
 # Compare versions between the CFEngine repositories to make sure they
 # match
-./"$(dirname "$0")/compare-versions"
+"$(dirname "$0")/compare-versions"


### PR DESCRIPTION
It's not needed, and becomes problematic when executing build-remote
using an absolute path.

Ticket: ENT-12603
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
