### PR TITLE
ENT-12603: build-remote: adjust destination directory

### DIFF
--- a/build-scripts/clean-results
+++ b/build-scripts/clean-results
@@ -27,6 +27,6 @@
 # The `xargs` puts each line as the argument of `rm -rf` to remove the remaining
 # files
 
-(cd "${BASEDIR}/../../../output/${SCHEDULER}" &&
+(cd "${BASEDIR}/output/${SCHEDULER}" &&
     find . -mindepth 1 -maxdepth 1 -type d -and -not -name '.*' -printf '%T@ %f\n' |
     sort -n | head -n-5 | awk '{print $2}' | xargs --no-run-if-empty rm -rf) || true

--- a/build-scripts/install-results
+++ b/build-scripts/install-results
@@ -8,7 +8,7 @@
 . "$(dirname "$0")"/functions
 . version
 
-LNK="$BASEDIR/../../../output/$SCHEDULER/current"
+LNK="$BASEDIR/output/$SCHEDULER/current"
 log_debug "Creating soft link from $BUILD_NUMBER to $LNK"
 rm -f "$LNK"
 ln -fs "$BUILD_NUMBER" "$LNK"

--- a/build-scripts/transfer-results
+++ b/build-scripts/transfer-results
@@ -8,11 +8,11 @@ log_debug "Fetching test results from build machine..."
 BUILDMACHINE="$1"
 
 # Make sure destination directory exits
-mkdir -p "$BASEDIR"/../../../output/"${SCHEDULER}"/"${BUILD_NUMBER}"
+mkdir -p "$BASEDIR"/output/"${SCHEDULER}"/"${BUILD_NUMBER}"
 
 # Copy files from test machine to this machine
 rsync -avr --delete "$BUILDMACHINE:build/output/*" \
-    "$BASEDIR"/../../../output/"${SCHEDULER}"/"${BUILD_NUMBER}" \
+    "$BASEDIR"/output/"${SCHEDULER}"/"${BUILD_NUMBER}" \
     >/tmp/rsync.log
 
 # Remove results from test machine


### PR DESCRIPTION
The previous path would cause build-remote to try to make the directory `/output/`. `/` is owned by root. Hence, permissions is denied. I think it makes more sense to put these files in `$BASEDIR/output/`.

These scripts are only used by build-remote. Hence, this change should be rather safe.

Ticket: ENT-12603
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
