### PR TITLE
ENT-13496: Use SYSTEM_SSL variable instead of hardcoded RHEL version check

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -23,8 +23,8 @@ Recommends: gzip
 Requires: selinux-policy >= @@SELINUX_POLICY_VERSION@@
 %endif
 
-# we don't bundle OpenSSL on RHEL 8 (and newer in the future)
-%if %{?rhel}%{!?rhel:0} == 8
+# We don't bundle OpenSSL on RHEL >= 8 and SuSE >= 15
+%if 0%{?SYSTEM_SSL}
 Requires: libssl.so.1.1()(64bit) libssl.so.1.1(OPENSSL_1_1_0)(64bit) libssl.so.1.1(OPENSSL_1_1_1)(64bit)
 Requires: libcrypto.so.1.1()(64bit) libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)
 %endif


### PR DESCRIPTION
Replace the hardcoded RHEL 8 check with the SYSTEM_SSL variable to
determine whether to use system-provided OpenSSL libraries. This makes
the build configuration more flexible and allows the same logic to be
applied across different platforms based on build configuration rather
than being tied to a specific RHEL version.

This change enables using system SSL on SuSE 15 in addition to RHEL 8.

Ticket: ENT-13496
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
