### PR TITLE
Adjusted RPM packaging to be avoid failed installs when selinux-policy version is not sufficient (3.24)

### DIFF
--- a/packaging/cfengine-community/cfengine-community.spec.in
+++ b/packaging/cfengine-community/cfengine-community.spec.in
@@ -138,6 +138,7 @@ rm -rf $RPM_BUILD_ROOT/usr/lib/systemd/system/cf-postgres.service
 %prefix/selinux/cfengine-enterprise.pp
 %prefix/selinux/cfengine-enterprise.te
 %prefix/selinux/cfengine-enterprise.fc
+%prefix/selinux/label-binaries-unconfined.sh
 %endif
 
 # Globally installed configs, scripts

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -354,6 +354,10 @@ exit 0
 %prefix/selinux/cfengine-enterprise.pp
 %prefix/selinux/cfengine-enterprise.te
 %prefix/selinux/cfengine-enterprise.fc
+%prefix/selinux/cfengine-enterprise-unconfined.pp
+%prefix/selinux/cfengine-enterprise-unconfined.te
+%prefix/selinux/cfengine-enterprise-unconfined.fc
+%prefix/selinux/label-binaries-unconfined.sh
 %endif
 
 # Documentation

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -20,7 +20,8 @@ Recommends: gzip
 # we require selinux-policy package version that matches or exceeds our build system version
 # this guarantees that our compiled selinux policy will work.
 %if %{?rhel}%{!?rhel:0} >= 8
-Requires: selinux-policy >= @@SELINUX_POLICY_VERSION@@
+Requires(post): selinux-policy >= @@SELINUX_POLICY_VERSION@@
+%define SELINUX_POLICY_VERSION=@@SELINUX_POLICY_VERSION@@
 %endif
 
 # we don't bundle OpenSSL on RHEL 8 (and newer in the future)

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -162,6 +162,10 @@ exit 0
 %prefix/selinux/cfengine-enterprise.pp
 %prefix/selinux/cfengine-enterprise.te
 %prefix/selinux/cfengine-enterprise.fc
+%prefix/selinux/cfengine-enterprise-unconfined.pp
+%prefix/selinux/cfengine-enterprise-unconfined.te
+%prefix/selinux/cfengine-enterprise-unconfined.fc
+%prefix/selinux/label-binaries-unconfined.sh
 %endif
 
 # Globally installed configs, scripts

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -163,10 +163,6 @@ exit 0
 %prefix/selinux/cfengine-enterprise.pp
 %prefix/selinux/cfengine-enterprise.te
 %prefix/selinux/cfengine-enterprise.fc
-%prefix/selinux/cfengine-enterprise-unconfined.pp
-%prefix/selinux/cfengine-enterprise-unconfined.te
-%prefix/selinux/cfengine-enterprise-unconfined.fc
-%prefix/selinux/label-binaries-unconfined.sh
 %endif
 
 # Globally installed configs, scripts

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -10,11 +10,16 @@ then
     test -x /usr/sbin/load_policy  || cf_console echo "warning: selinuxenabled exists and returns 0 but load_policy not found"
     test -x /usr/sbin/restorecon   || cf_console echo "warning: selinuxenabled exists and returns 0 but restorecon not found"
   fi
-  if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise.pp"; then
+  if cf_console semodule --list-modules | grep cfengine-enterprise-unconfined; then
+    if ! cf_console semodule --remove cfengine-enterprise-unconfined; then
+      cf_console echo "warning: unable to remove cfengine-enterprise-unconfined selinux module. The next steps may not work as well given this failure."
+    fi
+  fi
+  if ! cf_console semodule --noreload --install "$PREFIX/selinux/cfengine-enterprise.pp"; then
     cf_console echo "warning: cfengine-enterprise semodule install failed, will attempt to install cfengine-enterprise-unconfined instead. \
 The install failure should be examined in /var/log/CFEngine-Install.log and any issues reported as bugs at https://northerntech.atlassian.net/jira/software/c/projects/CFE/issues/."
 
-    if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise-unconfined.pp"; then
+    if ! cf_console semodule --noreload --install "$PREFIX/selinux/cfengine-enterprise-unconfined.pp"; then
       cf_console echo "warning: cfengine-enterprise-unconfined semodule failed to install. As a last attempt you can install the semanage program (probably policycoreutils-python-utils package) and run $PREFIX/selinux/label-binaries-unconfined.sh."
     else
       cf_console echo "info: cfengine-enterprise-unconfined semodule is installed. This allows CFEngine binaries to run unconfined which is not ideal. Please report issues with default cfengine-enterprise selinux module."

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -6,22 +6,19 @@ then
   if command -v /usr/sbin/selinuxenabled >/dev/null &&
       /usr/sbin/selinuxenabled;
   then
-    command -v semodule >/dev/null || cf_console echo "warning! selinuxenabled exists and returns 0 but semodule not found"
-    test -x /usr/sbin/load_policy  || cf_console echo "warning! selinuxenabled exists and returns 0 but load_policy not found"
-    test -x /usr/sbin/restorecon   || cf_console echo "warning! selinuxenabled exists and returns 0 but restorecon not found"
+    command -v semodule >/dev/null || cf_console echo "warning: selinuxenabled exists and returns 0 but semodule not found"
+    test -x /usr/sbin/load_policy  || cf_console echo "warning: selinuxenabled exists and returns 0 but load_policy not found"
+    test -x /usr/sbin/restorecon   || cf_console echo "warning: selinuxenabled exists and returns 0 but restorecon not found"
   fi
   if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise.pp"; then
-    cf_console echo "warning! semodule import failed, examine /var/log/CFE*log and \
-consider installing selinux-policy-devel package and \
-rebuilding policy with: \
-\
-cd $PREFIX/selinux \
-make -f /usr/share/selinux/devel/Makefile -j1 \
-semodule -n -i $PREFIX/selinux/cfengine-enterprise.pp \
-\
-and then restarting services with  \
-\
-systemctl restart cfengine3"
+    cf_console echo "warning: cfengine-enterprise semodule install failed, will attempt to install cfengine-enterprise-unconfined instead. \
+The install failure should be examined in /var/log/CFEngine-Install.log and any issues reported as bugs at https://northerntech.atlassian.net/jira/software/c/projects/CFE/issues/."
+
+    if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise-unconfined.pp"; then
+      cf_console echo "warning: cfengine-enterprise-unconfined semodule failed to install. As a last attempt you can install the semanage program (probably policycoreutils-python-utils package) and run $PREFIX/selinux/label-binaries-unconfined.sh."
+    else
+      cf_console echo "info: cfengine-enterprise-unconfined semodule is installed. This allows CFEngine binaries to run unconfined which is not ideal. Please report issues with default cfengine-enterprise selinux module."
+    fi
   fi
   if /usr/sbin/selinuxenabled; then
     /usr/sbin/load_policy
@@ -33,7 +30,7 @@ if [ -x /bin/systemctl ]; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
   if ! /bin/systemctl daemon-reload; then
-    cf_console echo "warning! /bin/systemctl daemon-reload failed."
+    cf_console echo "warning: /bin/systemctl daemon-reload failed."
     cf_console echo "systemd seems to be installed, but not working."
     cf_console echo "Relevant parts of CFEngine installation will fail."
     cf_console echo "Please fix systemd or use other ways to start CFEngine."

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -125,7 +125,12 @@ then
     test -x /usr/sbin/restorecon   || cf_console echo "warning: selinuxenabled exists and returns 0 but restorecon not found"
 
   fi
-  if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise.pp"; then
+  if cf_console semodule --list-modules | grep cfengine-enterprise-unconfined; then
+    if ! cf_console semodule --remove cfengine-enterprise-unconfined; then
+      cf_console echo "warning: unable to remove cfengine-enterprise-unconfined selinux module. The next steps may not work as well given this failure."
+    fi
+  fi
+  if ! cf_console semodule --noreload --install "$PREFIX/selinux/cfengine-enterprise.pp"; then
     cf_console echo "warning: cfengine-enterprise semodule install failed, will attempt to install cfengine-enterprise-unconfined instead. \
 The install failure should be examined in /var/log/CFEngine-Install.log and any issues reported as bugs at https://northerntech.atlassian.net/jira/software/c/projects/CFE/issues/."
 

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -2,7 +2,7 @@ if [ -x /bin/systemctl ]; then
   # This is important in case any of the units have been replaced by the package
   # and we call them in the postinstall script.
   if ! /bin/systemctl daemon-reload; then
-    cf_console echo "warning! /bin/systemctl daemon-reload failed."
+    cf_console echo "warning: /bin/systemctl daemon-reload failed."
     cf_console echo "systemd seems to be installed, but not working."
     cf_console echo "Relevant parts of CFEngine installation will fail."
     cf_console echo "Please fix systemd or use other ways to start CFEngine."
@@ -120,23 +120,20 @@ then
   if command -v /usr/sbin/selinuxenabled >/dev/null &&
       /usr/sbin/selinuxenabled;
   then
-    command -v semodule >/dev/null || cf_console echo "warning! selinux exists and returns 0 but semodule not found"
-    test -x /usr/sbin/load_policy  || cf_console echo "warning! selinuxenabled exists and returns 0 but load_policy not found"
-    test -x /usr/sbin/restorecon   || cf_console echo "warning! selinuxenabled exists and returns 0 but restorecon not found"
+    command -v semodule >/dev/null || cf_console echo "warning: selinux exists and returns 0 but semodule not found"
+    test -x /usr/sbin/load_policy  || cf_console echo "warning: selinuxenabled exists and returns 0 but load_policy not found"
+    test -x /usr/sbin/restorecon   || cf_console echo "warning: selinuxenabled exists and returns 0 but restorecon not found"
 
   fi
   if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise.pp"; then
-    cf_console echo "warning! semodule import failed, examine /var/log/CFE*log and \
-consider installing selinux-policy-devel package and \
-rebuilding policy with: \
-\
-cd $PREFIX/selinux \
-make -f /usr/share/selinux/devel/Makefile -j1 \
-semodule -n -i $PREFIX/selinux/cfengine-enterprise.pp \
-\
-and then restarting services with  \
-\
-systemctl restart cfengine3"
+    cf_console echo "warning: cfengine-enterprise semodule install failed, will attempt to install cfengine-enterprise-unconfined instead. \
+The install failure should be examined in /var/log/CFEngine-Install.log and any issues reported as bugs at https://northerntech.atlassian.net/jira/software/c/projects/CFE/issues/."
+
+    if ! cf_console semodule -n -i "$PREFIX/selinux/cfengine-enterprise-unconfined.pp"; then
+      cf_console echo "warning: cfengine-enterprise-unconfined semodule failed to install. As a last attempt you can install the semanage program (probably policycoreutils-python-utils package) and run $PREFIX/selinux/label-binaries-unconfined.sh."
+    else
+      cf_console echo "info: cfengine-enterprise-unconfined semodule is installed. This allows CFEngine binaries to run unconfined which is not ideal. Please report issues with default cfengine-enterprise selinux module."
+    fi
   fi
   if /usr/sbin/selinuxenabled; then
     /usr/sbin/load_policy

--- a/packaging/common/cfengine-non-hub/preinstall.sh
+++ b/packaging/common/cfengine-non-hub/preinstall.sh
@@ -1,3 +1,5 @@
+cf_console "CRAIG sees that selinux-policy installed package is $(rpm -qa selinux-policy)"
+cf_console "CRAIG looks for SELINUX_POLICY_VERSION, finds ${SELINUX_POLICY_VERSION}"
 if is_upgrade; then
   # This is nice to know to provide fixes for bugs in already released
   # package scripts.


### PR DESCRIPTION
As a workaround, if the cfengine-enterprise selinux module fails to install we set binaries to unconfined domain with bin_t type.

Ticket: ENT-12980
Changelog: title
(cherry picked from commit 190c97449960af62b2465b1f0b2a866c683a6a47)

together
https://github.com/cfengine/buildscripts/pull/2037

https://github.com/cfengine/core/pull/5945