### PR TITLE
Fixed bad quoting of variable expansions

### DIFF
--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -95,19 +95,28 @@ INCLUDES='--include=test.* --include=summary.*'
 # Note: Don't use sudo or "rsync -a", because we don't want root-owned files
 # to show up in the results.
 log_debug "Collecting test results from core repo..."
-rsync -rv "$INCLUDES" --exclude="*" \
+# shellcheck disable=SC2086
+# > Double quote to prevent globbing and word splitting.
+# We want word splitting
+rsync -rv $INCLUDES --exclude="*" \
     "$TESTMACHINE_URI$BASEDIR"/core/tests/acceptance/ \
     "$BASEDIR"/core/tests/acceptance/ \
     >>/tmp/rsync.log
 
 if [ "$PROJECT" = nova ]; then
     log_debug "Collecting test results from enterprise repo..."
-    rsync -rv "$INCLUDES" --exclude="*" \
+    # shellcheck disable=SC2086
+    # > Double quote to prevent globbing and word splitting.
+    # We want word splitting
+    rsync -rv $INCLUDES --exclude="*" \
         "$TESTMACHINE_URI$BASEDIR"/enterprise/tests/acceptance/ \
         "$BASEDIR"/enterprise/tests/acceptance/ \
         >>/tmp/rsync.log
     log_debug "Collecting test results from masterfiles repo..."
-    rsync -rv "$INCLUDES" --exclude="*" \
+    # shellcheck disable=SC2086
+    # > Double quote to prevent globbing and word splitting.
+    # We want word splitting
+    rsync -rv $INCLUDES --exclude="*" \
         "$TESTMACHINE_URI$BASEDIR"/masterfiles/tests/acceptance/ \
         "$BASEDIR"/masterfiles/tests/acceptance/ \
         >>/tmp/rsync.log


### PR DESCRIPTION
You would normally use double quotes when expanding variables to prevent
word splitting. However, these variables contain options to `rsync`,
hence we want word splitting to occur.

This should fix the issue where no test results are reported to the
Jenkins CI.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
