### PR TITLE
Revert "test-on-testmachine: use $BASEDIR from functions"

### DIFF
--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -23,10 +23,17 @@ chroot)
     ;;
 esac
 
+SCRIPT_BASEDIR="$(
+    cd "$(dirname "$0")"
+    pwd
+)"                                            # /home/user/whatever/buildscripts/build-scripts
+SCRIPT_BASEDIR="$(dirname "$SCRIPT_BASEDIR")" # /home/user/whatever/buildscripts
+SCRIPT_BASEDIR="$(dirname "$SCRIPT_BASEDIR")" # /home/user/whatever
+
 # We still need to perform several cleanup tasks after doing a chroot test run.
 # So wrap the test execution in an if so that we can proceed with clean-up on error.
 log_debug "Executing tests on test machine..."
-if remote_script_general "$SCRIPT" "$LOGIN_COMMAND" "$BASEDIR"; then
+if remote_script_general "$SCRIPT" "$LOGIN_COMMAND" "$SCRIPT_BASEDIR"; then
     return_code=0
 else
     return_code=$?


### PR DESCRIPTION
This reverts commit 17e04d90b3b461b1a859282dc5ed1eea927ed991.

Solaris & HP-UX
[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline&build=13028)](https://ci.cfengine.com/job/pr-pipeline/13028/)