### PR TITLE
release-monitoring.json: replaced project ID for Apache

### DIFF
--- a/deps-packaging/release-monitoring.json
+++ b/deps-packaging/release-monitoring.json
@@ -1,5 +1,5 @@
 {
-        "apache":"1335",
+        "apache":"387502",
         "apr":"95",
         "apr-util":"96",
         "diffutils":"436",


### PR DESCRIPTION
The project ID of Apache/httpd seems to have change. The previous ID now
returns 404 `https://release-monitoring.org/project/1335`.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
