### PR TITLE
Removed 3.21.x from workflow to update dependencies

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [master, 3.24.x, 3.21.x]
+        branch: [master, 3.24.x]
     steps:
       - name: Checks-out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
There won't be any more patch releases of 3.21.x.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
