### PR TITLE
ENT-12619: Reduced noise in clean-buildmachine

### DIFF
--- a/build-scripts/clean-buildmachine
+++ b/build-scripts/clean-buildmachine
@@ -9,7 +9,8 @@
 . "$(dirname "$0")"/functions
 . detect-environment
 
-uninstall_cfbuild
+log_debug "Removing all cfbuild packages..."
+run_and_print_on_failure uninstall_cfbuild
 
 if [ -z "$PREFIX" ] || [ "$PREFIX" = "/" ]; then
     fatal "\$PREFIX is not defined, is empty, or is set to the root directory. Aborting to prevent accidental deletion."


### PR DESCRIPTION
Uninstalling all the cfbuild packages creates a lot of noise from the package managers. Instead, let's print output on failure.

[![Build Status](https://ci.cfengine.com//buildStatus/icon?job=pr-pipeline&build=13371)](https://ci.cfengine.com//job/pr-pipeline/13371/)