### PR TITLE
ENT-12619: Fix typo in nghttp2 debian control file

### DIFF
--- a/deps-packaging/nghttp2/debian/control
+++ b/deps-packaging/nghttp2/debian/control
@@ -14,5 +14,5 @@ Description: CFEngine Build Automation -- nghttp2
 Package: cfbuild-nghttp2-devel
 Section: libdevel
 Architecture: any
-Desciption: CFEngine Build Automation -- cfbuild-nghttp2-devel
+Description: CFEngine Build Automation -- cfbuild-nghttp2-devel
  CFEngine Build Automation -- cfbuild-nghttp2-devel


### PR DESCRIPTION
## Summary
- Fixed misspelling of `Description` field (`Desciption`) in `deps-packaging/nghttp2/debian/control` for the `cfbuild-nghttp2-devel` package
- This typo caused dpkg to emit a "missing 'Description' field" warning on every subsequent `dpkg -i` call (~10+ times per testing-pr build)

Ticket: ENT-12619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline)](https://ci.cfengine.com/job/pr-pipeline/13380/)