### PR TITLE
ENT-12619: Suppress stderr from expected-failure commands

### DIFF
--- a/build-scripts/prepare-testmachine-chroot
+++ b/build-scripts/prepare-testmachine-chroot
@@ -21,9 +21,9 @@ CHROOT_ROOT=$HOME/testmachine-chroot/
 sudo mkdir -p "$CHROOT_ROOT"
 
 # Clean up previous chroot state by killing any processes that are using the CHROOT_ROOT directory.
-sudo "$FUSER" -k "$CHROOT_ROOT" || true
+sudo "$FUSER" -k "$CHROOT_ROOT" >/dev/null 2>&1 || true
 # Unmount the /proc filesystem if it was previously mounted inside the chroot.
-sudo umount "${CHROOT_ROOT}proc" || true
+sudo umount "${CHROOT_ROOT}proc" >/dev/null 2>&1 || true
 
 # Tell rsync not to touch the BASEDIR and PREFIX directories
 echo "P $BASEDIR" >"$TRANSFER_SCRIPT"

--- a/build-scripts/test-on-testmachine
+++ b/build-scripts/test-on-testmachine
@@ -51,7 +51,7 @@ chroot)
             # Minilogd may sometimes launch on RedHat without any user
             # intervention. Ignore that.
             # shellcheck disable=SC2009
-            if ps -ef | grep -E "^ *[^ ]+ +$pid" | grep minilogd; then
+            if ps -ef 2>/dev/null | grep -E "^ *[^ ]+ +$pid" | grep -q minilogd; then
                 continue
             fi
             ;;
@@ -59,7 +59,7 @@ chroot)
 
             # gpg-agent sometimes is spawned on suse during our tests.
             # This happens only in chroot. Ignore that.
-            if ps -o command --pid "$pid" | grep "gpg-agent --homedir /var/tmp/zypp.*zypp-trusted.*--daemon"; then
+            if ps -o command --pid "$pid" 2>/dev/null | grep -q "gpg-agent --homedir /var/tmp/zypp.*zypp-trusted.*--daemon"; then
                 continue
             fi
             ;;
@@ -67,7 +67,7 @@ chroot)
             # gpg-agent sometimes is spawned on Ubuntu 24 during our tests.
             # This happens only in chroot. Ignore that.
             if [ "$OS_VERSION_MAJOR" = "24" ]; then
-                if ps -o command --pid "$pid" | grep "gpg-agent --homedir /etc/apt/sources.list.d/.gnupg-temp --use-standard-socket --daemon"; then
+                if ps -o command --pid "$pid" 2>/dev/null | grep -q "gpg-agent --homedir /etc/apt/sources.list.d/.gnupg-temp --use-standard-socket --daemon"; then
                     continue
                 fi
             fi


### PR DESCRIPTION
## Summary
- Redirect stdout/stderr to /dev/null for `fuser -k` and `umount` cleanup commands in `prepare-testmachine-chroot` that may fail when there is nothing to kill/unmount, matching the pattern already used in `test-on-testmachine` lines 94 and 96
- Use `grep -q` and redirect `ps` stderr in `test-on-testmachine` process checks for known benign processes (minilogd, gpg-agent) since we only care about the exit code

Ticket: ENT-12619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline)](https://ci.cfengine.com/job/pr-pipeline/13384/)