### PR TITLE
ENT-12619: Reduce dpkg install noise with run_and_print_on_failure

### DIFF
--- a/deps-packaging/pkg-install-deb
+++ b/deps-packaging/pkg-install-deb
@@ -1,11 +1,13 @@
-#!/bin/sh -ex
+#!/bin/sh -e
 
 # Installs given packages
 
+. "$(dirname "$0")/../build-scripts/functions"
 
 if [ $# -eq 0 ]; then
-   echo "Usage: $0 <pkg> [<pkg> ...]"
-   exit 1
+    echo "Usage: $0 <pkg> [<pkg> ...]"
+    exit 1
 fi
 
-sudo dpkg -i "$@"
+log_debug "Installing packages: $*"
+run_and_print_on_failure sudo dpkg -i "$@"


### PR DESCRIPTION
## Summary
- Wrapped `dpkg -i` in `pkg-install-deb` with `run_and_print_on_failure` so verbose installation output is only shown on failure
- Removed `-x` from shebang to suppress shell trace output
- Each package install produces ~8 lines of verbose output; for a hub build with ~20 dependencies this eliminates ~160 lines of noise

Ticket: ENT-12619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[![Build Status](https://ci.cfengine.com/buildStatus/icon?job=pr-pipeline)](https://ci.cfengine.com/job/pr-pipeline/13383/)