### PR TITLE
ENT-13766: Fixes / improvements / security hardening

### DIFF
--- a/build-scripts/autogen
+++ b/build-scripts/autogen
@@ -61,7 +61,8 @@ for proj in $projects; do
     log_debug "Running autogen.sh for project $proj..."
     (
         cd "$BASEDIR/$proj"
-        NO_CONFIGURE=1 run_and_print_on_failure ./autogen.sh
+        export NO_CONFIGURE=1
+        run_and_print_on_failure ./autogen.sh
     )
 done
 

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -124,8 +124,9 @@ bundle agent cfengine_build_host_setup
       "xfsprogs";
 
 # note that shellcheck, fakeroot and ccache require epel-release to be installed
-    (redhat_7|centos_7).(yum_dnf_conf_ok)::
+    (redhat|centos).(yum_dnf_conf_ok)::
       "epel-release";
+    (redhat_7|centos_7).(yum_dnf_conf_ok)::
       "ccache";
       "fakeroot";
       "perl-JSON-PP";

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -262,6 +262,30 @@ root - core unlimited
 * - core unlimited
 ");
 
+      "/etc/ssh/sshd_config"
+        edit_line => comment_lines_matching("^PermitRootLogin\s+(?!no\s*$).*", "#"),
+        classes => if_repaired("sshd_hardened"),
+        comment => "Comment out insecure PermitRootLogin values";
+      "/etc/ssh/sshd_config"
+        edit_line => comment_lines_matching("^PasswordAuthentication\s+(?!no\s*$).*", "#"),
+        classes => if_repaired("sshd_hardened"),
+        comment => "Comment out insecure PasswordAuthentication value";
+      "/etc/ssh/sshd_config"
+        edit_line => comment_lines_matching("^KbdInteractiveAuthentication\s+(?!no\s*$).*", "#"),
+        classes => if_repaired("sshd_hardened"),
+        comment => "Comment out insecure KbdInteractiveAuthentication value (OpenSSH 8.7+)";
+      "/etc/ssh/sshd_config"
+        edit_line => comment_lines_matching("^ChallengeResponseAuthentication\s+(?!no\s*$).*", "#"),
+        classes => if_repaired("sshd_hardened"),
+        comment => "Comment out insecure ChallengeResponseAuthentication value (OpenSSH < 8.7)";
+      "/etc/ssh/sshd_config"
+        edit_line => lines_present("PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no"),
+        classes => if_repaired("sshd_hardened"),
+        comment => "Ensure SSH hardening directives are present";
+
     ubuntu_16|ubuntu_18|redhat_9|redhat_10::
       "/etc/hosts" -> { "ENT-12437" }
         edit_line => regex_replace("127.0.0.1 localhost localhost.localdomain","127.0.0.1 localhost.localdomain"),
@@ -342,6 +366,12 @@ jenkins_builds ALL=NOPASSWD: /usr/bin/podman
       "useradd -u 2 bin" contain => in_shell;
     !have_sys_user.(suse|sles|opensuse)::
       "useradd -u 3 sys" contain => in_shell;
+
+  services:
+    sshd_hardened::
+      "sshd"
+        service_policy => "restart",
+        comment => "Restart sshd to apply hardened configuration";
 
 # skip /etc/hosts change for now, seems kind of wrong and corrupts ip6 entries like `::1 ip6-ip6-loopback`
 # maybe the following is needed to silence such errors as:     ubuntu-16-mingw-j1: sudo: unable to resolve host localhost.localdomain

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -24,6 +24,8 @@ bundle agent cfengine_build_host_setup
       "ntp";
 
     debian|ubuntu::
+      "fail2ban"
+        comment => "Ban IPs with repeated failed SSH auth attempts";
       "libltdl7" package_policy => "delete";
       "libltdl-dev" package_policy => "delete";
       "binutils";
@@ -126,6 +128,8 @@ bundle agent cfengine_build_host_setup
 # note that shellcheck, fakeroot and ccache require epel-release to be installed
     (redhat|centos).(yum_dnf_conf_ok)::
       "epel-release";
+      "fail2ban"
+        comment => "Ban IPs with repeated failed SSH auth attempts";
     (redhat_7|centos_7).(yum_dnf_conf_ok)::
       "ccache";
       "fakeroot";
@@ -263,6 +267,17 @@ root - core unlimited
 * - core unlimited
 ");
 
+      "/etc/fail2ban/jail.local"
+        create => "true",
+        content => "[sshd]
+enabled = true
+port = ssh
+maxretry = 5
+bantime = 3600
+findtime = 600",
+        classes => if_repaired("fail2ban_config_changed"),
+        comment => "Configure fail2ban to ban IPs after 5 failed SSH attempts within 10 minutes";
+
       "/etc/ssh/sshd_config"
         edit_line => comment_lines_matching("^PermitRootLogin\s+(?!no\s*$).*", "#"),
         classes => if_repaired("sshd_hardened"),
@@ -373,6 +388,14 @@ jenkins_builds ALL=NOPASSWD: /usr/bin/podman
       "sshd"
         service_policy => "restart",
         comment => "Restart sshd to apply hardened configuration";
+    any::
+      "fail2ban"
+        service_policy => "start",
+        comment => "Ensure fail2ban is running";
+    fail2ban_config_changed::
+      "fail2ban"
+        service_policy => "restart",
+        comment => "Restart fail2ban to apply jail configuration";
 
 # skip /etc/hosts change for now, seems kind of wrong and corrupts ip6 entries like `::1 ip6-ip6-loopback`
 # maybe the following is needed to silence such errors as:     ubuntu-16-mingw-j1: sudo: unable to resolve host localhost.localdomain

--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -37,11 +37,11 @@ function cleanup()
   fi
   echo "Cleaning up CFEngine install by moving to /var/bak.cfengine and /opt/bak.cfengine"
   rm -rf /var/bak.cfengine
-  mv /var/cfengine /var/bak.cfengine || true
+  mv /var/cfengine /var/bak.cfengine 2>/dev/null || true
   rm -rf /opt/bak.cfengine
-  mv /opt/cfengine /opt/bak.cfengine || true
-  mv /var/log/CFE* /var/bak.cfengine/ || true
-  mv /var/log/postgresql.log /var/bak.cfengine || true
+  mv /opt/cfengine /opt/bak.cfengine 2>/dev/null || true
+  mv /var/log/CFE* /var/bak.cfengine/ 2>/dev/null || true
+  mv /var/log/postgresql.log /var/bak.cfengine 2>/dev/null || true
 
   if command -v pkill >/dev/null 2>&1; then
     pkill -9 cf-agent || true


### PR DESCRIPTION
- **Suppress cleanup() errors for missing files**
- **Export NO_CONFIGURE so it propagates to autogen.sh subprocesses**
- **Harden SSH on build hosts: disable root login and password auth**
-  **Install epel-release on all RHEL/CentOS versions**
- **Install and configure fail2ban on all build hosts**