### PR TITLE
Fixed dotfile mv in pkg-build-deb picking up . and ..

### DIFF
--- a/deps-packaging/pkg-build-deb
+++ b/deps-packaging/pkg-build-deb
@@ -64,8 +64,13 @@ echo "$SRCFILES" | while read srcfile opts; do
     mkdir -p "$TD"
     $UNCOMPRESS $srcfile | tar -C $TD -xf -
     mv $TD/*/* $PKGDIR
-    # Also move dot files, but don't fail if there are none
-    mv $TD/*/.* $PKGDIR || true
+    # Also move dot files (.gitignore, etc.), skipping . and ..
+    for _dotfile in $TD/*/.*; do
+      case "${_dotfile##*/}" in
+        .|..) continue ;;
+        *) mv "$_dotfile" "$PKGDIR" ;;
+      esac
+    done
     rm -r "$TD"
   fi
 done


### PR DESCRIPTION
## Summary
- The glob pattern `.*` in `pkg-build-deb` matches `.` and `..`, causing spurious warnings during tarball extraction in dependency packaging
- The `|| true` prevented the script from failing, but the warnings are noisy and confusing
- Replaced with a loop that skips `.` and `..`

🤖 Generated with [Claude Code](https://claude.com/claude-code)