### PR TITLE
Added ARM64 platform support for container builds

### DIFF
--- a/build-in-container.py
+++ b/build-in-container.py
@@ -94,6 +94,10 @@ def build_image(platform_name, platform_config, script_dir, rebuild=False):
     if rebuild:
         cmd.append("--no-cache")
 
+    docker_platform = platform_config.get("docker_platform")
+    if docker_platform:
+        cmd.extend(["--platform", docker_platform])
+
     cmd.extend(["--network", "host"])
 
     # Build context is the container/ directory
@@ -120,8 +124,13 @@ def pull_image(platform_name):
     """
     ref = registry_image_ref(platform_name)
     log.info(f"Pulling image {ref}...")
+    cmd = ["docker", "pull"]
+    docker_platform = get_config()[platform_name].get("docker_platform")
+    if docker_platform:
+        cmd.extend(["--platform", docker_platform])
+    cmd.append(ref)
     result = subprocess.run(
-        ["docker", "pull", ref],
+        cmd,
         capture_output=True,
         text=True,
     )
@@ -189,7 +198,7 @@ def update_platform_versions(platform_name=None):
     config_path.write_text(json.dumps(config, indent=2) + "\n")
 
 
-def run_container(args, image_tag, source_dir, script_dir):
+def run_container(args, image_tag, source_dir, script_dir, platform_config):
     """Run the build inside a Docker container."""
     output_dir = Path(args.output_dir).resolve()
     cache_dir = Path(args.cache_dir).resolve()
@@ -199,6 +208,10 @@ def run_container(args, image_tag, source_dir, script_dir):
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     cmd = ["docker", "run", "--rm", "--network", "host"]
+
+    docker_platform = platform_config.get("docker_platform")
+    if docker_platform:
+        cmd.extend(["--platform", docker_platform])
 
     if args.shell:
         cmd.extend(["-it"])
@@ -401,7 +414,7 @@ def main():
         )
 
     # Run the container
-    rc = run_container(args, image_tag, source_dir, script_dir)
+    rc = run_container(args, image_tag, source_dir, script_dir, platform_config)
 
     if rc != 0:
         log.error(f"Build failed (exit code {rc}).")

--- a/platforms.json
+++ b/platforms.json
@@ -36,5 +36,48 @@
     "base_image": "debian:12",
     "base_image_sha": "sha256:ad83e02b01f4bb0c3fa818396d8bf47c0e9f5803e98bf6cbd8f772ae9e2ec4e4",
     "dockerfile": "Dockerfile.debian"
+  },
+  "ubuntu-20-arm64": {
+    "image_name": "cfengine-builder-ubuntu-20-arm64",
+    "image_version": "1",
+    "base_image": "ubuntu:20.04",
+    "base_image_sha": "sha256:722ea796ac2d57eeb3627c58a582fc1acc58be51faf815e1bce1682ae5c092f7",
+    "dockerfile": "Dockerfile.debian",
+    "docker_platform": "linux/arm64",
+    "extra_build_args": {
+      "NCURSES_PKGS": "libncurses5 libncurses5-dev"
+    }
+  },
+  "ubuntu-22-arm64": {
+    "image_name": "cfengine-builder-ubuntu-22-arm64",
+    "image_version": "1",
+    "base_image": "ubuntu:22.04",
+    "base_image_sha": "sha256:d7538f2e1022cc798971b7ef0162cde7ef4f079c8a1bb8e2036124e4c9be5d66",
+    "dockerfile": "Dockerfile.debian",
+    "docker_platform": "linux/arm64"
+  },
+  "ubuntu-24-arm64": {
+    "image_name": "cfengine-builder-ubuntu-24-arm64",
+    "image_version": "1",
+    "base_image": "ubuntu:24.04",
+    "base_image_sha": "sha256:11c7dd0cbd7effee6cd4f11811caffb5fdf682f1667c7f152c5cee7d32cc337c",
+    "dockerfile": "Dockerfile.debian",
+    "docker_platform": "linux/arm64"
+  },
+  "debian-11-arm64": {
+    "image_name": "cfengine-builder-debian-11-arm64",
+    "image_version": "1",
+    "base_image": "debian:11",
+    "base_image_sha": "sha256:738ac3c14081caa9ba3d7737a0d27ea78eaa5f0ec4969113fb3f9c6d61d97e67",
+    "dockerfile": "Dockerfile.debian",
+    "docker_platform": "linux/arm64"
+  },
+  "debian-12-arm64": {
+    "image_name": "cfengine-builder-debian-12-arm64",
+    "image_version": "1",
+    "base_image": "debian:12",
+    "base_image_sha": "sha256:d01662367b48fc3bd42f389af59f2b39e20652b8f4be4130f80d1ac223d7eb27",
+    "dockerfile": "Dockerfile.debian",
+    "docker_platform": "linux/arm64"
   }
 }


### PR DESCRIPTION
## Summary
- Added arm64 variants for all Debian/Ubuntu platforms in `platforms.json` with architecture-specific base image digests and a new `docker_platform` field
- Updated `build-in-container.py` to pass `--platform` to `docker build`, `docker pull`, and `docker run` when `docker_platform` is configured
- Enables native ARM64 container builds, avoiding QEMU emulation issues (e.g. bad file descriptors in zlib) on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)