### PR TITLE
Updated dependency 'openssl' from version 3.6.1 to 3.6.2 (3.24.x)

### DIFF
--- a/deps-packaging/openssl/cfbuild-openssl.spec
+++ b/deps-packaging/openssl/cfbuild-openssl.spec
@@ -1,4 +1,4 @@
-%define openssl_version 3.6.1
+%define openssl_version 3.6.2
 
 Summary: CFEngine Build Automation -- openssl
 Name: cfbuild-openssl

--- a/deps-packaging/openssl/distfiles
+++ b/deps-packaging/openssl/distfiles
@@ -1,1 +1,1 @@
-b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e  openssl-3.6.1.tar.gz
+aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f  openssl-3.6.2.tar.gz

--- a/deps-packaging/openssl/source
+++ b/deps-packaging/openssl/source
@@ -1,1 +1,1 @@
-https://github.com/openssl/openssl/releases/download/openssl-3.6.1/
+https://github.com/openssl/openssl/releases/download/openssl-3.6.2/


### PR DESCRIPTION
(cherry picked from commit c10a1e6314fc964b52ed618800f10553c8c2b5d5)
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
