### PR TITLE
feature: added build host setup handling cfengine_role env var for policy use

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -2,6 +2,11 @@
 shopt -s expand_aliases
 thisdir="$(dirname "$0")"
 
+# handle env cfengine_role
+if [ -n "$cfengine_role" ]; then
+  touch /etc/cfengine-"$cfengine_role".flag
+fi
+
 # install needed packages and software for a build host
 set -e
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
We can add this as a platform specific env var in jenkins config to trigger different types of build hosts.
In this case we are enabling our mingw build host setup.

Ticket: ENT-13862
Changelog: none
