### PR TITLE
Add reviewers to automated base image update PRs

### DIFF
--- a/.github/workflows/update-base-images.yml
+++ b/.github/workflows/update-base-images.yml
@@ -27,3 +27,6 @@ jobs:
           body: |
             Automated update of `image_version` in `platforms.json` to the
             latest tags from ghcr.io.
+          reviewers: |
+            larsewi
+            craigcomstock


### PR DESCRIPTION
Adds `larsewi` and `craigcomstock` as reviewers on PRs opened by the `update-base-images` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)