### PR TITLE
Adjusted install scriptlets to give more time for shutting down database (3.24)

### DIFF
--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1059,7 +1059,10 @@ if [ -n "$httpds" ]; then
   fi
 fi
 
-(cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m smart" || su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data -m fast")
+# wait 5 minutes for smart shutdown to happen, on slower machines it might take a while
+if ! (cd /tmp && su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data --timeout=300 -m smart"); then
+  su cfpostgres -c "$PREFIX/bin/pg_ctl stop -D $PREFIX/state/pg/data --timeout=300 -m fast"
+fi
 
 # Have to be careful here because httpd/php/bin wants to be root:root
 chown root:$MP_APACHE_USER $PREFIX/httpd/php


### PR DESCRIPTION
On a slow raspberry pi 4 I found that the current smart and then immediate stop (immediate) did not work well.
The system needed more time.

Ticket: ENT-12750
Changelog: title
(cherry picked from commit f2b3ca35e98427a4d02dad8260a9ca118b4447f5)
