### PR TITLE
fix: build-scripts/get_labels_expr.py was printing () if no exotics which broke jenkins filters (3.27)

### DIFF
--- a/build-scripts/get_labels_expr.py
+++ b/build-scripts/get_labels_expr.py
@@ -70,9 +70,10 @@ def main(labels_f_path, exotics_f_path, run_on_exotics, only_exotics):
     else:
         labels_to_run = all_labels
 
-    print("(", end="")
-    labels_eqs = ('label == "%s"' % label for label in sorted(labels_to_run))
-    print(" || \\\n ".join(labels_eqs) + ")")
+    if len(labels_to_run) != 0:
+        print("(", end="")
+        labels_eqs = ('label == "%s"' % label for label in sorted(labels_to_run))
+        print(" || \\\n ".join(labels_eqs) + ")")
 
     return 0
 


### PR DESCRIPTION
This happened after we removed ALL entries from exotics.txt

Ticket: ENT-14025
Changelog: none
(cherry picked from commit 41b2b3d06d2ed0e4d22c3cf49c2e27d68fce160c)
