### PR TITLE
fix: ci/initialize-build-host.sh: fail if workspace cannot be cleaned up (master)

### DIFF
--- a/ci/fix-buildhost.sh
+++ b/ci/fix-buildhost.sh
@@ -1,0 +1,12 @@
+if [ "$(uname)" = "HP-UX" ]; then
+  # /etc/profile contains tty code that won't work well when sourced and this VUE env var guards against running those bits
+  # https://ftp.mirrorservice.org/sites/www.bitsavers.org/pdf/hp/9000_hpux/9.x/B1171-90044_HP_Visual_User_Environment_System_Administration_Manual_Nov91.pdf
+  VUE=true
+  export VUE
+fi
+
+if [ -f /etc/profile ]; then
+  # running on the proxied host or not we want to make sure local customizations are taken
+  # e.g. ent-14014: custom build of ssh needed for build-artifacts-cache needed and /etc/profile has PATH=/opt/craig/bin:$PATH
+  . /etc/profile
+fi

--- a/ci/initialize-build-host.sh
+++ b/ci/initialize-build-host.sh
@@ -72,6 +72,7 @@ set_github_status()
     return 0
 }
 
+# main() as it were, begin non-function definition section of script
 if broken_posix_shell >/dev/null 2>&1; then
     try_exec /usr/xpg4/bin/sh "$0" "$@"
     echo "No compatible shell script interpreter found."
@@ -87,14 +88,14 @@ then
     trap set_github_status EXIT
 fi
 
-# Make sure error detection and verbose output is on, if they aren't already.
-set -x -e
+# Make sure error detection is on, if it isn't already
+set -e
 
 
 echo "Current user: $USER"
 echo "IP information:"
-/sbin/ifconfig -a || true
-/sbin/ip addr || true
+command -v /sbin/ifconfig 2>/dev/null && /sbin/ifconfig -a || true
+command -v /sbin/ip 2>/dev/null && /sbin/ip addr || true
 
 
 RSYNC="rsync --delete -zrlpt -T /tmp"
@@ -371,7 +372,13 @@ then
     # job section yet.
     if [ -n "$WORKSPACE" ]
     then
+        $RSH $login rm -rf "$WORKSPACE_REMOTE" || true
+        # if the user can't delete it, try sudo, if sudo isn't available, that's ok, we tried
         $RSH  $login  sudo rm -rf "$WORKSPACE_REMOTE" || true
+        if $RSH $login ls "$WORKSPACE_REMOTE"; then
+            echo "$WORKSPACE_REMOTE is not removed on build host."
+            exit 2
+        fi
         $RSH  $login  mkdir -p "$WORKSPACE_REMOTE"
         $RSYNC -e "$RSH"    "$WORKSPACE"/  $login:"$WORKSPACE_REMOTE"/
     fi


### PR DESCRIPTION
- **fix: add ci/fix-buildhost.sh to source /etc/profile especially for exotics which may have basic tools like ssh in odd places added to PATH in /etc/profile**
- **fix: tidy up ci/initialize-build-host.sh to be more quiet and fail if workspace cleanup fails**
