### PR TITLE
fix: ci/fix-buildhost.sh should only source /etc/profile on solaris and hp-ux build hosts where it is needed (3.27)

### DIFF
--- a/ci/fix-buildhost.sh
+++ b/ci/fix-buildhost.sh
@@ -5,8 +5,12 @@ if [ "$(uname)" = "HP-UX" ]; then
   export VUE
 fi
 
-if [ -f /etc/profile ]; then
-  # running on the proxied host or not we want to make sure local customizations are taken
-  # e.g. ent-14014: custom build of ssh needed for build-artifacts-cache needed and /etc/profile has PATH=/opt/craig/bin:$PATH
-  . /etc/profile
+# /etc/profile can contain tricky things, on suse for example it includes a call to tty which will fail in CI
+# so only source /etc/profile where we absolutely need it.
+if [ "$(uname)" = "HP-UX" ] || [ "$(uname)" = "SunOS" ]; then
+  if [ -f /etc/profile ]; then
+    # running on the proxied host or not we want to make sure local customizations are taken
+    # e.g. ent-14014: custom build of ssh needed for build-artifacts-cache needed and /etc/profile has PATH=/opt/craig/bin:$PATH
+    . /etc/profile
+  fi
 fi


### PR DESCRIPTION
Sourcing this on suse-12 and suse-15 caused trouble due to a failing call to the tty command.

Ticket: ENT-14040
Changelog: none
(cherry picked from commit c3fedaef7fb24c0f89f90e7800a437e44cccd965)
