### PR TITLE
Adjusted rpm packaging for use in minimal container instances (3.27)

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -35,6 +35,7 @@ Requires: selinux-policy >= @@SELINUX_POLICY_VERSION@@
 %if %{?rhel}%{!?rhel:0} == 8
 Requires: libssl.so.1.1()(64bit) libssl.so.1.1(OPENSSL_1_1_0)(64bit) libssl.so.1.1(OPENSSL_1_1_1)(64bit)
 Requires: libcrypto.so.1.1()(64bit) libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)
+Requires: openssl
 %endif
 
 # We build against systems with the latest available dependencies such as OpenSSL.
@@ -44,6 +45,7 @@ Requires: libcrypto.so.1.1()(64bit) libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)
 %if %{?rhel}%{!?rhel:0} > 8
 Requires: libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_@@OPENSSL_VERSION@@)(64bit)
 Requires: libssl.so.3()(64bit) libssl.so.3(OPENSSL_@@OPENSSL_VERSION@@)(64bit)
+Requires: openssl
 %endif
 
 # cfbs/Build requires Python 3.5+ (not available on RHEL 6)

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -22,7 +22,7 @@ Requires: hostname
 %if %{?rhel}%{!?rhel:0} >= 8
 Recommends: gzip
 %endif
-Requires(pre): /usr/sbin/useradd, /usr/sbin/userdel, /usr/bin/getent
+Requires(pre): /usr/sbin/useradd, /usr/sbin/userdel, /usr/bin/getent, /usr/bin/hostname
 Requires(post): /usr/sbin/usermod, /bin/sed
 
 # we require selinux-policy package version that matches or exceeds our build system version

--- a/packaging/common/cfengine-hub/postinstall.sh
+++ b/packaging/common/cfengine-hub/postinstall.sh
@@ -1082,7 +1082,7 @@ if ! is_upgrade; then
   else
     case "`os_type`" in
       redhat)
-        chkconfig --add cfengine3
+        test -x /sbin/chkconfig && test -f /etc/init.d/cfengine3 && chkconfig --add cfengine3
         ;;
       debian)
         update-rc.d cfengine3 defaults

--- a/packaging/common/cfengine-non-hub/postinstall.sh
+++ b/packaging/common/cfengine-non-hub/postinstall.sh
@@ -79,7 +79,7 @@ case `os_type` in
       case `os_type` in
         redhat)
           if ! is_upgrade; then
-            chkconfig --add cfengine3
+            test -x /sbin/chkconfig && test -f /etc/init.d/cfengine3 && chkconfig --add cfengine3
           fi
           ;;
         debian)


### PR DESCRIPTION
- **Added cfengine-nova-hub package requires for openssl command that is needed during install**
- **Added /usr/bin/hostname to Requires for redhat packages**
- **Added check for existence of chkconfig command before using it to add cfengine3 service**
