### PR TITLE
fix: ci/cfengine-build-host-setup.cf unzip is needed to unpack groovy distribution archive for install on containers hosts

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -84,6 +84,7 @@ bundle agent cfengine_build_host_setup
       "autoconf-archive" comment => "Required to resolve the AX_PTHREAD macro";
 
     debian.containers_host:: # in jenkins, CONTAINER labeled nodes are capable of running container builds like valgrind-check and static-check
+      "unzip" comment => "linux-install-groovy.sh needs unzip to unpack the groovy distribution archive.";
       "buildah";
       "jq";
       "make";


### PR DESCRIPTION
Ticket: none
Changelog: none
