### PR TITLE
fix: build host policy typo prevented java and groovy to be installed for containers build hosts

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -261,7 +261,7 @@ bundle agent cfengine_build_host_setup
         contain => in_shell;
     containers_host.missing_groovy.java_ok::
       "sh $(this.promise_dirname)/linux-install-groovy.sh" contain => in_shell;
-    missing_java.insufficient_java_version::
+    missing_java|insufficient_java_version::
       "sh $(this.promise_dirname)/linux-install-jdk21.sh"
         contain => in_shell,
         classes => results( "bundle", "java" );


### PR DESCRIPTION
Ticket: none
Changelog: none
