### PR TITLE
ENT-14108: drain cf-agent in hub preremove.sh before stopping cfengine3 umbrella

### DIFF
--- a/packaging/common/cfengine-hub/preremove.sh
+++ b/packaging/common/cfengine-hub/preremove.sh
@@ -1,3 +1,16 @@
+# Drain in-flight cf-agent before stopping the cfengine3 umbrella: otherwise
+# a running cf-agent can re-trigger cf-php-fpm (which Wants=cf-postgres),
+# leaving cf-postgres in a Restart=always loop while the package is gone.
+if use_systemd; then
+  /bin/systemctl stop cf-execd.service >/dev/null 2>&1 || true
+  t=60
+  while [ $t -gt 0 ] && pgrep -x cf-agent >/dev/null 2>&1; do
+    sleep 1
+    t=$((t - 1))
+  done
+  pkill -KILL -x cf-agent >/dev/null 2>&1 || true
+fi
+
 cf_console platform_service cfengine3 stop
 if use_systemd && [ -e /usr/lib/systemd/system/cfengine3-web.service ]; then
   # When using systemd, the services are split in two, and although both will


### PR DESCRIPTION
Race: prerm stops cf-execd and cf-postgres, but a still-running cf-agent then starts cf-php-fpm — which pulls cf-postgres back in as a dependency (`Wants=cf-postgres.service`). The start fails (data dir being torn down) and `Restart=always` keeps it looping into the next install's postinst, eventually clobbering postinst's postgres so the final `pg_ctl stop` fails and dpkg aborts.

This PR drains in-flight cf-agent in prerm before the umbrella stop, so policy can't re-trigger services during teardown. See the commit message for the full mechanism.