### PR TITLE
Added install of openssl development packages for redhat-based platforms to fix-buildhost.sh

### DIFF
--- a/ci/fix-buildhost.sh
+++ b/ci/fix-buildhost.sh
@@ -10,3 +10,11 @@ if [ -f /etc/profile ]; then
   # e.g. ent-14014: custom build of ssh needed for build-artifacts-cache needed and /etc/profile has PATH=/opt/craig/bin:$PATH
   . /etc/profile
 fi
+
+# while ENT-13750 is in progress we need to ensure that OTHER builds include openssl devel packages on redhat-based platforms
+if command -v zypper >/dev/null 2>/dev/null; then
+  sudo zypper install -y libopenssl-devel || true
+fi
+if command -v yum >/dev/null 2>/dev/null; then
+  sudo yum install -y openssl-devel || true
+fi


### PR DESCRIPTION
This is needed because we share build hosts with ent-13750 pull request builds that remove these packages due to migrating back to vendored openssl there.

Ticket: ENT-13750
Changelog: none
