### PR TITLE
ENT-14061: Reproducible masterfiles builds with container scripts

### DIFF
--- a/build-in-container-inner.sh
+++ b/build-in-container-inner.sh
@@ -124,7 +124,9 @@ run_step() {
 # === Build steps ===
 run_step "01-autogen" "$BASEDIR/buildscripts/build-scripts/autogen"
 run_step "02-install-dependencies" "$BASEDIR/buildscripts/build-scripts/install-dependencies"
-if [ "$EXPLICIT_ROLE" = "hub" ]; then
+# Mission Portal is an Enterprise/nova-only component; its sources are only
+# synced when PROJECT=nova. Skip this step for community hubs.
+if [ "$PROJECT" = "nova" ] && [ "$EXPLICIT_ROLE" = "hub" ]; then
     run_step "03-mission-portal-deps" install_mission_portal_deps
 fi
 run_step "04-configure" "$BASEDIR/buildscripts/build-scripts/configure"

--- a/build-in-container-inner.sh
+++ b/build-in-container-inner.sh
@@ -88,6 +88,23 @@ install_mission_portal_deps() (
     find "$BASEDIR/mission-portal" "$BASEDIR/nova/api/http" -type d -name .git -path '*/vendor/*' -exec rm -rf {} +
 )
 
+# Build the masterfiles tarballs, mirroring build-scripts/bootstrap-tarballs.
+# Produces both the source tarball ("make dist") and the package tarball
+# ("make tar-package", files laid out as installed under prefix) and drops
+# them in /output alongside the platform packages.
+build_masterfiles_tarballs() (
+    set -e
+
+    cd "$BASEDIR/masterfiles"
+    rm -f cfengine-masterfiles*.tar.gz
+    # Configure so the dist targets work, matching bootstrap-tarballs (no args).
+    ./configure
+    make dist        # source tarball:  cfengine-masterfiles-<version>.tar.gz
+    make tar-package # package tarball: cfengine-masterfiles-<version>.pkg.tar.gz
+    mv cfengine-masterfiles*.tar.gz /output/
+    make distclean
+)
+
 # === Step runner with failure reporting ===
 # Disable set -e so we can capture exit codes and report which step failed.
 set +e
@@ -113,6 +130,7 @@ fi
 run_step "04-configure" "$BASEDIR/buildscripts/build-scripts/configure"
 run_step "05-compile" "$BASEDIR/buildscripts/build-scripts/compile"
 run_step "06-package" "$BASEDIR/buildscripts/build-scripts/package"
+run_step "07-masterfiles-tarballs" build_masterfiles_tarballs
 
 # === Copy output packages ===
 # Packages are created under $BASEDIR/<project>/ by dpkg-buildpackage / rpmbuild.

--- a/build-in-container.py
+++ b/build-in-container.py
@@ -474,7 +474,7 @@ def main():
         packages = (
             list(output_dir.glob("*.deb"))
             + list(output_dir.glob("*.rpm"))
-            + list(output_dir.glob("*.pkg.tar.gz"))
+            + list(output_dir.glob("*.tar.gz"))
         )
         if packages:
             log.info("Output packages:")

--- a/container/Dockerfile.debian
+++ b/container/Dockerfile.debian
@@ -17,9 +17,11 @@ RUN apt-get update && apt-get install -y ${NCURSES_PKGS} \
     && rm -rf /var/lib/apt/lists/*
 
 # Hub build tools: Node.js 20 LTS (system nodejs is too old for modern npm
-# packages that use the node: protocol), PHP, and Composer
+# packages that use the node: protocol), PHP, and Composer.
+# php-zip lets Composer extract --prefer-dist zip archives natively instead
+# of falling back to git clones (which leave non-reproducible .git dirs).
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs php-cli \
+    && apt-get install -y nodejs php-cli php-zip \
     && rm -rf /var/lib/apt/lists/*
 RUN npm install -g less
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer.phar


### PR DESCRIPTION
Key changes for reproducible builds is in https://github.com/cfengine/masterfiles/pull/3166. However, the version of tar must be pinned. Hence, we should build it in the container script.

Ticket: ENT-14061

TODO:
- [x] Check that masterfiles SHA is the same

Checksums between community and enterprise build:
```
$ sha256sum output.a/cfengine-masterfiles-* output.b/cfengine-masterfiles-*
f189bfaf12405708859f97c1c1deb9555f69147f298ab6534a0f9b25f800bb22  output.a/cfengine-masterfiles-3.28.0a.77c11bace-1.pkg.tar.gz
af92551c0210d4b0e091cc9d9282526a459f9abf724f40bfd9049612b064caaf  output.a/cfengine-masterfiles-3.28.0a.77c11bace.tar.gz
f189bfaf12405708859f97c1c1deb9555f69147f298ab6534a0f9b25f800bb22  output.b/cfengine-masterfiles-3.28.0a.77c11bace-1.pkg.tar.gz
af92551c0210d4b0e091cc9d9282526a459f9abf724f40bfd9049612b064caaf  output.b/cfengine-masterfiles-3.28.0a.77c11bace.tar.gz
```