### PR TITLE
Added install of openssl development packages for redhat-based platforms to fix-buildhost.sh (3.24)

### DIFF
--- a/ci/fix-buildhost.sh
+++ b/ci/fix-buildhost.sh
@@ -14,3 +14,11 @@ if [ "$(uname)" = "HP-UX" ] || [ "$(uname)" = "SunOS" ]; then
     . /etc/profile
   fi
 fi
+
+# while ENT-13750 is in progress we need to ensure that OTHER builds include openssl devel packages on redhat-based platforms
+if command -v zypper >/dev/null 2>/dev/null; then
+  sudo zypper install -y libopenssl-devel || true
+fi
+if command -v yum >/dev/null 2>/dev/null; then
+  sudo yum install -y openssl-devel || true
+fi


### PR DESCRIPTION
This is needed because we share build hosts with ent-13750 pull request builds that remove these packages due to migrating back to vendored openssl there.

Ticket: ENT-13750
Changelog: none
(cherry picked from commit 21cbd0d1e8c0ed3bebfa35d2a668a5b3d78cabba)
