### PR TITLE
ENT-14100: CFEngine Enterprise packages now install a configuration file for leech2

### DIFF
--- a/build-scripts/package-msi
+++ b/build-scripts/package-msi
@@ -117,6 +117,10 @@ pre() {
         ;;
     esac
 
+    # Copy default leech2 config (ENT-14100)
+    install -d "$P"/state/.leech2
+    install -m 644 "$BASEDIR"/cfengine/dist"$BUILDPREFIX"/state/.leech2/config.json "$P"/state/.leech2/
+
     # Copy WiX source file for MSI generation
     cp "$BASEDIR"/buildscripts/packaging/cfengine-nova/cfengine-nova.wxs "$P"
 

--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -469,5 +469,10 @@ exit 0
 %dir %prefix/outputs
 %dir %prefix/inputs
 %dir %prefix/state
+%dir %prefix/state/.leech2
+
+# Mode must match the cfengine-nova package, which also ships this file
+%defattr(600,root,root,700)
+%prefix/state/.leech2/config.json
 
 %changelog

--- a/packaging/cfengine-nova/cfengine-nova.spec.in
+++ b/packaging/cfengine-nova/cfengine-nova.spec.in
@@ -216,6 +216,9 @@ exit 0
 %dir %prefix/outputs
 %dir %prefix/inputs
 %dir %prefix/modules
+%dir %prefix/state
+%dir %prefix/state/.leech2
+%prefix/state/.leech2/config.json
 
 
 %changelog

--- a/packaging/cfengine-nova/cfengine-nova.wxs
+++ b/packaging/cfengine-nova/cfengine-nova.wxs
@@ -178,6 +178,14 @@
                 <File Id='openssl.cnf' Name='openssl.cnf' KeyPath='yes' DiskId='1' Source='$(var.CfSourceDir)\ssl\openssl.cnf' />
               </Component>
             </Directory>
+			<!-- ===== Cfengine\state\.leech2 ===== -->
+            <Directory Id='dir_state' Name='state'>
+              <Directory Id='dir_state_leech2' Name='.leech2'>
+                <Component Id='leech2_config.json' Guid='1781E340-7772-4715-833D-DFAAE22A83EF' Win64='$(var.isWin64)'>
+                  <File Id='leech2_config.json' Name='config.json' KeyPath='yes' DiskId='1' Source='$(var.CfSourceDir)\state\.leech2\config.json' />
+                </Component>
+              </Directory>
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
@@ -222,6 +230,8 @@
 	    <ComponentRef Id='libcurl_4.dll' />
 
 	    <ComponentRef Id='openssl.cnf' />
+
+	    <ComponentRef Id='leech2_config.json' />
       </Feature>
 
       <UI>

--- a/packaging/cfengine-nova/debian/cfengine-nova.install
+++ b/packaging/cfengine-nova/debian/cfengine-nova.install
@@ -23,6 +23,7 @@
 /var/cfengine/lib/liblmdb.so
 /var/cfengine/lib/libleech2.so
 /var/cfengine/bin/lch
+/var/cfengine/state/.leech2/config.json
 /var/cfengine/share/doc
 /var/cfengine/modules
 /var/cfengine/inputs


### PR DESCRIPTION
CFEngine Enterprise packages now install a configuration file for the new reporting system, at /var/cfengine/state/.leech2/config.json. This file is present on all the hosts, and specifies what reporting data (tables, and columns) will be sent.

Together with https://github.com/cfengine/enterprise/pull/925

Ticket: [ENT-14100](https://northerntech.atlassian.net/browse/ENT-14100)

[ENT-14100]: https://northerntech.atlassian.net/browse/ENT-14100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ