### PR TITLE
ENT-12619: Use sudo to read root-owned cloud-init log &  distinguished unset from invalid EXPLICIT_ROLE

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -190,7 +190,11 @@ hub)
     ROLE=hub
     ;;
 *)
-    log_debug "Bad or unset EXPLICIT_ROLE '$EXPLICIT_ROLE': attempting autodetection"
+    if [ -z "$EXPLICIT_ROLE" ]; then
+        log_debug "EXPLICIT_ROLE is unset; attempting to autodetect role"
+    else
+        log_error "Bad EXPLICIT_ROLE '$EXPLICIT_ROLE'; attempting to autodetect role"
+    fi
     case x"$label" in
     x)
         log_debug "label is not set, assuming that this is not the main build job; Setting ROLE=agent."

--- a/ci/initialize-build-host.sh
+++ b/ci/initialize-build-host.sh
@@ -137,7 +137,7 @@ do
 done
 
 echo '========================================= PRINTING CLOUD-INIT LOG ==================================================='
-sed 's/^.*/>>> &/' /var/log/cloud-init-output.log || true
+sudo sed 's/^.*/>>> &/' /var/log/cloud-init-output.log || true
 echo '======================================= DONE PRINTING CLOUD-INIT LOG ================================================'
 
 if [ $attempts -le 0 ]


### PR DESCRIPTION
/var/log/cloud-init-output.log is owned by root, so reading it as an unprivileged user failed with "Permission denied".

Ticket: ENT-12619