### PR TITLE
ENT-12619: Use sudo to read root-owned cloud-init log (3.24.x)

### DIFF
--- a/ci/initialize-build-host.sh
+++ b/ci/initialize-build-host.sh
@@ -160,7 +160,7 @@ do
 done
 
 echo '========================================= PRINTING CLOUD-INIT LOG ==================================================='
-sed 's/^.*/>>> &/' /var/log/cloud-init-output.log || true
+sudo sed 's/^.*/>>> &/' /var/log/cloud-init-output.log || true
 echo '======================================= DONE PRINTING CLOUD-INIT LOG ================================================'
 
 if [ $attempts -le 0 ]


### PR DESCRIPTION
/var/log/cloud-init-output.log is owned by root, so reading it as an unprivileged user failed with "Permission denied".


(cherry picked from commit 29e9ec04a96c4cd6ca4651af9b34ad7c76741e4e)