### PR TITLE
ENT-14191: Do not install obsolete python package on Ubuntu 26

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -20,7 +20,7 @@ bundle agent cfengine_build_host_setup
 
       "shellcheck" comment => "not sure why only ubuntu-20 needed this.";
 
-    debian.(!debian_13.!debian_12.!ubuntu_22.!ubuntu_24.!ubuntu_25)::
+    debian.(!debian_13.!debian_12.!ubuntu_22.!ubuntu_24.!ubuntu_25.!ubuntu_26)::
       "python" comment => "debian>=12 and ubuntu>=22 only has python3";
 
     debian.(!debian_9.!debian_10.!debian_11.!ubuntu_20.!ubuntu_18.!ubuntu_16)::


### PR DESCRIPTION
Ticket: ENT-14191