### PR TITLE
ENT-14191: Fixed systemctl stub for uutils coreutils on Ubuntu 26

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -28,8 +28,13 @@ function cleanup() {
     set -e
     if command -v apt >/dev/null 2>&1; then
         # workaround for CFE-4544, remove scriptlets call systemctl even when systemctl is-system-running returns false
-        rm /bin/systemctl
-        ln -s /bin/echo /bin/systemctl
+        # Replace systemctl with a no-op stub that always succeeds. We can't
+        # symlink to /bin/echo (or /bin/true): on Ubuntu 26 coreutils is the
+        # single multi-call uutils binary that dispatches on argv[0], so it
+        # would fail with "coreutils: unknown program 'systemctl'".
+        rm -f /bin/systemctl
+        printf '#!/bin/sh\nexit 0\n' > /bin/systemctl
+        chmod +x /bin/systemctl
         apt remove -y cfengine-nova || true
     elif command -v yum >/dev/null 2>&1; then
         yum erase -y cfengine-nova || true


### PR DESCRIPTION
The systemctl → echo symlink breaks on Ubuntu 26 because echo is now just an alias into the coreutils multicall binary, which dispatches on argv[0] — invoked as systemctl, it doesn't match, so it fails. Fix: use a no-op stub script that exits 0 instead.

Ticket: ENT-14191