### PR TITLE
Removed suse >= 15 from platforms using system provided OpenSSL

### DIFF
--- a/build-scripts/compile-options
+++ b/build-scripts/compile-options
@@ -32,11 +32,6 @@ export PROJECT
 # It's a flag: if it's set to 1 - then we use system OpenSSL.
 # Otherwise, we build it.
 if [ -z "$SYSTEM_SSL" ]; then
-    if [ "$OS" = "opensuse" ] || [ "$OS" = "sles" ]; then
-        if [ "$OS_VERSION_MAJOR" -ge "15" ]; then
-            SYSTEM_SSL=1
-        fi
-    fi
     # Detect using system ssl when running a Jenkins job
     # shellcheck disable=SC2154
     # > label is referenced but not assigned.


### PR DESCRIPTION
In commit 0e1f4e3b1ebc0323dcf1a2b7944f681d86d03cc7 this removal was skipped for no good reason.

Ticket: ENT-13750
Chaneglog: none
