### PR TITLE
ENT-13275: Removed duplicate share/GUI entry from nova-hub %files (3.27.x)

### DIFF
--- a/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
+++ b/packaging/cfengine-nova-hub/cfengine-nova-hub.spec.in
@@ -422,8 +422,6 @@ exit 0
 %dir %prefix/share
 %prefix/share/cf-support-nova-hub.sh
 %prefix/share/doc
-# Web interface
-%prefix/share/GUI
 #postgresql share
 %prefix/share/postgresql/*
 # PostgreSQL log file


### PR DESCRIPTION
share/GUI was listed twice in the %files section

Ticket: ENT-13275

(cherry picked from commit 56310a5db75e2157b718d85bf43e0e351ce83363)