### PR TITLE
ENT-13792: Made Windows MSI assembly fully reproducible

### DIFF
--- a/build-scripts/package-msi
+++ b/build-scripts/package-msi
@@ -13,6 +13,36 @@
 # MSI packaging uses wixl (GNOME msitools), which builds Windows MSIs natively
 # on Linux - no Windows and no Wine.
 
+# Derive a deterministic GUID from a label (ENT-13792)
+deterministic_guid() {
+    printf '{%s}\n' "$(uuidgen --sha1 \
+        --namespace B883FBCC-6F05-4AFA-98FA-CAF09BF464EA \
+        --name "$1" | tr '[:lower:]' '[:upper:]')"
+}
+
+# Make the Summary Information reproducible: wixl writes a random package code
+# (property 9) and the wall-clock build time (12/13 = Created/Last saved).
+# Rewrite them to a version-derived package code and SOURCE_DATE_EPOCH.
+# (ENT-13792)
+normalize_msi_summary() {
+    msi="$1"
+    revision="$2"
+    if [ -z "$SOURCE_DATE_EPOCH" ]; then
+        log_debug "SOURCE_DATE_EPOCH unset; skipping MSI summary normalization"
+        return 0
+    fi
+    pkgcode=$(deterministic_guid "package:$revision")
+    datestr=$(TZ=UTC date -u -d "@$SOURCE_DATE_EPOCH" +"%Y/%m/%d %H:%M:%S")
+    msiinfo export "$msi" _SummaryInformation | tr -d '\r' |
+        awk -v u="$pkgcode" -v d="$datestr" -F '\t' 'BEGIN { OFS = "\t" }
+            $1 == "9"  { $2 = u }
+            $1 == "12" { $2 = d }
+            $1 == "13" { $2 = d }
+            { print }' | sed 's/$/\r/' >_summary.idt
+    msibuild "$msi" -i _summary.idt
+    rm -f _summary.idt
+}
+
 # Determine build directory name based on Jenkins job or version/arch
 log_debug "Determining build directory name (JOB_NAME=$JOB_NAME, VERSION=$VERSION, ARCH=$ARCH)"
 if [ -z "$JOB_NAME" ]; then
@@ -85,6 +115,13 @@ pre() {
     if [ "$ARCH" = "x86" ]; then
         sed -i '/lib\(crypto\|ssl\)/s/[_-]x64//g' "$P"/cfengine-nova.wxs
     fi
+
+    # Reproducible builds (ENT-13792): pin every packaged file's mtime to
+    # SOURCE_DATE_EPOCH so the CAB stores a fixed timestamp per file instead
+    # of the time each file was created.
+    if [ -n "$SOURCE_DATE_EPOCH" ]; then
+        find "$P" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+    fi
 }
 
 # wixl_build() - Build the MSI from the WiX source using wixl (msitools).
@@ -108,7 +145,13 @@ wixl_build() {
     log_debug "Running wixl with REVISION=$REVISION, ARCH=$ARCH"
     wixl -a "$wixl_arch" \
         -D CfSourceDir=. -D CfVersion="$REVISION" -D CfArch="$ARCH" \
+        -D CfProductCode="$(deterministic_guid "product:$REVISION")" \
         -o cfengine-nova.msi cfengine-nova.wxs
+
+    # wixl still bakes a random package code and the wall-clock build time into
+    # the Summary Information; rewrite them for a byte-reproducible MSI.
+    # (ENT-13792)
+    normalize_msi_summary cfengine-nova.msi "$REVISION"
 }
 
 # package() - Main packaging function that creates the MSI installer

--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -91,6 +91,10 @@ bundle agent cfengine_build_host_setup
       "wixl";
       "msitools";
 
+      # build-scripts/package-msi derives deterministic MSI GUIDs with uuidgen
+      # (uuid-runtime) for reproducible builds. See ENT-13792.
+      "uuid-runtime";
+
       "binfmt-support"
         comment => "update-binfmts command needed for build-scripts/package-msi script";
 

--- a/ci/fix-buildhost.sh
+++ b/ci/fix-buildhost.sh
@@ -75,12 +75,13 @@ if [ -f /etc/os-release ]; then
 fi
 
 # MinGW hosts build the MSI with wixl (build-scripts/package-msi) and inspect it
-# with msiinfo (msitools). Installed by the build-host-setup policy at image
-# time; install here too so not-yet-reimaged mingw hosts get them without a
-# reimage. See ENT-13868.
+# with msiinfo (msitools). uuidgen (uuid-runtime) derives deterministic MSI
+# GUIDs for reproducible builds (ENT-13792). Installed by the build-host-setup
+# policy at image time; install here too so not-yet-reimaged mingw hosts get
+# them without a reimage. See ENT-13868.
 if [ -f /etc/cfengine-mingw-build-host.flag ]; then
-  if ! command -v wixl >/dev/null 2>&1 || ! command -v msiinfo >/dev/null 2>&1; then
+  if ! command -v wixl >/dev/null 2>&1 || ! command -v msiinfo >/dev/null 2>&1 || ! command -v uuidgen >/dev/null 2>&1; then
     sudo apt-get update
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wixl msitools
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wixl msitools uuid-runtime
   fi
 fi

--- a/container/Dockerfile.mingw
+++ b/container/Dockerfile.mingw
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     autoconf automake binutils bison build-essential curl debhelper dpkg-dev \
     expat fakeroot flex gdb git libexpat1-dev libmodule-load-conditional-perl \
     libpam0g-dev libtool libncurses6 libncurses-dev pkg-config psmisc \
-    python3-pip rsync sudo systemd-coredump unzip wget \
+    python3-pip rsync sudo systemd-coredump unzip uuid-runtime wget \
     && rm -rf /var/lib/apt/lists/*
 
 # MinGW-w64 cross toolchain.

--- a/packaging/cfengine-nova/cfengine-nova.wxs
+++ b/packaging/cfengine-nova/cfengine-nova.wxs
@@ -26,7 +26,9 @@
 	 <?endif?>
    <?endif?>
 
-   <Product Id='*' Name='CFEngine Nova' Language='1033'
+   <!-- ProductCode is pinned (not '*') so rebuilds of the same version are
+        byte-reproducible; package-msi derives it deterministically. ENT-13792 -->
+   <Product Id='$(var.CfProductCode)' Name='CFEngine Nova' Language='1033'
             Version='$(var.CfVersion)' Manufacturer='Northern.tech AS' UpgradeCode='B883FBCC-6F05-4AFA-98FA-CAF09BF464EA' >
 
       <Package Description='CFEngine Nova'

--- a/packaging/cfengine-nova/cfengine-nova.wxs
+++ b/packaging/cfengine-nova/cfengine-nova.wxs
@@ -264,11 +264,16 @@
 	<!-- The sequence numbers are weird to avoid collisions with built-in numbers -->
 
    <InstallExecuteSequence>
-     <RemoveExistingProducts Sequence='1450' />
      <InstallInitialize Sequence='1500' />
 	 <Custom Action='GenerateKey' After='InstallFiles'>NOT Installed</Custom>
 
 	 <InstallFinalize Sequence='6600' />
+
+	 <!-- After InstallFinalize: install new files first, then remove the old
+	      product, so equal-versioned shared DLLs survive via refcounting. Early
+	      placement deletes them and breaks upgrades. Ref:
+	      https://learn.microsoft.com/en-us/windows/win32/msi/removeexistingproducts-action -->
+	 <RemoveExistingProducts Sequence='6700' />
    </InstallExecuteSequence>
 
    </Product>


### PR DESCRIPTION
The issue was that wixl bakes a random package code, wall-clock summary-info timestamps, and per-file CAB timestamps into the MSI. Further more the wxs file used a random ProductCode. Hence, two builds of identical source produced different MSIs.

Fixed it by deriving the ProductCode and package code deterministically from the version, pinning the CAB file mtimes and summary-info to `SOURCE_DATE_EPOCH`.

```
$ ./build-in-container.py --platform ubuntu-24-mingw --project nova --role agent --build-type DEBUG --rebuild-image --output-dir out-a/
$ ./build-in-container.py --platform ubuntu-24-mingw --project nova --role agent --build-type DEBUG --rebuild-image --output-dir out-b/
$ sha256sum out-{a,b}/*.msi
21f7cca0b26cf4164d2c40c019dbdfc9ed842d1750fac9e7126a3d60eced0f85  out-a/cfengine-nova-3.29.0a-1-x86_64.msi
21f7cca0b26cf4164d2c40c019dbdfc9ed842d1750fac9e7126a3d60eced0f85  out-b/cfengine-nova-3.29.0a-1-x86_64.msi
```

- [x] Test bootstrap
```
  PS C:\Users\Administrator> msiexec /i "C:\Users\Administrator\Desktop\cfengine-nova-3.29.0a-1-x86_64.msi" /qn /l*v "C:\Users\Administrator\Desktop\cfengine-install-3.29.log"
PS C:\Users\Administrator> & 'C:\Program Files\Cfengine\bin\cf-agent.exe' -V
CFEngine Core 3.29.0a.e8a605dd9
CFEngine Enterprise 3.29.0a.22cb72acf
PS C:\Users\Administrator> & 'C:\Program Files\Cfengine\bin\cf-agent.exe' -B 172.31.7.249
  notice: Bootstrap mode: implicitly trusting server, use --trust-server=no if server trust is already established
  notice: Trusting new key: SHA=601bd5305ac7c8b70ecaddc64159f2f3dcd392f793edc7906290fbb36fd2a966
R: Bootstrapping from host '172.31.7.249' via built-in policy 'C:\Program Files\Cfengine\inputs\failsafe.cf'
R: This autonomous node assumes the role of voluntary client
R: Updated local policy from policy server
R: Triggered an initial run of the policy
R: Started the scheduler
  notice: Bootstrap to '172.31.7.249' completed successfully!
```
- [x] Test upgrade
```
PS C:\Users\Administrator> & 'C:\Program Files\Cfengine\bin\cf-agent.exe' -V
CFEngine Core 3.29.0
CFEngine Enterprise 3.29.0
PS C:\Users\Administrator> & 'C:\Program Files\Cfengine\bin\cf-agent.exe' -V
CFEngine Core 3.30.0
CFEngine Enterprise 3.30.0 
```