### PR TITLE
Pin libopenssl-3-devel to installed openssl version on SUSE 15 

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -123,9 +123,9 @@ bundle agent cfengine_build_host_setup
       "platform-python-devel" -> { "cfbs shebang", "ENT-11338" }
         comment => "py3_shebang_fix macro needs /usr/bin/pathfix.py from platform-python-devel package";
 
-    suse_15::
-      "libopenssl-devel" -> { "ENT-12528" }
-        comment => "like redhat, suse 15+ needs to build with system openssl.";
+    # NOTE: suse 15+ needs libopenssl-3-devel to build against system openssl (ENT-12528),
+    # but it is installed via a version-pinned command below (ENT-14345), not here, so the
+    # lower-priority oss/update repos cannot pull an SP6 -devel and downgrade openssl.
 
     (redhat_8|centos_8|redhat_9).(yum_dnf_conf_ok)::
       "java-1.8.0-openjdk-headless" package_policy => "delete",
@@ -155,6 +155,11 @@ bundle agent cfengine_build_host_setup
 
   vars:
     "suse_users_and_groups" slist => { "daemon", "bin", "sys" };
+
+    suse_15::
+      "libopenssl3_version" -> { "ENT-14345" }
+        string => execresult("/usr/bin/rpm -q --qf %{VERSION} libopenssl3", "noshell"),
+        comment => "version of the installed system openssl, used to pin libopenssl-3-devel.";
 
   classes:
     any::
@@ -203,6 +208,10 @@ bundle agent cfengine_build_host_setup
       "sed -i '/best=True/s/True/False/' /etc/yum.conf" contain => in_shell;
     (redhat_8|centos_8|redhat_9).!dnf_conf_ok::
       "sed -i '/best=True/s/True/False/' /etc/dnf/dnf.conf" contain => in_shell;
+    suse_15.!have_libopenssl_3_devel::
+      "zypper install -y libopenssl-3-devel=$(libopenssl3_version)" -> { "ENT-12528", "ENT-14345" }
+        contain => in_shell,
+        comment => "suse 15+ builds against system openssl. Pin -devel to the installed libopenssl3 version so the lower-priority oss/update repos (still SP6 3.1.4) do not pull an older -devel and downgrade the whole openssl stack.";
 
 
   classes:
@@ -215,6 +224,9 @@ bundle agent cfengine_build_host_setup
     opensuse|suse|sles::
       "have_$(suse_users_and_groups)_group" expression => returnszero("grep '^$(suse_users_and_groups):' /etc/group >/dev/null", "useshell");
       "have_$(suse_users_and_groups)_user" expression => returnszero("grep '^$(suse_users_and_groups):' /etc/passwd >/dev/null", "useshell");
+    suse_15::
+      "have_libopenssl_3_devel" -> { "ENT-14345" }
+        expression => returnszero("rpm -q libopenssl-3-devel >/dev/null", "useshell");
 
   files:
     ubuntu_16|redhat_9::

--- a/ci/fix-buildhost.sh
+++ b/ci/fix-buildhost.sh
@@ -17,7 +17,15 @@ fi
 
 # while ENT-13750 is in progress we need to ensure that OTHER builds include openssl devel packages on redhat-based platforms
 if command -v zypper >/dev/null 2>/dev/null; then
-  sudo zypper install -y libopenssl-devel || true
+  # ENT-14345: pin libopenssl-3-devel to the installed libopenssl3 version. Lower-priority
+  # oss/update repos still carry SP6 openssl (3.1.4), so an unpinned install picks the old
+  # -devel and tries to downgrade the whole SP7 openssl stack (3.2.3). Pinning avoids that.
+  ossl_ver=$(rpm -q --qf '%{VERSION}' libopenssl3 2>/dev/null)
+  if [ -n "$ossl_ver" ]; then
+    sudo zypper install -y "libopenssl-3-devel=${ossl_ver}" || true
+  else
+    sudo zypper install -y libopenssl-3-devel || true
+  fi
 fi
 if command -v yum >/dev/null 2>/dev/null; then
   sudo yum install -y openssl-devel || true


### PR DESCRIPTION
The legacy libopenssl-devel metapackage hard-pins openssl to an exact version. After the golden AMI rebake updated the runtime openssl from SP6 (3.1.4) to SP7 (3.2.3), the SP6-only libopenssl-devel could no longer install without downgrading the whole openssl stack, which zypper refuses non-interactively. libopenssl-3-devel depends on libopenssl3 rather than an exact openssl version, so it matches the installed 3.2.3.

Ticket: ENT-14345