### PR TITLE
Revert use of -T /tmp in initialize-build-host due to disk full troubles (3.24)

### DIFF
--- a/ci/initialize-build-host.sh
+++ b/ci/initialize-build-host.sh
@@ -98,7 +98,7 @@ command -v /sbin/ifconfig 2>/dev/null && /sbin/ifconfig -a || true
 command -v /sbin/ip 2>/dev/null && /sbin/ip addr || true
 
 
-RSYNC="rsync --delete -zrlpt -T /tmp"
+RSYNC="rsync --delete -zrlpt"
 RSH="ssh -o BatchMode=yes"
 
 # Support launching scripts that were initially launched under bash.


### PR DESCRIPTION
On some hosts, /tmp is not large enough to hold the transfer.
This was introduced in commit 8b51092b10f5d178e2f4a1bd4312ec163eb4588e with the comment: Try to avoid temporary rsync files from other hosts while copying.

Ticket: ENT-14400
Changelog: none