### PR TITLE
CFE-90: Remapped container storage on CI hosts regardless of subuid edits

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -90,16 +90,20 @@ echo "Using buildscripts commit:"
 # we have very old platforms with old git that doesn't understand -C option so cd/cd .. it is
 (
     cd "$thisdir"/..
-    # buildscripts is owned by jenkins so in order to run rev-parse command as root (this script is run with sudo) we must make it safe if git is used
-    if [ -d /home/jenkins/buildscripts/.git ]; then
+    # Not every caller clones into ~/buildscripts: fast-build-and-deploy-docs-master
+    # uses tmp-buildscripts, where the hardcoded path reported no commit at all.
+    if [ -d .git ]; then
         if command -v git >/dev/null; then
-            git config --global --add safe.directory /home/jenkins/buildscripts
+            # buildscripts is owned by jenkins so in order to run rev-parse command as root (this script is run with sudo) we must make it safe if git is used
+            git config --global --add safe.directory "$PWD"
             # show what version of buildscripts we are using
             git rev-parse HEAD
         else
             echo "buildscripts/.git is present but git is not installed"
             exit 1
         fi
+    else
+        echo "no .git in $PWD, cannot determine buildscripts commit"
     fi
 )
 

--- a/ci/setup-ci-host.sh
+++ b/ci/setup-ci-host.sh
@@ -26,7 +26,6 @@ function file-line()
 }
 
 # Replaces an existing range for the user rather than appending a second one.
-subids_changed=0
 function subid-range()
 {
   local file=$1
@@ -44,7 +43,27 @@ function subid-range()
     echo "Adding $user:$range to $file"
     echo "$user:$range" >> "$file"
   fi
-  subids_changed=1
+}
+
+# Storage keeps the mapping it was extracted with, so a wrongly mapped store
+# stays broken (no setuid bits, sudo unusable) even once /etc/subuid is right.
+# Track what the store was mapped with, not whether we edited the range.
+function remap-container-storage()
+{
+  local range=$1
+  local stamp=/var/lib/cfengine-ci-subid-mapping
+
+  if [ "$(cat "$stamp" 2>/dev/null)" = "$range" ]; then
+    return
+  fi
+
+  echo "Container storage was not mapped with $range, remapping and discarding images"
+  su - jenkins -c 'podman system migrate'
+  # migrate cannot restore setuid bits, so images must be rebuilt. Leaked
+  # working containers reference them, so remove those first.
+  su - jenkins -c 'buildah rm --all' || true
+  su - jenkins -c 'buildah rmi --all --force' || true
+  echo "$range" >"$stamp"
 }
 
 function github-known-hosts()
@@ -132,14 +151,10 @@ EOF
 
         # Without a subordinate id range, rootless container storage runs single-uid
         # and drops setuid bits while extracting layers, breaking sudo in the image.
-        subid-range /etc/subuid jenkins 100000:65536
-        subid-range /etc/subgid jenkins 100000:65536
-        if [ "$subids_changed" = 1 ]; then
-            # Remap storage and discard images extracted under the previous mapping:
-            # migrate cannot restore setuid bits, so those images must be rebuilt.
-            su - jenkins -c 'podman system migrate'
-            su - jenkins -c 'buildah rmi --all --force'
-        fi
+        subid_range=100000:65536
+        subid-range /etc/subuid jenkins "$subid_range"
+        subid-range /etc/subgid jenkins "$subid_range"
+        remap-container-storage "$subid_range"
     fi
     exit 0
 fi


### PR DESCRIPTION
Gating the storage remap on having edited `/etc/subuid` made it a no-op on hosts where `useradd` already allocated the default `100000:65536`, so their images stayed broken and `sudo` still failed in the docs build image.