### PR TITLE
CFE-90: Replaced chown -R of the jenkins home with fixing root owned files

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 shopt -s expand_aliases
-thisdir="$(dirname "$0")"
+# absolute because this script changes directory below
+thisdir="$(cd "$(dirname "$0")" && pwd)"
 
 # handle env cfengine_role
 if [ -n "$cfengine_role" ]; then
@@ -14,11 +15,31 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
+# Fixes and names just the root owned files. chown -R over the whole tree clears
+# setuid bits, which stripped /usr/bin/sudo inside every image in the rootless
+# container store under /home/jenkins.
+function chown-root-owned-to-jenkins()
+{
+    root_owned=$(find /home/jenkins -user root -print 2>/dev/null | head -n 20)
+    if [ -n "$root_owned" ]; then
+        echo "Root owned files in /home/jenkins (first 20), chowning all to jenkins:"
+        echo "$root_owned"
+        find /home/jenkins -user root -exec chown jenkins {} \;
+    fi
+}
+
 ls -la /home/
 if ! id -u jenkins; then
     useradd jenkins -p jenkins
 fi
 mkdir -p /home/jenkins
+
+# Work where root owns the directory. Called from the jenkins home, this script
+# used to leave the masterfiles tarball, an extracted masterfiles/, a core clone
+# and promises.log there owned by root, which is what the chown -R was for.
+setupdir=/var/tmp/cfengine-build-host-setup
+mkdir -p "$setupdir"
+cd "$setupdir"
 
 # The following is copied from prepare-testmachine-chroot
 CHROOT_ROOT=/home/jenkins/testmachine-chroot/
@@ -27,8 +48,8 @@ fuser -k "$CHROOT_ROOT" >/dev/null 2>&1 || true
 umount "${CHROOT_ROOT}proc" >/dev/null 2>&1 || true
 
 # ENT-14386 often it seems we are experiencing a race condition with this script and something else causing trouble
-if ! chown -R jenkins /home/jenkins; then
-  echo "ENT-14386 some trouble chown -R jenkins /home/jenkins, current processes are:"
+if ! chown-root-owned-to-jenkins; then
+  echo "ENT-14386 some trouble chowning /home/jenkins, current processes are:"
   ps -efl
 fi
 
@@ -78,7 +99,7 @@ function cleanup() {
         ps -efl | grep cf
     fi
     ls -l /home
-    chown -R jenkins /home/jenkins
+    chown-root-owned-to-jenkins
     echo "Done with cleanup()"
 }
 
@@ -298,16 +319,17 @@ cp -a masterfiles/* /var/cfengine/inputs/
 (
     cd "$thisdir"
     policy=./cfengine-build-host-setup.cf
+    promises="$setupdir"/promises.log
     # just to be sure, make policy read/write for our user only to avoid errors when running
     chmod 600 "$policy"
-    /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log
-    grep -i error: promises.log && exit 1
-    /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee -a promises.log
-    grep -i error: promises.log && exit 1
-    /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee -a promises.log
-    grep -i error: promises.log && exit 1
+    /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee "$promises"
+    grep -i error: "$promises" && exit 1
+    /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee -a "$promises"
+    grep -i error: "$promises" && exit 1
+    /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee -a "$promises"
+    grep -i error: "$promises" && exit 1
     echo "Done evaluating policy. End of promises.log:"
-    tail promises.log
+    tail "$promises"
 )
 
 cleanup

--- a/ci/setup-ci-host.sh
+++ b/ci/setup-ci-host.sh
@@ -25,28 +25,6 @@ function file-line()
   fi
 }
 
-# Replaces an existing range for the user rather than appending a second one.
-subids_changed=0
-function subid-range()
-{
-  local file=$1
-  local user=$2
-  local range=$3
-
-  touch "$file"
-  if grep -q "^$user:$range\$" "$file"; then
-    return
-  fi
-  if grep -q "^$user:" "$file"; then
-    echo "Correcting $user range in $file to $range"
-    sed -i "s|^$user:.*|$user:$range|" "$file"
-  else
-    echo "Adding $user:$range to $file"
-    echo "$user:$range" >> "$file"
-  fi
-  subids_changed=1
-}
-
 function github-known-hosts()
 {
   echo "ensuring github hostkeys are added to /home/jenkins/.ssh/known_hosts"
@@ -129,17 +107,6 @@ jenkins ALL=NOPASSWD: /usr/bin/podman
 EOF
         chmod 400 /etc/sudoers.d/999-local
         chown root:root /etc/sudoers.d/999-local
-
-        # Without a subordinate id range, rootless container storage runs single-uid
-        # and drops setuid bits while extracting layers, breaking sudo in the image.
-        subid-range /etc/subuid jenkins 100000:65536
-        subid-range /etc/subgid jenkins 100000:65536
-        if [ "$subids_changed" = 1 ]; then
-            # Remap storage and discard images extracted under the previous mapping:
-            # migrate cannot restore setuid bits, so those images must be rebuilt.
-            su - jenkins -c 'podman system migrate'
-            su - jenkins -c 'buildah rmi --all --force'
-        fi
     fi
     exit 0
 fi


### PR DESCRIPTION
The pre-build `chown -R jenkins /home/jenkins` walked the rootless container store, and `chown(2)` clears setuid bits even when the owner is unchanged, so `/usr/bin/sudo` inside stored image layers lost its setuid bit and every container build that reused an image failed. The root owned files it was compensating for were this script's own, left in the jenkins home because it ran from there; it now works in `/var/tmp` and chowns only what is still root owned, reporting it.

Also reverts e19e3240, which addressed the same failure on the wrong premise: the subuid range was already correct on the CI hosts.