### PR TITLE
Patches for openldap 2.7.0 on exotics

### DIFF
--- a/deps-packaging/openldap/aix_symbol_version_script.patch
+++ b/deps-packaging/openldap/aix_symbol_version_script.patch
@@ -1,0 +1,11 @@
+--- openldap-2.7.0/build/lib-shared.mk
++++ patched-openldap/build/lib-shared.mk
+@@ -23,7 +23,7 @@
+ .c.lo:
+ 	$(LTCOMPILE_LIB) $<
+ 
+-$(LIBRARY): version.lo $(SYMBOL_VERSION_SCRIPT)
++$(LIBRARY): version.lo @DO_VERSIONED_SYMBOLS@$(SYMBOL_VERSION_SCRIPT)
+ 	$(LTLINK_LIB) -o $@ $(OBJS) version.lo $(LINK_LIBS)
+ 
+ Makefile: $(top_srcdir)/build/lib-shared.mk

--- a/deps-packaging/openldap/cfbuild-openldap-aix.spec
+++ b/deps-packaging/openldap/cfbuild-openldap-aix.spec
@@ -7,6 +7,9 @@ Release: 1
 Source0: openldap-%{openldap_version}.tgz
 Patch0:  no_Sockaddr_redefine.patch
 Patch1: gcc-8.5.patch
+# xlc cannot preprocess the generated symbol version scripts, and the AIX
+# linker has no use for them anyway
+Patch2: aix_symbol_version_script.patch
 License: MIT
 Group: Other
 Url: https://cfengine.com
@@ -22,6 +25,7 @@ mkdir -p %{_builddir}
 
 %patch0 -p0
 %patch1 -p1
+%patch2 -p1
 
 # Either "$LDFLAGS -L%{prefix}lib"
 # Or     "-bsvr4 $LDFLAGS -Wl,-R,%{prefix}/lib"

--- a/deps-packaging/openldap/cfbuild-openldap-aix.spec
+++ b/deps-packaging/openldap/cfbuild-openldap-aix.spec
@@ -6,6 +6,7 @@ Version: %{version}
 Release: 1
 Source0: openldap-%{openldap_version}.tgz
 Patch0:  no_Sockaddr_redefine.patch
+Patch1: gcc-8.5.patch
 License: MIT
 Group: Other
 Url: https://cfengine.com
@@ -20,6 +21,7 @@ mkdir -p %{_builddir}
 %setup -q -n openldap-%{openldap_version}
 
 %patch0 -p0
+%patch1 -p1
 
 # Either "$LDFLAGS -L%{prefix}lib"
 # Or     "-bsvr4 $LDFLAGS -Wl,-R,%{prefix}/lib"

--- a/deps-packaging/openldap/hpux/build
+++ b/deps-packaging/openldap/hpux/build
@@ -17,6 +17,7 @@ export LDFLAGS
 
 ${PATCH} -p1 <host_name_max_hpux.patch
 ${PATCH} -p0 <no_Sockaddr_redefine.patch
+${PATCH} -p1 <gcc-8.5.patch
 
 # Configure
 

--- a/deps-packaging/openldap/solaris/build
+++ b/deps-packaging/openldap/solaris/build
@@ -10,6 +10,7 @@ OLD=${BUILD_ROOT}/cfbuild-openldap-devel${PREFIX}
 # Patch
 
 #patch -p0 -i configure.patch configure
+$PATCH -p1 < gcc-8.5.patch
 
 # Configure
 


### PR DESCRIPTION
I merged openldap 2.7.0 dependency upgrade without testing them on exotics. My bad :sweat_smile: These patches should fix things.