### PR TITLE
Now hands the container's output back to the user who started it

### DIFF
--- a/build-in-container-inner.sh
+++ b/build-in-container-inner.sh
@@ -14,6 +14,11 @@ mkdir -p "$BASEDIR"
 # Fix ownership so builder can write to them.
 sudo chown -R "$(id -u):$(id -g)" "$HOME/.cache" /output
 
+# And hand ownership back to the host user on the way out.
+if [ -n "$HOST_UID" ] && [ -n "$HOST_GID" ]; then
+    trap 'sudo chown -R "$HOST_UID:$HOST_GID" "$HOME/.cache" /output' EXIT
+fi
+
 # Prevent git "dubious ownership" errors
 git config --global --add safe.directory '*'
 

--- a/build-in-container.py
+++ b/build-in-container.py
@@ -11,6 +11,7 @@ import functools
 import hashlib
 import json
 import logging
+import os
 import subprocess
 import sys
 import urllib.request
@@ -387,6 +388,13 @@ def run_container(args, image_tag, source_dir, script_dir):
             f"EXPLICIT_ROLE={args.role}",
             "-e",
             f"BUILD_NUMBER={args.build_number}",
+            # Who to give the writable mounts back to. The container builds as
+            # its own user, whose UID is not ours, so without this the packages
+            # and the cache come out owned by a stranger.
+            "-e",
+            f"HOST_UID={os.getuid()}",
+            "-e",
+            f"HOST_GID={os.getgid()}",
             "-e",
             f"JOB_BASE_NAME={cache_label}",
             "-e",


### PR DESCRIPTION
The script already chowns those mounts to builder on the way in. Now it chowns them back on the way out from a trap.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
