### PR TITLE
Now exits with 1 when a build produced no packages

### DIFF
--- a/build-in-container.py
+++ b/build-in-container.py
@@ -704,12 +704,13 @@ def main():
             + list(output_dir.glob("*.msi"))
             + list(output_dir.glob("*.tar.gz"))
         )
-        if packages:
-            log.info("Output packages:")
-            for p in sorted(packages):
-                log.info(f"  {p}")
-        else:
-            log.warning("No packages found in output directory.")
+        if not packages:
+            log.error(f"Build produced nothing in {output_dir}.")
+            sys.exit(1)
+
+        log.info("Output packages:")
+        for p in sorted(packages):
+            log.info(f"  {p}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The container exiting zero was taken as success, even with an empty output directory. A build that produces nothing has failed, and a caller checking only the exit code had no way to tell.

A failing container already exited non-zero. This covers the case where it claims success but leaves nothing behind.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
