### PR TITLE
ENT-14361: Added --label to build by Jenkins build label

### DIFF
--- a/build-in-container.md
+++ b/build-in-container.md
@@ -11,6 +11,9 @@ only Docker and Python 3 on the host.
 
 # Build a nova hub release package for Debian 12
 ./build-in-container.py --platform debian-12 --project nova --role hub --build-type RELEASE
+
+# Alternatively, use Jenkins labels (see build-scripts/labels.txt)
+./build-in-container.py --label PACKAGES_HUB_x86_64_linux_debian_12 --project nova --build-type RELEASE
 ```
 
 In the examples above, we run the script from inside `buildscripts/` (with

--- a/build-in-container.py
+++ b/build-in-container.py
@@ -386,6 +386,21 @@ def cache_label(platform_name, role, arch):
     return f"PACKAGES{hub}_{arch_token}_linux_{label_os}"
 
 
+def platform_role_arch(label):
+    """Return the (platform, role, arch) that cache_label() turns into label.
+
+    Found by trying every combination rather than by parsing the label. That
+    keeps cache_label() the only place that knows how a label is spelled, so the
+    two cannot drift apart.
+    """
+    for platform_name, platform_config in get_config().items():
+        for role in ("agent", "hub"):
+            for arch in platform_architectures(platform_config):
+                if cache_label(platform_name, role, arch) == label:
+                    return platform_name, role, arch
+    return None
+
+
 def run_container(args, image_tag, source_dir, script_dir, label):
     """Run the build inside a Docker container."""
     # Keep the packages in a directory of their own, so that building several
@@ -494,6 +509,12 @@ def parse_args():
         help="Target platform",
     )
     parser.add_argument(
+        "--label",
+        help="Build what this Jenkins build label names, e.g. "
+        "PACKAGES_HUB_x86_64_linux_debian_12. Sets --platform, --role and "
+        "--arch, so it replaces all three. See build-scripts/labels.txt.",
+    )
+    parser.add_argument(
         "--project",
         choices=["community", "nova"],
         help="CFEngine edition",
@@ -592,6 +613,17 @@ def parse_args():
     if args.update or args.update_sha:
         # --platform is optional for these modes; updates all if omitted
         return args
+
+    if args.label:
+        if args.tarballs:
+            parser.error("--label and --tarballs build different things")
+        if args.platform or args.role or args.arch:
+            parser.error("--label already sets --platform, --role and --arch")
+        found = platform_role_arch(args.label)
+        if not found:
+            parser.error(f"no platform builds {args.label}")
+        args.platform, args.role, args.arch = found
+        log.info(f"{args.label}: {args.platform} {args.role} {args.arch}")
 
     if args.tarballs:
         # The tarballs are built from core and masterfiles alone, in an image of


### PR DESCRIPTION
The `build-in-container.py` script already knows how a Jenkins label maps to a platform. Hence, an option to build based on a label makes it so that a Jenkins job does not also have to know this mapping.

With this change, adding a platform will only require editing `platforms.json` and `labels.txt`.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
