### PR TITLE
Fixed /tmp remount running on build hosts that have no /tmp mount

### DIFF
--- a/ci/cfengine-build-host-setup.cf
+++ b/ci/cfengine-build-host-setup.cf
@@ -299,7 +299,10 @@ bundle agent cfengine_build_host_setup
 
     linux::
       "have_tmp_mount"
-        expression => returnszero("mount | grep '/tmp'", "useshell");
+        comment => "Match the mount point exactly, an unqualified '/tmp' also matches
+                    mounts below it like the '/tmp/snap.rootfs_XXXXXX' that a failed
+                    snap install hook leaves behind.",
+        expression => returnszero("mount | grep -E ' on /tmp '", "useshell");
 
       "have_coredumpctl"
         expression => returnszero("command -v coredumpctl", "useshell");


### PR DESCRIPTION
The `have_tmp_mount` class matched any mount path containing `/tmp`, so the `/tmp/snap.rootfs_XXXXXX` left behind by a failed snap install hook set it on a host with no `/tmp` mount and the remount aborted build host setup.

Seen on `legion7-ubuntu-22-x64-j1` in [testing-pr 3062](https://ci.cfengine.com/job/testing-pr/label=PACKAGES_HUB_x86_64_linux_ubuntu_22/3062/).