### PR TITLE
Added cf-support for Windows to the MSI (3.27.x)

### DIFF
--- a/packaging/cfengine-nova/cfengine-nova.wxs
+++ b/packaging/cfengine-nova/cfengine-nova.wxs
@@ -111,6 +111,16 @@
               <Component Id='mdb_load.exe' Guid='0C48B31C-A05D-43F5-A452-2CE6CC91E963' Win64='$(var.isWin64)'>
                 <File Id='mdb_load.exe' Name='mdb_load.exe' KeyPath='yes' DiskId='1' Source='$(var.CfSourceDir)\bin\mdb_load.exe' />
               </Component>
+              <!-- Support data collection. cf-support.cmd is the entry point a
+                   customer is told to run; it launches the .ps1 with
+                   -ExecutionPolicy Bypass so the default machine policy does
+                   not block an unsigned script. -->
+              <Component Id='cf_support.ps1' Guid='6FD91F99-35BE-4DD3-890B-B1902300F647' Win64='$(var.isWin64)'>
+                <File Id='cf_support.ps1' Name='cf-support.ps1' KeyPath='yes' DiskId='1' Source='$(var.CfSourceDir)/bin/cf-support.ps1' />
+              </Component>
+              <Component Id='cf_support.cmd' Guid='ADEF2A32-F2B3-4F72-A245-FC5913F37A07' Win64='$(var.isWin64)'>
+                <File Id='cf_support.cmd' Name='cf-support.cmd' KeyPath='yes' DiskId='1' Source='$(var.CfSourceDir)/bin/cf-support.cmd' />
+              </Component>
               <Component Id='lmmgr.exe' Guid='DBF87C39-43FA-4DFE-A442-D2AB5B8985F0' Win64='$(var.isWin64)'>
                 <File Id='lmmgr.exe' Name='lmmgr.exe' KeyPath='yes' DiskId='1' Source='$(var.CfSourceDir)\bin\lmmgr.exe' />
               </Component>
@@ -194,6 +204,8 @@
             <ComponentRef Id='mdb_copy.exe' />
             <ComponentRef Id='mdb_stat.exe' />
             <ComponentRef Id='lmmgr.exe' />
+            <ComponentRef Id='cf_support.ps1' />
+            <ComponentRef Id='cf_support.cmd' />
             <ComponentRef Id='lmdump.exe' />
             <ComponentRef Id='diff.exe' />
             <ComponentRef Id='diff3.exe' />


### PR DESCRIPTION
Backport of #2444. Requires cfengine/core#6330, which builds the scripts.

Ticket: ENT-9046