### PR TITLE
ENT-14451: Suppressed errexit when sourcing /etc/profile in ci/fix-buildhost.sh (3.27.x)

### DIFF
--- a/ci/fix-buildhost.sh
+++ b/ci/fix-buildhost.sh
@@ -28,7 +28,8 @@ fi
 if [ -f /etc/profile ]; then
   # running on the proxied host or not we want to make sure local customizations are taken
   # e.g. ent-14014: custom build of ssh needed for build-artifacts-cache needed and /etc/profile has PATH=/opt/craig/bin:$PATH
-  . /etc/profile
+  # suse's /etc/profile calls tty, which exits non-zero in CI and would kill us via set -e, so suppress errexit
+  . /etc/profile || true
 fi
 
 mkdir -p ~/.ssh


### PR DESCRIPTION
On suse /etc/profile calls tty, which exits non-zero in a non-interactive CI shell.

Ticket: ENT-14451
Changelog: none
(cherry picked from commit bda0bd9ea5724f105029a5bdc7ed55f274e4362b)