### PR TITLE
Fixed apt lock race in setup-cfengine-build-host.sh on freshly booted (3.24)

### DIFF
--- a/ci/setup-cfengine-build-host.sh
+++ b/ci/setup-cfengine-build-host.sh
@@ -133,6 +133,15 @@ if [ -f /etc/os-release ]; then
         alias software='yum install --assumeyes'
         alias erase-packages='yum erase --assumeyes'
     elif grep -q debian /etc/os-release; then
+        # wait for the boot-time unattended upgrades apt-get to release the apt/dpkg locks
+        timeout 300 bash -c '
+          while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 \
+             || fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
+            echo "waiting for apt/dpkg lock to clear..."
+            sleep 5
+          done
+        ' || true
+
         # Acquire::Retries because the archive mirrors sometimes return transient 503s
         DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 update --yes --quiet
 


### PR DESCRIPTION
… hosts

On a freshly booted Debian/Ubuntu EC2 build host the boot-time apt-daily / unattended-upgrades apt-get is often still running when this script starts, so "apt update" fails with "Could not get lock /var/lib/apt/lists/lock".

Ticket: ENT-14403

(cherry picked from commit f8cf5bb90364aab5b481fef21727c50c81aaa2ba)